### PR TITLE
Speed up order list view

### DIFF
--- a/assets/js/wcmp-admin.js
+++ b/assets/js/wcmp-admin.js
@@ -46,7 +46,34 @@ jQuery( function( $ ) {
 	// show summary when clicked
 	$('.wcmp_show_shipment_summary').click( function ( event ) {
 		event.preventDefault();
-		$( this ).next('.wcmp_shipment_summary_list').slideToggle();
+		$summary_list = $( this ).next('.wcmp_shipment_summary_list');
+		if ($summary_list.is(":visible") || $summary_list.data('loaded') != '') {
+			// just open / close
+			$summary_list.slideToggle();
+		} else if ($summary_list.is(":hidden") && $summary_list.data('loaded') == '') {
+			$summary_list.addClass('ajax-waiting');
+			$summary_list.find('.wcmp_spinner').show();
+			$summary_list.slideToggle();
+			var data = {
+				security:      wc_myparcel.nonce,
+				action:        "wcmp_get_shipment_summary_status",
+				order_id:      $summary_list.data('order_id'),
+				shipment_id:   $summary_list.data('shipment_id'),
+			};
+			xhr = $.ajax({
+				type:		'POST',
+				url:		wc_myparcel.ajax_url,
+				data:		data,
+				context:	$summary_list,
+				success:	function( response ) {
+					this.removeClass('ajax-waiting');
+					this.html(response);
+					this.data('loaded','yes');
+				}
+			});
+
+		}
+
 	});
 	// hide summary when click outside
 	$(document).click(function(event) {

--- a/includes/class-wcmp-admin.php
+++ b/includes/class-wcmp-admin.php
@@ -25,6 +25,7 @@ class WooCommerce_MyParcel_Admin {
 		add_action( 'woocommerce_admin_order_data_after_shipping_address', array( $this, 'single_order_shipment_options' ) );
 
 		add_action( 'wp_ajax_wcmp_save_shipment_options', array( $this, 'save_shipment_options_ajax' ) );
+		add_action( 'wp_ajax_wcmp_get_shipment_summary_status', array( $this, 'order_list_ajax_get_shipment_summary' ) );
 
 		// HS code in product shipping options tab
 		add_action( 'woocommerce_product_options_shipping', array( $this, 'product_hs_code_field' ) );
@@ -52,19 +53,12 @@ class WooCommerce_MyParcel_Admin {
 			// only use last shipment
 			$last_shipment = array_pop( $consignments );
 			$last_shipment_id = $last_shipment['shipment_id'];
-
-			$shipment = WooCommerce_MyParcel()->export->get_shipment_data( $last_shipment_id, $order );
-			// echo '<pre>';var_dump($shipment);echo '</pre>';die();
-			if (!empty($shipment['tracktrace'])) {
-				$order_has_shipment = true;
-				$tracktrace_url = $this->get_tracktrace_url( $order_id, $shipment['tracktrace']);
-			}
 			?>
 			<div class="wcmp_shipment_summary" <?php echo $style; ?>>
 				<?php $this->show_order_delivery_options( $order ); ?>
 				<a href="#" class="wcmp_show_shipment_summary"><span class="encircle wcmp_show_shipment_summary">i</span></a>
-				<div class="wcmp_shipment_summary_list" style="display: none;">
-					<?php include('views/wcmp-order-shipment-summary.php'); ?>
+				<div class="wcmp_shipment_summary_list" data-loaded="" data-shipment_id="<?php echo $last_shipment_id; ?>" data-order_id="<?php echo $order_id; ?>" style="display: none;">
+					<img src="<?php echo WooCommerce_MyParcel()->plugin_url() . '/assets/img/wpspin_light.gif';?>" class="wcmp_spinner"/>
 				</div>
 			</div>
 			<?php
@@ -84,6 +78,23 @@ class WooCommerce_MyParcel_Admin {
 			</div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Get shipment status + track&trace link via AJAX 
+	 */
+	public function order_list_ajax_get_shipment_summary(){
+		check_ajax_referer( 'wc_myparcel', 'security' );
+		extract($_POST); // order_id, shipment_id
+		$order = wc_get_order($order_id);
+		$shipment = WooCommerce_MyParcel()->export->get_shipment_data( $shipment_id, $order );
+		if (!empty($shipment['tracktrace'])) {
+			$order_has_shipment = true;
+			$tracktrace_url = $this->get_tracktrace_url( $order_id, $shipment['tracktrace']);
+		}
+
+		include('views/wcmp-order-shipment-summary.php');
+		die();
 	}
 
 


### PR DESCRIPTION
Fixes #21 @aprwebdesign

Instead of iterating over all orders in the WC order backend and checking the shipment status, this makes separate calls over AJAX, offering great speed improvements (especially when the orders screen is set to show 50 or even more orders). This also drastically lessens the MyParcel API server load from unnecessary calls.