### PR TITLE
add filter for shipment API data

### DIFF
--- a/includes/class-wcmp-export.php
+++ b/includes/class-wcmp-export.php
@@ -473,7 +473,7 @@ class WooCommerce_MyParcel_Export {
             }
             */
 
-            $shipments[] = $shipment;
+            $shipments[] = apply_filters( 'wc_myparcel_order_shipment', $shipment, $order, $type, $this );
         }
 
         return $shipments;


### PR DESCRIPTION
allows custom modification, for example to add preliminary support for "digitale postzegel". Filter usage example:
``` php
add_filter( 'wc_myparcel_order_shipment', 'wc_myparcel_postzegel', 10, 4 );
function wc_myparcel_postzegel( $shipment, $order, $type, $export ) {
	if ( $saved_options = $order->get_meta('_myparcel_shipment_options') ) {
		return $options; // don't override saved options
	}

	$parcel_weight = (int) round( $export->get_parcel_weight( $order ) * 1000 );

	// note: does not check dimensions!
	if ( $parcel_weight < 350 ) {
		$shipment['options']['package_type'] = 4; // digitale postzegel
		$shipment['physical_properties']['weight'] = $parcel_weight;
	}

	return $shipment;
}
```