### PR TITLE
logging can be grouped by context

### DIFF
--- a/includes/class-wcmp-export.php
+++ b/includes/class-wcmp-export.php
@@ -1602,21 +1602,33 @@ class WooCommerce_MyParcel_Export {
 
     public function log($message) {
         if (isset(WooCommerce_MyParcel()->general_settings['error_logging'])) {
+
+            // Starting with WooCommerce 3.0, logging can be grouped by context and severity.
+            if (class_exists('WC_Logger') && version_compare(WOOCOMMERCE_VERSION, '3.0', '>=')) {
+                $logger = wc_get_logger();
+                $logger->debug( $message, array( 'source' => 'wc-myparcel' ) );
+
+                return;
+            }
+
             if (class_exists('WC_Logger')) {
                 $wc_logger = function_exists('wc_get_logger') ? wc_get_logger() : new WC_Logger();
                 $wc_logger->add('wc-myparcel', $message);
-            } else {
-                // Old WC versions didn't have a logger
-                // log file in upload folder - wp-content/uploads
-                $upload_dir = wp_upload_dir();
-                $upload_base = trailingslashit($upload_dir['basedir']);
-                $log_file = $upload_base . 'myparcel_log.txt';
 
-                $current_date_time = date("Y-m-d H:i:s");
-                $message = $current_date_time . ' ' . $message . "\n";
-
-                file_put_contents($log_file, $message, FILE_APPEND);
+                return;
             }
+
+            // Old WC versions didn't have a logger
+            // log file in upload folder - wp-content/uploads
+            $upload_dir = wp_upload_dir();
+            $upload_base = trailingslashit($upload_dir['basedir']);
+            $log_file = $upload_base . 'myparcel_log.txt';
+
+            $current_date_time = date("Y-m-d H:i:s");
+            $message = $current_date_time . ' ' . $message . "\n";
+
+            file_put_contents($log_file, $message, FILE_APPEND);
+            return;
         }
     }
 


### PR DESCRIPTION
Starting with WooCommerce 3.0, logging can be grouped by context and severity. Solved code 0 error