### PR TITLE
Fix WooCommerce PDF Invoices & Packing Slips placeholders compatibility

### DIFF
--- a/includes/compatibility/class-wcpdf-compatibility.php
+++ b/includes/compatibility/class-wcpdf-compatibility.php
@@ -16,19 +16,11 @@ class WCMP_WCPDF_Compatibility
     public static function add_filters()
     {
         // WooCommerce PDF Invoices & Packing Slips Premium Templates compatibility
-        add_filter(
-            "wpo_wcpdf_templates_replace_myparcel_tracktrace",
-            [__CLASS__, "track_trace"],
-            10,
-            2
-        );
+        add_filter("wpo_wcpdf_templates_replace_myparcel_tracktrace", [__CLASS__, "track_trace"], 10, 2);
+        add_filter("wpo_wcpdf_templates_replace_myparcel_track_trace", [__CLASS__, "track_trace"], 10, 2);
 
-        add_filter(
-            "wpo_wcpdf_templates_replace_myparcel_tracktrace_link",
-            [__CLASS__, "track_trace_link"],
-            10,
-            2
-        );
+        add_filter("wpo_wcpdf_templates_replace_myparcel_tracktrace_link", [__CLASS__, "track_trace_link"], 10, 2);
+        add_filter("wpo_wcpdf_templates_replace_myparcel_track_trace_link", [__CLASS__, "track_trace_link"], 10, 2);
     }
 
     /**

--- a/includes/compatibility/class-wcpdf-compatibility.php
+++ b/includes/compatibility/class-wcpdf-compatibility.php
@@ -37,11 +37,10 @@ class WCMP_WCPDF_Compatibility
         $track_trace = [];
 
         foreach ($shipments as $shipment) {
-            if (! empty($shipment['link'])) {
-                $track_trace[] = $shipment['link'];
+            if (! empty($shipment['track_trace'])) {
+                $track_trace[] = $shipment['track_trace'];
             }
         }
-
         return implode(', ', $track_trace);
     }
 
@@ -54,7 +53,7 @@ class WCMP_WCPDF_Compatibility
      */
     public function track_trace_link($replacement, $order)
     {
-        $track_trace_links = WCMP_Frontend::getTrackTraceShipments(WCX_Order::get_id($order));
+        $track_trace_links = WCMP_Frontend::getTrackTraceLinks(WCX_Order::get_id($order));
 
         $track_trace_links = array_map(
             function ($link) {

--- a/includes/compatibility/class-wcpdf-compatibility.php
+++ b/includes/compatibility/class-wcpdf-compatibility.php
@@ -17,15 +17,15 @@ class WCMP_WCPDF_Compatibility
     {
         // WooCommerce PDF Invoices & Packing Slips Premium Templates compatibility
         add_filter(
-            "wpo_wcpdf_templates_replace_myparcel_track_trace",
-            ["WCMP_WCPDF_Compatibility", "track_trace"],
+            "wpo_wcpdf_templates_replace_myparcel_tracktrace",
+            [__CLASS__, "track_trace"],
             10,
             2
         );
 
         add_filter(
-            "wpo_wcpdf_templates_replace_myparcel_track_trace_link",
-            ["WCMP_WCPDF_Compatibility", "track_trace_link"],
+            "wpo_wcpdf_templates_replace_myparcel_tracktrace_link",
+            [__CLASS__, "track_trace_link"],
             10,
             2
         );

--- a/includes/frontend/class-wcmp-frontend.php
+++ b/includes/frontend/class-wcmp-frontend.php
@@ -68,10 +68,10 @@ class WCMP_Frontend
     }
 
     /**
-     * @param $replacement
-     * @param $order
+     * @param string   $replacement
+     * @param WC_Order $order
      *
-     * @return false|string
+     * @return string
      * @throws Exception
      */
     public function wpo_wcpdf_delivery_options($replacement, WC_Order $order)
@@ -82,16 +82,17 @@ class WCMP_Frontend
     }
 
     /**
-     * @param $replacement
-     * @param $order
+     * @param string   $replacement
+     * @param WC_Order $order
      *
-     * @return false|string
+     * @return string
      * @throws Exception
      */
     public function wpo_wcpdf_delivery_date($replacement, WC_Order $order)
     {
         $deliveryOptions = WCMYPA_Admin::getDeliveryOptionsFromOrder($order);
-        if ( $deliveryDate = $deliveryOptions->getDate() ) {
+        $deliveryDate = $deliveryOptions->getDate()
+        if ($deliveryDate) {
             return wc_format_datetime(new WC_DateTime($deliveryDate), 'l d-m');
         }
 

--- a/includes/frontend/class-wcmp-frontend.php
+++ b/includes/frontend/class-wcmp-frontend.php
@@ -29,12 +29,9 @@ class WCMP_Frontend
         // pickup address on thank you page
         add_action("woocommerce_thankyou", [$this, "thankyou_pickup_html"], 10, 1);
 
-        add_filter(
-            "wpo_wcpdf_templates_replace_myparcel_delivery_options",
-            [$this, "wpo_wcpdf_delivery_options"],
-            10,
-            2
-        );
+        // WooCommerce PDF Invoices & Packing Slips Premium Templates compatibility
+        add_filter("wpo_wcpdf_templates_replace_myparcel_delivery_options", [$this, "wpo_wcpdf_delivery_options"], 10, 2);
+        add_filter("wpo_wcpdf_templates_replace_myparcel_delivery_date", [$this, "wpo_wcpdf_delivery_date"], 10, 2);
 
         // Initialize delivery options fees
         new WCMP_Cart_Fees();
@@ -82,6 +79,23 @@ class WCMP_Frontend
         ob_start();
         WCMYPA()->admin->showDeliveryOptionsForOrder($order);
         return ob_get_clean();
+    }
+
+    /**
+     * @param $replacement
+     * @param $order
+     *
+     * @return false|string
+     * @throws Exception
+     */
+    public function wpo_wcpdf_delivery_date($replacement, WC_Order $order)
+    {
+        $deliveryOptions = WCMYPA_Admin::getDeliveryOptionsFromOrder($order);
+        if ( $deliveryDate = $deliveryOptions->getDate() ) {
+            return wc_format_datetime(new WC_DateTime($deliveryDate), 'l d-m');
+        }
+
+        return $replacement;
     }
 
     /**

--- a/includes/frontend/class-wcmp-frontend.php
+++ b/includes/frontend/class-wcmp-frontend.php
@@ -91,7 +91,7 @@ class WCMP_Frontend
     public function wpo_wcpdf_delivery_date($replacement, WC_Order $order)
     {
         $deliveryOptions = WCMYPA_Admin::getDeliveryOptionsFromOrder($order);
-        $deliveryDate = $deliveryOptions->getDate()
+        $deliveryDate = $deliveryOptions->getDate();
         if ($deliveryDate) {
             return wc_format_datetime(new WC_DateTime($deliveryDate), 'l d-m');
         }


### PR DESCRIPTION
WooCommerce PDF Invoices & Packing Slips Premium Templates compatibility
The `{{myparcel_delivery_date}}` placeholder got left out in the 4.0 upgrade (while it was present in 3.x). I wasn't sure whether to place it in `includes/compatibility/class-wcpdf-compatibility.php` or ` includes/frontend/class-wcmp-frontend.php` but since the former appears to be used specifically for the track & trace placeholders I opted for the latter. Might be good to bundle them all together in the compatibility class after all?

Several bugs in the other placeholder methods are also addressed.

Fixes #412 