### PR TITLE
Add wpm-config.json

### DIFF
--- a/wpm-config.json
+++ b/wpm-config.json
@@ -1,0 +1,20 @@
+{
+  "admin_pages": [
+    "woocommerce_page_wcmp_settings"
+  ],
+  "options": {
+    "woocommerce_myparcel_checkout_settings": {
+      "barcode_in_note_title" : {},
+      "label_description" : {},
+
+      "header_delivery_options_title" : {},
+      "delivery_title" : {},
+      "morning_title" : {},
+      "standard_title" : {},
+      "evening_title" : {},
+      "only_recipient_title" : {},
+      "signature_title" : {},
+      "pickup_title" : {}
+    }
+  }
+}


### PR DESCRIPTION
Adds support for [WP-Multilang](https://wordpress.org/plugins/wp-multilang/). This allows the delivery options (e.g. 'Delivered at home or at work') to be translated to multiple languages.

This wpm-config.json file is automatically detected by WP-Multilang. It will add a language switcher on top of the MyParcel-settings page. The settings can be stored in multiple languages.