### PR TITLE
fix: url for old vendor map

### DIFF
--- a/migration/wcmp-upgrade-migration-v4-1-0.php
+++ b/migration/wcmp-upgrade-migration-v4-1-0.php
@@ -57,7 +57,7 @@ class WCMP_Upgrade_Migration_v4_1_0 extends WCMP_Upgrade_Migration
 
     protected function import(): void
     {
-        require_once(WCMYPA()->plugin_path() . '/includes/vendor/autoload.php');
+        require_once(WCMYPA()->plugin_path() . '/vendor/autoload.php');
         require_once(WCMYPA()->plugin_path() . '/includes/admin/settings/class-wcmypa-settings.php');
         require_once(WCMYPA()->plugin_path() . '/includes/class-wcmp-data.php');
     }


### PR DESCRIPTION
The url to autoload.php changed in migration file