### PR TITLE
fix: export age check with setting of product

### DIFF
--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -250,7 +250,7 @@ class OrderSettings
         $ageCheckOfProduct           = $this->getAgeCheckOfProduct();
         $ageCheckFromSettings        = (bool) WCMYPA()->setting_collection->getByName($settingName);
 
-        $this->ageCheck = $ageCheckFromShipmentOptions || $ageCheckOfProduct || $ageCheckFromSettings;
+        $this->ageCheck = $ageCheckFromShipmentOptions ?? $ageCheckOfProduct ?? $ageCheckFromSettings;
     }
 
     /**

--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -250,7 +250,7 @@ class OrderSettings
         $ageCheckOfProduct           = $this->getAgeCheckOfProduct();
         $ageCheckFromSettings        = (bool) WCMYPA()->setting_collection->getByName($settingName);
 
-        $this->ageCheck = $ageCheckFromShipmentOptions ?? $ageCheckOfProduct ?? $ageCheckFromSettings;
+        $this->ageCheck = $ageCheckFromShipmentOptions || $ageCheckOfProduct || $ageCheckFromSettings;
     }
 
     /**
@@ -266,11 +266,11 @@ class OrderSettings
             $product         = $item->get_product();
             $productAgeCheck = WCX_Product::get_meta($product, WCMYPA_Admin::META_AGE_CHECK, true);
 
-            if ($productAgeCheck === 1) {
+            if ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_ENABLED) {
                 return true;
             }
 
-            if ($productAgeCheck === 0) {
+            if ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_DISABLED) {
                 $hasAgeCheck = false;
             }
         }

--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -818,7 +818,7 @@ class WCMYPA_Admin
             ],
             'Age-check'         => [
                 'id'          => self::META_AGE_CHECK,
-                'label'       => __('Age csddsdsdsheck', 'woocommerce-myparcel'),
+                'label'       => __('Age check', 'woocommerce-myparcel'),
                 'type'        => 'select',
                 'options'     => [
                     'Default',

--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -57,6 +57,9 @@ class WCMYPA_Admin
     public const BULK_ACTION_PRINT        = "wcmp_print";
     public const BULK_ACTION_EXPORT_PRINT = "wcmp_export_print";
 
+    public const PRODUCT_OPTIONS_ENABLED  = "yes";
+    public const PRODUCT_OPTIONS_DISABLED = "no";
+
     public function __construct()
     {
         if (is_wp_version_compatible("4.7.0")) {
@@ -707,9 +710,9 @@ class WCMYPA_Admin
                         'id'          => $productOption['id'],
                         'label'       => $productOption['label'],
                         'options' => [
-                            null => __("Default", "woocommerce-myparcel"),
-                            0    => __("Disabled", "woocommerce-myparcel"),
-                            1    => __("Enabled", "woocommerce-myparcel"),
+                            null                           => __("Default", "woocommerce-myparcel"),
+                            self::PRODUCT_OPTIONS_DISABLED => __("Disabled", "woocommerce-myparcel"),
+                            self::PRODUCT_OPTIONS_ENABLED  => __("Enabled", "woocommerce-myparcel"),
                         ],
                         'description' => $productOption['description'],
                     ]
@@ -815,7 +818,7 @@ class WCMYPA_Admin
             ],
             'Age-check'         => [
                 'id'          => self::META_AGE_CHECK,
-                'label'       => __('Age check', 'woocommerce-myparcel'),
+                'label'       => __('Age csddsdsdsheck', 'woocommerce-myparcel'),
                 'type'        => 'select',
                 'options'     => [
                     'Default',


### PR DESCRIPTION
- `0` can't be saved into the database
- check for age check is not always true or null.