### PR TITLE
fix: export order with incorrect shipment

### DIFF
--- a/includes/admin/class-wcmp-api.php
+++ b/includes/admin/class-wcmp-api.php
@@ -189,7 +189,7 @@ class WCMP_API extends WCMP_Rest
             $order           = WC_Core::get_order($orderId);
             $lastShipmentIds = WCX_Order::get_meta($order, WCMYPA_Admin::META_LAST_SHIPMENT_IDS);
 
-            if (is_bool($lastShipmentIds)) {
+            if (empty($lastShipmentIds)) {
                 continue;
             }
 

--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -370,7 +370,7 @@ class WCMP_Export
         }
 
         foreach ($order_ids as $order_id) {
-            if ($this->errors[$order_id]) {
+            if (isset($this->errors[$order_id])) {
                 continue;
             }
 

--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -370,7 +370,6 @@ class WCMP_Export
         }
 
         foreach ($order_ids as $order_id) {
-
             if ($this->errors[$order_id]) {
                 continue;
             }

--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -370,6 +370,11 @@ class WCMP_Export
         }
 
         foreach ($order_ids as $order_id) {
+
+            if ($this->errors[$order_id]) {
+                continue;
+            }
+
             $order          = WCX::get_order($order_id);
             $consignmentIds = ($collection->getConsignmentsByReferenceIdGroup($order_id))->getConsignmentIds();
 


### PR DESCRIPTION
- LastShipmentIds is taken from the meta, there is no bool in it, but it is either empty or filled.
- If an order has an error, the order status will not have to be changed