### PR TITLE
fix: barcode in email with order status automation

### DIFF
--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -393,8 +393,6 @@ class WCMP_Export
                 WCMYPA_Admin::META_LAST_SHIPMENT_IDS,
                 $consignmentIds
             );
-
-            $this->updateOrderStatus($order);
         }
 
         if (! empty($this->success)) {
@@ -1549,24 +1547,6 @@ class WCMP_Export
         }
 
         return false;
-    }
-
-    /**
-     * Update the status of given order based on the automatic order status settings.
-     *
-     * @param WC_Order $order
-     */
-    private function updateOrderStatus(WC_Order $order): void
-    {
-        if (WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTING_ORDER_STATUS_AUTOMATION)) {
-            $newStatus = $this->getSetting(WCMYPA_Settings::SETTING_AUTOMATIC_ORDER_STATUS);
-            $order->update_status(
-                $newStatus,
-                __("MyParcel shipment created:", "woocommerce-myparcel")
-            );
-
-            WCMP_Log::add("Status of order {$order->get_id()} updated to \"$newStatus\"");
-        }
     }
 
     /**


### PR DESCRIPTION
track trace mail must be sent as soon as a barcode is known (printed). Only then can the status changed.