### PR TITLE
fix: handle weight in a more robust manner

### DIFF
--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -459,7 +459,8 @@ class OrderSettings
     }
 
     /**
-     * @param null $deliveryOptions
+     * @param \MyParcelNL\Sdk\src\Adapter\DeliveryOptions\AbstractDeliveryOptionsAdapter|array|null
+
      *
      * @throws \Exception
      */

--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -9,6 +9,8 @@ use WPO\WC\MyParcel\Compatibility\Product as WCX_Product;
 
 class OrderSettings
 {
+    private const DEFAULT_COLLO_AMOUNT = 1;
+
     /**
      * @var \MyParcelNL\Sdk\src\Adapter\DeliveryOptions\AbstractDeliveryOptionsAdapter
      */
@@ -109,8 +111,7 @@ class OrderSettings
     public function __construct(
         WC_Order $order,
         $deliveryOptions = null
-    )
-    {
+    ) {
         $this->order = $order;
 
         $this->setDeliveryOptions($deliveryOptions);
@@ -300,7 +301,7 @@ class OrderSettings
      */
     private function setColloAmount(): void
     {
-        $this->colloAmount = (int) ($this->extraOptions['collo_amount'] ?? 1);
+        $this->colloAmount = (int) ($this->extraOptions['collo_amount'] ?? self::DEFAULT_COLLO_AMOUNT);
     }
 
     /**

--- a/includes/admin/OrderSettingsRows.php
+++ b/includes/admin/OrderSettingsRows.php
@@ -25,7 +25,7 @@ class OrderSettingsRows
     private const OPTION_CARRIER                            = "[carrier]";
     private const OPTION_DELIVERY_TYPE                      = "[delivery_type]";
     private const OPTION_EXTRA_OPTIONS_COLLO_AMOUNT         = "[extra_options][collo_amount]";
-    private const OPTION_EXTRA_OPTIONS_WEIGHT               = "[extra_options][weight]";
+    private const OPTION_EXTRA_OPTIONS_DIGITAL_STAMP_WEIGHT = "[extra_options][digital_stamp_weight]";
     private const OPTION_PACKAGE_TYPE                       = "[package_type]";
     private const OPTION_SHIPMENT_OPTIONS_INSURED           = "[shipment_options][insured]";
     private const OPTION_SHIPMENT_OPTIONS_INSURED_AMOUNT    = "[shipment_options][insured_amount]";
@@ -78,13 +78,14 @@ class OrderSettingsRows
         AbstractDeliveryOptionsAdapter $deliveryOptions,
         WC_Order $order
     ): array {
-        $orderSettings      = new OrderSettings($deliveryOptions, $order);
+        $orderSettings      = new OrderSettings($order, $deliveryOptions);;
+        $shippingCountry    = $orderSettings->getShippingCountry();
         $isEuCountry        = WCMP_Country_Codes::isEuCountry();
-        $isHomeCountry      = WCMP_Data::isHomeCountry($order->get_shipping_country());
+        $isHomeCountry      = WCMP_Data::isHomeCountry($shippingCountry);
         $packageTypeOptions = array_combine(WCMP_Data::getPackageTypes(), WCMP_Data::getPackageTypesHuman());
 
         // Remove mailbox and digital stamp, because this is not possible for international shipments
-        if (! $isHomeCountry){
+        if (! $isHomeCountry) {
             unset($packageTypeOptions['mailbox']);
             unset($packageTypeOptions['digital_stamp']);
         }
@@ -189,15 +190,13 @@ class OrderSettingsRows
     {
         return [
             [
-                "name"        => self::OPTION_EXTRA_OPTIONS_WEIGHT,
+                "name"        => self::OPTION_EXTRA_OPTIONS_DIGITAL_STAMP_WEIGHT,
                 "type"        => "select",
                 "label"       => __("Weight", "woocommerce-myparcel"),
-                "description" => $orderSettings->getWeight()
-                    ? sprintf(
-                        __("Calculated weight: %s", "woocommerce-myparcel"),
-                        wc_format_weight($orderSettings->getWeight())
-                    )
-                    : null,
+                "description" => sprintf(
+                    __("Calculated weight: %s", "woocommerce-myparcel"),
+                    wc_format_weight($orderSettings->getWeight())
+                ),
                 "options"     => WCMP_Export::getDigitalStampRangeOptions(),
                 "value"       => $orderSettings->getDigitalStampRangeWeight(),
                 "condition"   => [

--- a/includes/admin/OrderSettingsRows.php
+++ b/includes/admin/OrderSettingsRows.php
@@ -135,11 +135,8 @@ class OrderSettingsRows
             $rows[] = [
                 "name"      => self::OPTION_SHIPMENT_OPTIONS_LARGE_FORMAT,
                 "type"      => "toggle",
-                "label"     => __("Extra large size", "woocommerce-myparcel"),
-                "help_text" => __(
-                    "Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet rate will be charged.",
-                    "woocommerce-myparcel"
-                ),
+                "label"     => __("shipment_options_large_format", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_large_format_help_text", "woocommerce-myparcel"),
                 "value"     => $orderSettings->hasLargeFormat(),
                 "condition" => [
                     self::CONDITION_PACKAGE_TYPE_PACKAGE,
@@ -192,9 +189,9 @@ class OrderSettingsRows
             [
                 "name"        => self::OPTION_EXTRA_OPTIONS_DIGITAL_STAMP_WEIGHT,
                 "type"        => "select",
-                "label"       => __("Weight", "woocommerce-myparcel"),
+                "label"       => __("weight", "woocommerce-myparcel"),
                 "description" => sprintf(
-                    __("Calculated weight: %s", "woocommerce-myparcel"),
+                    __("calculated_order_weight", "woocommerce-myparcel"),
                     wc_format_weight($orderSettings->getWeight())
                 ),
                 "options"     => WCMP_Export::getDigitalStampRangeOptions(),
@@ -215,11 +212,8 @@ class OrderSettingsRows
             [
                 "name"      => self::OPTION_SHIPMENT_OPTIONS_ONLY_RECIPIENT,
                 "type"      => "toggle",
-                "label"     => __("Home address only", "woocommerce-myparcel"),
-                "help_text" => __(
-                    "If you don't want the parcel to be delivered at the neighbours, choose this option.",
-                    "woocommerce-myparcel"
-                ),
+                "label"     => __("shipment_options_only_recipient", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_only_recipient_help_text", "woocommerce-myparcel"),
                 "value"     => $orderSettings->hasOnlyRecipient(),
                 "condition" => [
                     self::CONDITION_PACKAGE_TYPE_PACKAGE,
@@ -231,12 +225,9 @@ class OrderSettingsRows
             [
                 "name"      => self::OPTION_SHIPMENT_OPTIONS_SIGNATURE,
                 "type"      => "toggle",
-                "label"     => __("Signature on delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_signature", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_signature_help_text", "woocommerce-myparcel"),
                 "value"     => $orderSettings->hasSignature(),
-                "help_text" => __(
-                    "The parcel will be offered at the delivery address. If the recipient is not at home, the parcel will be delivered to the neighbours. In both cases, a signature will be required.",
-                    "woocommerce-myparcel"
-                ),
                 "condition" => [
                     self::CONDITION_PACKAGE_TYPE_PACKAGE,
                     self::CONDITION_DELIVERY_TYPE_DELIVERY,
@@ -259,12 +250,9 @@ class OrderSettingsRows
             [
                 "name"      => self::OPTION_SHIPMENT_OPTIONS_RETURN_SHIPMENT,
                 "type"      => "toggle",
-                "label"     => __("Return if no answer", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_return", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_return_help_text", "woocommerce-myparcel"),
                 "value"     => $orderSettings->hasReturnShipment(),
-                "help_text" => __(
-                    "By default, a parcel will be offered twice. After two unsuccessful delivery attempts, the parcel will be available at the nearest pickup point for two weeks. There it can be picked up by the recipient with the note that was left by the courier. If you want to receive the parcel back directly and NOT forward it to the pickup point, enable this option.",
-                    "woocommerce-myparcel"
-                ),
                 "condition" => [
                     self::CONDITION_PACKAGE_TYPE_PACKAGE,
                     self::CONDITION_DELIVERY_TYPE_DELIVERY,
@@ -274,7 +262,7 @@ class OrderSettingsRows
             [
                 "name"      => self::OPTION_SHIPMENT_OPTIONS_INSURED,
                 "type"      => "toggle",
-                "label"     => __("Insured", "woocommerce-myparcel"),
+                "label"     => __("insured", "woocommerce-myparcel"),
                 "value"     => $orderSettings->isInsured(),
                 "condition" => [
                     self::CONDITION_PACKAGE_TYPE_PACKAGE,
@@ -290,7 +278,7 @@ class OrderSettingsRows
             [
                 "name"      => self::OPTION_SHIPMENT_OPTIONS_INSURED_AMOUNT,
                 "type"      => "select",
-                "label"     => __("Insurance amount", "woocommerce-myparcel"),
+                "label"     => __("insured_amount", "woocommerce-myparcel"),
                 "options"   => WCMP_Data::getInsuranceAmounts(),
                 "value"     => $orderSettings->getInsuranceAmount(),
                 "condition" => [

--- a/includes/admin/class-wcmp-export-consignments.php
+++ b/includes/admin/class-wcmp-export-consignments.php
@@ -17,6 +17,8 @@ if (class_exists("WCMP_Export_Consignments")) {
 
 class WCMP_Export_Consignments
 {
+    private const DEFAULT_PRODUCT_QUANTITY = 1;
+
     /**
      * @var AbstractConsignment
      */
@@ -183,7 +185,7 @@ class WCMP_Export_Consignments
                 $description = substr($item["name"], 0, 47) . "...";
             }
             // Amount
-            $amount = (int) ($item["qty"] ?? 1);
+            $amount = (int) ($item["qty"] ?? self::DEFAULT_PRODUCT_QUANTITY);
 
             // Weight (total item weight in grams)
             $weight = WCMP_Export::convertWeightToGrams($product->get_weight());

--- a/includes/admin/settings/class-wcmp-settings-data.php
+++ b/includes/admin/settings/class-wcmp-settings-data.php
@@ -410,30 +410,21 @@ class WCMP_Settings_Data
         return [
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_ONLY_RECIPIENT,
-                "label"     => __("Home address only", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_only_recipient", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_only_recipient_help_text", "woocommerce-myparcel"),
                 "type"      => "toggle",
-                "help_text" => __(
-                    "If you don't want the parcel to be delivered at the neighbours, choose this option.",
-                    "woocommerce-myparcel"
-                ),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_SIGNATURE,
-                "label"     => __("Signature on delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_signature", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_signature_help_text", "woocommerce-myparcel"),
                 "type"      => "toggle",
-                "help_text" => __(
-                    "The parcel will be offered at the delivery address. If the recipient is not at home, the parcel will be delivered to the neighbours. In both cases, a signature will be required.",
-                    "woocommerce-myparcel"
-                ),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_LARGE_FORMAT,
-                "label"     => __("Extra large size", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_large_format", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_large_format_help_text", "woocommerce-myparcel"),
                 "type"      => "toggle",
-                "help_text" => __(
-                    "Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet rate will be charged.",
-                    "woocommerce-myparcel"
-                ),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_AGE_CHECK,
@@ -443,42 +434,30 @@ class WCMP_Settings_Data
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_RETURN,
-                "label"     => __("Return if no answer", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_return", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_return_help_text", "woocommerce-myparcel"),
                 "type"      => "toggle",
-                "help_text" => __(
-                    "By default, a parcel will be offered twice. After two unsuccessful delivery attempts, the parcel will be available at the nearest pickup point for two weeks. There it can be picked up by the recipient with the note that was left by the courier. If you want to receive the parcel back directly and NOT forward it to the pickup point, enable this option.",
-                    "woocommerce-myparcel"
-                ),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_INSURED,
-                "label"     => __("Insured shipment", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_insured", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_insured_help_text", "woocommerce-myparcel"),
                 "type"      => "toggle",
-                "help_text" => __(
-                    "By default, there is no insurance on the shipments. If you still want to insure the shipment, you can do that. We insure the purchase value of the shipment, with a maximum insured value of € 5.000. Insured parcels always contain the options 'Home address only' en 'Signature for delivery'",
-                    "woocommerce-myparcel"
-                ),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_INSURED_FROM_PRICE,
                 "condition" => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_INSURED,
-                "label"     => __("Insure from price", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_insured_from_price", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_insured_from_price_help_text", "woocommerce-myparcel"),
                 "type"      => "number",
-                "help_text" => __(
-                    "Insure all orders that exceed this price point.",
-                    "woocommerce-myparcel"
-                ),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_INSURED_AMOUNT,
                 "condition" => WCMYPA_Settings::SETTING_CARRIER_DEFAULT_EXPORT_INSURED,
-                "label"     => __("Max insured amount", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_insured_amount", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_insured_amount_help_text", "woocommerce-myparcel"),
                 "type"      => "select",
                 "options"   => WCMP_Data::getInsuranceAmounts(),
-                "help_text" => __(
-                    "Insure all parcels up to the selected amount.",
-                    "woocommerce-myparcel"
-                ),
             ],
         ];
     }
@@ -566,7 +545,7 @@ class WCMP_Settings_Data
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_ONLY_RECIPIENT_ENABLED,
                 "condition" => WCMYPA_Settings::SETTING_CARRIER_DELIVERY_ENABLED,
-                "label"     => __("Home address only", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_only_recipient", "woocommerce-myparcel"),
                 "type"      => "toggle",
             ],
             self::getFeeField(
@@ -579,7 +558,7 @@ class WCMP_Settings_Data
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_SIGNATURE_ENABLED,
                 "condition" => WCMYPA_Settings::SETTING_CARRIER_DELIVERY_ENABLED,
-                "label"     => __("Signature on delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_signature", "woocommerce-myparcel"),
                 "type"      => "toggle",
                 "help_text" => __(
                     "Enter an amount that is either positive or negative. For example, do you want to give a discount for using this function or do you want to charge extra for this delivery option.",
@@ -934,13 +913,13 @@ class WCMP_Settings_Data
                 "name"      => WCMYPA_Settings::SETTING_ONLY_RECIPIENT_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
                 "label"     => __("Home address only title", "woocommerce-myparcel"),
-                "default"   => __("Home address only", "woocommerce-myparcel"),
+                "default"   => __("shipment_options_only_recipient", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_SIGNATURE_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
                 "label"     => __("Signature on delivery title", "woocommerce-myparcel"),
-                "default"   => __("Signature on delivery", "woocommerce-myparcel"),
+                "default"   => __("shipment_options_signature", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_PICKUP_TITLE,

--- a/includes/admin/settings/class-wcmp-shipping-methods.php
+++ b/includes/admin/settings/class-wcmp-shipping-methods.php
@@ -210,6 +210,10 @@ class WCMP_Shipping_Methods
     {
         $shippingMethodOption = get_option($zoneShippingMethod->shipping_methods_option);
 
+        if (!$shippingMethodOption) {
+            return;
+        }
+
         foreach ($shippingMethodOption as $item) {
             $this->addShippingMethod($item['id_for_shipping'], $item['method_title']);
         }

--- a/includes/admin/settings/class-wcmp-shipping-methods.php
+++ b/includes/admin/settings/class-wcmp-shipping-methods.php
@@ -210,7 +210,7 @@ class WCMP_Shipping_Methods
     {
         $shippingMethodOption = get_option($zoneShippingMethod->shipping_methods_option);
 
-        if (!$shippingMethodOption) {
+        if (! $shippingMethodOption) {
             return;
         }
 

--- a/includes/admin/views/html-order-return-shipment-options.php
+++ b/includes/admin/views/html-order-return-shipment-options.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
 
 if (! defined('ABSPATH')) {
@@ -12,7 +14,7 @@ if (! defined('ABSPATH')) {
  */
 
 /** @noinspection PhpUnhandledExceptionInspection */
-$deliveryOptions = WCMYPA_Admin::getDeliveryOptionsFromOrder($order);
+$orderSettings = new OrderSettings($order);
 
 ?>
 <table class="wcmp__settings-table" style="width: auto">
@@ -21,7 +23,7 @@ $deliveryOptions = WCMYPA_Admin::getDeliveryOptionsFromOrder($order);
             <?php _e("Shipment type", "woocommerce-myparcel") ?>:<br/> <small class="calculated_weight">
                 <?php printf(
                     __("Calculated weight: %s", "woocommerce-myparcel"),
-                    wc_format_weight($order->get_meta(WCMYPA_Admin::META_ORDER_WEIGHT))
+                    wc_format_weight($orderSettings->getWeight())
                 ) ?>
             </small>
         </td>

--- a/includes/admin/views/html-order-return-shipment-options.php
+++ b/includes/admin/views/html-order-return-shipment-options.php
@@ -22,7 +22,7 @@ $orderSettings = new OrderSettings($order);
         <td>
             <?php _e("Shipment type", "woocommerce-myparcel") ?>:<br/> <small class="calculated_weight">
                 <?php printf(
-                    __("Calculated weight: %s", "woocommerce-myparcel"),
+                    __("calculated_order_weight", "woocommerce-myparcel"),
                     wc_format_weight($orderSettings->getWeight())
                 ) ?>
             </small>

--- a/includes/admin/views/html-order-shipment-summary.php
+++ b/includes/admin/views/html-order-shipment-summary.php
@@ -20,8 +20,8 @@ $shipments       = WCMYPA()->export->getShipmentData([$shipment_id], $order);
 $deliveryOptions = WCMYPA_Admin::getDeliveryOptionsFromOrder($order);
 
 $option_strings = [
-    "signature"      => __("Signature on delivery", "woocommerce-myparcel"),
-    "only_recipient" => __("Only recipient", "woocommerce-myparcel"),
+    "signature"      => __("shipment_options_signature", "woocommerce-myparcel"),
+    "only_recipient" => __("shipment_options_only_recipient", "woocommerce-myparcel"),
 ];
 
 $firstShipment = $shipments[$shipment_id];
@@ -52,7 +52,7 @@ foreach ($option_strings as $key => $label) {
 
 if ($insurance) {
     $price = number_format(Arr::get($insurance, "amount") / 100, 2);
-    printf('<li>%s: € %s</li>', __("Insured for", "woocommerce-myparcel"), $price);
+    printf('<li>%s: € %s</li>', __("insured_for", "woocommerce-myparcel"), $price);
 }
 
 if ($labelDescription) {

--- a/includes/admin/views/html-send-return-email-form.php
+++ b/includes/admin/views/html-send-return-email-form.php
@@ -65,8 +65,7 @@ $target_url = wp_nonce_url(
                                         <tr>
                                             <th>#</th>
                                             <th><?php _e("Product name", "woocommerce-myparcel"); ?></th>
-                                            <th class="wcmp__text--right"><?php _e("Weight", "woocommerce-myparcel");
-                                                ?></th>
+                                            <th class="wcmp__text--right"><?php _e("weight", "woocommerce-myparcel"); ?></th>
                                         </tr>
                                         </thead>
                                         <tbody>

--- a/includes/admin/views/html-send-return-email-form.php
+++ b/includes/admin/views/html-send-return-email-form.php
@@ -29,7 +29,9 @@ $target_url = wp_nonce_url(
             <?php
             $c = true;
             foreach ($order_ids as $order_id) :
-                $order = WCX::get_order($order_id);
+                $order         = WCX::get_order($order_id);
+                $orderSettings = new OrderSettings($order);
+
                 // skip non-myparcel destinations
                 $shipping_country = WCX_Order::get_prop($order, 'shipping_country');
                 if (! WCMP_Country_Codes::isAllowedDestination($shipping_country)) {
@@ -93,10 +95,10 @@ $target_url = wp_nonce_url(
                                             <th><?php _e("Total weight", "woocommerce-myparcel"); ?></th>
                                             <th class="wcmp__text--right">
                                                 <?php
-                                                $orderWeight = $order->get_meta(WCMYPA_Admin::META_ORDER_WEIGHT);
+                                                $weight = $orderSettings->getWeight();
 
-                                                if ($orderWeight) {
-                                                    echo wc_format_weight($orderWeight);
+                                                if ($weight) {
+                                                    echo wc_format_weight($weight);
                                                 } else {
                                                     echo esc_html__('N/A', 'woocommerce');
                                                 }

--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -348,17 +348,6 @@ class WCMP_Checkout
             WCMYPA()->version
         );
 
-        /**
-         * Save the order weight here because it's easier than digging through order data after creating it.
-         *
-         * @see https://businessbloomer.com/woocommerce-save-display-order-total-weight/
-         */
-        WCX_Order::update_meta_data(
-            $order,
-            WCMYPA_Admin::META_ORDER_WEIGHT,
-            WC()->cart->get_cart_contents_weight()
-        );
-
         WCX_Order::update_meta_data(
             $order,
             WCMYPA_Admin::META_SHIPMENT_OPTIONS_EXTRA,

--- a/languages/woocommerce-myparcel-en_GB.po
+++ b/languages/woocommerce-myparcel-en_GB.po
@@ -35,9 +35,6 @@ msgstr ""
 msgid "Address details are not entered"
 msgstr "Address details are not entered"
 
-msgid "settings_checkout_display_for_all_methods"
-msgstr "All shipping methods"
-
 msgid ""
 "Amount of days a customer can postpone a shipment. Default is 0 days with a "
 "maximum value of 14 days."
@@ -101,6 +98,9 @@ msgstr ""
 "contain the options 'Home address only' en 'Signature for delivery'"
 
 msgid "Calculated weight: %s"
+msgstr "Calculated weight: %s"
+
+msgid "calculated_order_weight"
 msgstr "Calculated weight: %s"
 
 msgid "Carrier"
@@ -220,9 +220,6 @@ msgstr "Digital stamp"
 
 msgid "Disabled"
 msgstr "Disabled"
-
-msgid "settings_checkout_display_for"
-msgstr "Display for"
 
 msgid "Documents"
 msgstr "Documents"
@@ -403,7 +400,7 @@ msgstr "Insure all parcels up to the selected amount."
 msgid "Insure from price"
 msgstr "Insure from price"
 
-msgid "Insured"
+msgid "insured"
 msgstr "Insured"
 
 msgid "Insured for"
@@ -411,6 +408,12 @@ msgstr "Insured for"
 
 msgid "Insured shipment"
 msgstr "Insured shipment"
+
+msgid "insured_amount"
+msgstr "Insurance amount"
+
+msgid "insured_for"
+msgstr "Insured for"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -628,6 +631,30 @@ msgstr "Send email"
 msgid "Settings"
 msgstr "Settings"
 
+msgid "settings_checkout_display_for"
+msgstr "Display for"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "All shipping methods"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"You can link the delivery options to specific shipping methods by adding "
+"them to the package types in \"Standard export settings\". The delivery "
+"options are not visible for foreign addresses."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Shipping methods associated with package type"
+
+msgid "settings_checkout_price_format"
+msgstr "Show prices as"
+
+msgid "settings_checkout_surcharge"
+msgstr "Surcharge"
+
+msgid "settings_checkout_total_price"
+msgstr "Total price"
+
 msgid "Shipment type"
 msgstr "Shipment type"
 
@@ -641,8 +668,65 @@ msgstr ""
 "receipt\" and \"Delivery only at recipient\" are included with this option. "
 "This option can't be combined with morning or evening delivery."
 
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Shipping methods associated with package type"
+msgid "shipment_options_insured"
+msgstr "Insured shipment"
+
+msgid "shipment_options_insured_amount"
+msgstr "Max insured amount"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Insure all parcels up to the selected amount."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Insure from price"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Insure all orders that exceed this price point."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"By default, there is no insurance on the shipments. If you still want to "
+"insure the shipment, you can do that. We insure the purchase value of the "
+"shipment, with a maximum insured value of € 5.000. Insured parcels always "
+"contain the options 'Home address only' en 'Signature for delivery'"
+
+msgid "shipment_options_large_format"
+msgstr "Extra large size"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but "
+"smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the "
+"parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet "
+"rate will be charged."
+
+msgid "shipment_options_only_recipient"
+msgstr "Home address only"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"If you don't want the parcel to be delivered at the neighbours, choose this "
+"option."
+
+msgid "shipment_options_return"
+msgstr "Return if no answer"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"By default, a parcel will be offered twice. After two unsuccessful delivery "
+"attempts, the parcel will be available at the nearest pickup point for two "
+"weeks. There it can be picked up by the recipient with the note that was "
+"left by the courier. If you want to receive the parcel back directly and "
+"NOT forward it to the pickup point, enable this option."
+
+msgid "shipment_options_signature"
+msgstr "Signature on delivery"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"The parcel will be offered at the delivery address. If the recipient is not "
+"at home, the parcel will be delivered to the neighbours. In both cases, a "
+"signature will be required."
 
 msgid "Show after billing details"
 msgstr "Show after billing details"
@@ -668,9 +752,6 @@ msgid ""
 msgstr ""
 "The \"Show delivery date\" option allows your customers to see the delivery "
 "date in order confirmations and My Account."
-
-msgid "settings_checkout_price_format"
-msgstr "Show prices as"
 
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Show Track & Trace code and link in My Account."
@@ -702,9 +783,6 @@ msgstr "Street name"
 msgid "Suffix"
 msgstr "Suffix"
 
-msgid "settings_checkout_surcharge"
-msgstr "Surcharge"
-
 msgid "The label has been printed."
 msgstr "The label has been printed."
 
@@ -730,6 +808,9 @@ msgstr ""
 "The parcel will be offered at the delivery address. If the recipient is not "
 "at home, the parcel will be delivered to the neighbours. In both cases, a "
 "signature will be required."
+
+msgid "The selected orders have not been exported to MyParcel yet!"
+msgstr "The selected orders have not been exported to MyParcel yet!"
 
 msgid "The selected orders have not been exported to MyParcel yet! "
 msgstr "The selected orders have not been exported to MyParcel yet! "
@@ -767,9 +848,6 @@ msgstr "Title before the barcode"
 msgid "Titles"
 msgstr "Titles"
 
-msgid "settings_checkout_total_price"
-msgstr "Total price"
-
 msgid "Total weight"
 msgstr "Total weight"
 
@@ -797,7 +875,7 @@ msgstr "Unpaid letter"
 msgid "View logs"
 msgstr "View logs"
 
-msgid "Weight"
+msgid "weight"
 msgstr "Weight"
 
 msgid ""
@@ -882,12 +960,6 @@ msgstr ""
 
 msgid "You can change the text before the barcode inside an note"
 msgstr "You can change the text before the barcode inside an note"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"You can link the delivery options to specific shipping methods by adding "
-"them to the package types in \"Standard export settings\". The delivery "
-"options are not visible for foreign addresses."
 
 msgid ""
 "You can place a delivery title above the MyParcel options. When there is no "

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -35,9 +35,6 @@ msgstr ""
 msgid "Address details are not entered"
 msgstr "Les données relatives à l'adresse ne sont pas complétées"
 
-msgid "settings_checkout_display_for_all_methods"
-msgstr "Tous les modes d'expédition"
-
 msgid ""
 "Amount of days a customer can postpone a shipment. Default is 0 days with a "
 "maximum value of 14 days."
@@ -91,6 +88,9 @@ msgid ""
 msgstr ""
 
 msgid "Calculated weight: %s"
+msgstr "Poids calculé : %s"
+
+msgid "calculated_order_weight"
 msgstr "Poids calculé : %s"
 
 msgid "Carrier"
@@ -209,9 +209,6 @@ msgstr ""
 msgid "Disabled"
 msgstr "désactivé"
 
-msgid "settings_checkout_display_for"
-msgstr "Afficher pour"
-
 msgid "Documents"
 msgstr "Les documents"
 
@@ -240,10 +237,10 @@ msgid "Enable MyParcel delivery options"
 msgstr "Activer les options de livraison MyParcel"
 
 msgid "Enable PostNL delivery"
-msgstr "Activer la livraison postnl"
+msgstr "Activer la livraison PostNL"
 
 msgid "Enable PostNL pickup"
-msgstr "Activer le ramassage postnl"
+msgstr "Activer le ramassage PostNL"
 
 msgid ""
 "Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but "
@@ -383,7 +380,7 @@ msgstr ""
 msgid "Insure from price"
 msgstr ""
 
-msgid "Insured"
+msgid "insured"
 msgstr ""
 
 msgid "Insured for"
@@ -391,6 +388,12 @@ msgstr "Montant assuré"
 
 msgid "Insured shipment"
 msgstr ""
+
+msgid "insured_amount"
+msgstr ""
+
+msgid "insured_for"
+msgstr "Montant assuré"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -516,7 +519,7 @@ msgid "Pick up at"
 msgstr "Ramasser à"
 
 msgid "Pick up from"
-msgstr "Collecte à partir de "
+msgstr "Collecte à partir de"
 
 msgid "Pickup"
 msgstr "Ramasser"
@@ -549,16 +552,16 @@ msgid "Postcode/city combination unknown"
 msgstr "Combinaison code postal / ville inconnue"
 
 msgid "PostNL"
-msgstr "postnl"
+msgstr "PostNL"
 
 msgid "PostNL delivery options"
-msgstr "Options de livraison postnl"
+msgstr "Options de livraison PostNL"
 
 msgid "PostNL export settings"
 msgstr ""
 
 msgid "PostNL pickup options"
-msgstr "Options de ramassage postnl"
+msgstr "Options de ramassage PostNL"
 
 msgid "Print"
 msgstr "Imprimer"
@@ -610,6 +613,31 @@ msgstr "Envoyer l'e-mail"
 msgid "Settings"
 msgstr "Paramètres"
 
+msgid "settings_checkout_display_for"
+msgstr "Afficher pour"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "Tous les modes d'expédition"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"Vous pouvez lier les options de livraison à des méthodes d'expédition "
+"spécifiques en les ajoutant aux types de colis sous \"Paramètres "
+"d'exportation standard\". Les options de livraison ne sont pas visibles aux "
+"adresses étrangères."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Mode d'expédition couplé au type de colis"
+
+msgid "settings_checkout_price_format"
+msgstr ""
+
+msgid "settings_checkout_surcharge"
+msgstr ""
+
+msgid "settings_checkout_total_price"
+msgstr ""
+
 msgid "Shipment type"
 msgstr "Types d'expédition"
 
@@ -622,10 +650,49 @@ msgstr ""
 "destinataire doit montrer qu'ils ont plus de 18 ans au moyen d'une preuve "
 "d'identité. Avec ceci L'option 'signature pour réception' et 'livraison "
 "uniquement chez le destinataire' sont inclus. Cette option ne peut pas être "
-"combinée avec la livraison le matin ou le soir. "
+"combinée avec la livraison le matin ou le soir."
 
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Mode d'expédition couplé au type de colis"
+msgid "shipment_options_insured"
+msgstr ""
+
+msgid "shipment_options_insured_amount"
+msgstr ""
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr ""
+
+msgid "shipment_options_insured_from_price"
+msgstr ""
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr ""
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+
+msgid "shipment_options_large_format"
+msgstr "Très grande taille"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+
+msgid "shipment_options_only_recipient"
+msgstr "Seul destinataire"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+
+msgid "shipment_options_return"
+msgstr ""
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+
+msgid "shipment_options_signature"
+msgstr "Signature pour réception"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
 
 msgid "Show after billing details"
 msgstr "Afficher après les données de facturation"
@@ -648,9 +715,6 @@ msgstr "Afficher la date de livraison"
 msgid ""
 "Show delivery day options allow your customers to see the delivery day in "
 "order confirmation and My Account."
-msgstr ""
-
-msgid "settings_checkout_price_format"
 msgstr ""
 
 msgid "Show Track & Trace trace code and link in My Account."
@@ -683,9 +747,6 @@ msgstr "Rue"
 msgid "Suffix"
 msgstr "Extension"
 
-msgid "settings_checkout_surcharge"
-msgstr ""
-
 msgid "The label has been printed."
 msgstr "L'étiquette est imprimée."
 
@@ -709,6 +770,9 @@ msgid ""
 "signature will be required."
 msgstr ""
 
+msgid "The selected orders have not been exported to MyParcel yet!"
+msgstr "Les commandes sélectionnées n'ont pas encore été exportées vers MyParcel!"
+
 msgid "The selected orders have not been exported to MyParcel yet! "
 msgstr "Les commandes sélectionnées n'ont pas encore été exportées vers MyParcel!"
 
@@ -719,7 +783,7 @@ msgid ""
 "These settings will be applied to PostNL shipments you create in the "
 "backend."
 msgstr ""
-"Ces paramètres seront appliqués aux envois postnl que vous créez dans le "
+"Ces paramètres seront appliqués aux envois PostNL que vous créez dans le "
 "backend."
 
 msgid "This option enables you to continue printing where you left off last time"
@@ -744,9 +808,6 @@ msgstr "Titre pour le code-barres"
 
 msgid "Titles"
 msgstr "Titres"
-
-msgid "settings_checkout_total_price"
-msgstr ""
 
 msgid "Total weight"
 msgstr "Poids total"
@@ -775,7 +836,7 @@ msgstr ""
 msgid "View logs"
 msgstr "Afficher les logs"
 
-msgid "Weight"
+msgid "weight"
 msgstr ""
 
 msgid ""
@@ -853,13 +914,6 @@ msgstr ""
 
 msgid "You can change the text before the barcode inside an note"
 msgstr "Vous pouvez modifier le texte du code-barres dans une note"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"Vous pouvez lier les options de livraison à des méthodes d'expédition "
-"spécifiques en les ajoutant aux types de colis sous \"Paramètres "
-"d'exportation standard\". Les options de livraison ne sont pas visibles aux "
-"adresses étrangères."
 
 msgid ""
 "You can place a delivery title above the MyParcel options. When there is no "

--- a/languages/woocommerce-myparcel-nl_BE.po
+++ b/languages/woocommerce-myparcel-nl_BE.po
@@ -35,9 +35,6 @@ msgstr ""
 msgid "Address details are not entered"
 msgstr "Adresgegevens zijn niet ingevuld"
 
-msgid "settings_checkout_display_for_all_methods"
-msgstr "Alle verzendmethoden"
-
 msgid ""
 "Amount of days a customer can postpone a shipment. Default is 0 days with a "
 "maximum value of 14 days."
@@ -99,6 +96,9 @@ msgstr ""
 "afgeleverd op het thuisadres en een handtekening is vereist."
 
 msgid "Calculated weight: %s"
+msgstr "Berekend gewicht: %s"
+
+msgid "calculated_order_weight"
 msgstr "Berekend gewicht: %s"
 
 msgid "Carrier"
@@ -218,9 +218,6 @@ msgstr "Digitale postzegel"
 
 msgid "Disabled"
 msgstr "Uitschakelen"
-
-msgid "settings_checkout_display_for"
-msgstr "Toon bij"
 
 msgid "Documents"
 msgstr "Documenten"
@@ -401,7 +398,7 @@ msgstr "Verzeker alle orders tot het geselecteerde bedrag."
 msgid "Insure from price"
 msgstr "Verzeker vanaf bedrag"
 
-msgid "Insured"
+msgid "insured"
 msgstr "Verzekerd"
 
 msgid "Insured for"
@@ -409,6 +406,12 @@ msgstr "Verzekerd voor"
 
 msgid "Insured shipment"
 msgstr "Verzekerde zending"
+
+msgid "insured_amount"
+msgstr "Verzekerd bedrag"
+
+msgid "insured_for"
+msgstr "Verzekerd voor"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -569,7 +572,7 @@ msgid "PostNL"
 msgstr "PostNL"
 
 msgid "PostNL delivery options"
-msgstr "PostNL bezorgopties "
+msgstr "PostNL bezorgopties"
 
 msgid "PostNL export settings"
 msgstr "PostNL export instellingen"
@@ -625,6 +628,30 @@ msgstr "Verstuur e-mail"
 msgid "Settings"
 msgstr "Instellingen"
 
+msgid "settings_checkout_display_for"
+msgstr "Toon bij"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "Alle verzendmethoden"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
+"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
+"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Verzendmethoden gekoppeld aan pakkettype"
+
+msgid "settings_checkout_price_format"
+msgstr "Prijzen tonen als"
+
+msgid "settings_checkout_surcharge"
+msgstr "Meerprijs"
+
+msgid "settings_checkout_total_price"
+msgstr "Totaalprijs"
+
 msgid "Shipment type"
 msgstr "Soort zending"
 
@@ -638,8 +665,65 @@ msgstr ""
 "voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
 "worden gecombineerd met ochtend- of avondlevering."
 
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Verzendmethoden gekoppeld aan pakkettype"
+msgid "shipment_options_insured"
+msgstr "Verzekerde zending"
+
+msgid "shipment_options_insured_amount"
+msgstr "Verzekeren tot maximaal"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Verzeker alle orders tot het geselecteerde bedrag."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Verzeker vanaf bedrag"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Verzeker alle orders met een totaal prijs hoger dan het ingevulde bedrag."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"Standaard zit er geen verzekering op zendingen. Als je alsnog een zending "
+"wilt verzekeren kan dat. Wij verzekeren het aankoopbedrag van een zending "
+"met een maximum van €5000. Verzekerde zendingen worden altijd alleen "
+"afgeleverd op het thuisadres en een handtekening is vereist."
+
+msgid "shipment_options_large_format"
+msgstr "Extra grote verpakking"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Activeer deze instelling als je zending groter is dan 100 x 70 x 50 cm, "
+"maar kleiner dan 175 x 78 x 58 cm. Dit kost meer. Let op! Als het pakket "
+"groter dan 175 x 78 x 58 cm of zwaarder dan 30kg is, wordt het gerekend als "
+"pallet."
+
+msgid "shipment_options_only_recipient"
+msgstr "Alleen thuisadres"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
+"optie."
+
+msgid "shipment_options_return"
+msgstr "Retour bij mislukte leverpoging"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"Standaard wordt een pakket 2x aangeboden. Bij 2 mislukte afleverpogingen, "
+"wordt het pakket bij het dichtstbijzijnde pickup point beschikbaar voor 2 "
+"weken. Daar kan het worden opgehaald met het bewijs dat is achtergelaten "
+"door de bezorger. Als je het pakket meteen retour wilt en NIET afgeleverd "
+"wil laten worden bij een pickup point, zet deze optie dan aan."
+
+msgid "shipment_options_signature"
+msgstr "Handtekening voor ontvangst"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
+"thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
+"een handtekening vereist."
 
 msgid "Show after billing details"
 msgstr "Toon na factuurgegevens"
@@ -665,9 +749,6 @@ msgid ""
 msgstr ""
 "De optie \"Toon bezorgdatum\" laat je klanten de bezorgdag zien in "
 "orderbevestigingen en Mijn Account."
-
-msgid "settings_checkout_price_format"
-msgstr "Prijzen tonen als"
 
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Toon Track & Trace code en link in Mijn Account."
@@ -699,9 +780,6 @@ msgstr "Straatnaam"
 msgid "Suffix"
 msgstr "Toev."
 
-msgid "settings_checkout_surcharge"
-msgstr "Meerprijs"
-
 msgid "The label has been printed."
 msgstr "Het label is geprint."
 
@@ -730,6 +808,9 @@ msgstr ""
 "thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
 "een handtekening vereist."
 
+msgid "The selected orders have not been exported to MyParcel yet!"
+msgstr "De geselecteerde bestellingen zijn nog niet geëxporteerd naar MyParcel!"
+
 msgid "The selected orders have not been exported to MyParcel yet! "
 msgstr "De geselecteerde bestellingen zijn nog niet geëxporteerd naar MyParcel!"
 
@@ -740,8 +821,8 @@ msgid ""
 "These settings will be applied to PostNL shipments you create in the "
 "backend."
 msgstr ""
-"Deze instellingen worden toegepast op PostNL zendingen die je in de backend "
-"aanmaakt."
+"Deze instellingen gelden voor PostNL zendingen die je aanmaakt in de "
+"backend."
 
 msgid "This option enables you to continue printing where you left off last time"
 msgstr ""
@@ -770,9 +851,6 @@ msgstr "Titel voor de barcode"
 msgid "Titles"
 msgstr "Titels"
 
-msgid "settings_checkout_total_price"
-msgstr "Totaalprijs"
-
 msgid "Total weight"
 msgstr "Totaal gewicht"
 
@@ -800,7 +878,7 @@ msgstr "Ongefrankeerd"
 msgid "View logs"
 msgstr "Logs weergeven"
 
-msgid "Weight"
+msgid "weight"
 msgstr "Gewicht"
 
 msgid ""
@@ -888,12 +966,6 @@ msgstr ""
 
 msgid "You can change the text before the barcode inside an note"
 msgstr "Je kunt de tekst veranderen voor de barcode in een notitie"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
-"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
-"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
 
 msgid ""
 "You can place a delivery title above the MyParcel options. When there is no "

--- a/languages/woocommerce-myparcel-nl_NL.po
+++ b/languages/woocommerce-myparcel-nl_NL.po
@@ -35,9 +35,6 @@ msgstr ""
 msgid "Address details are not entered"
 msgstr "Adresgegevens zijn niet ingevuld"
 
-msgid "settings_checkout_display_for_all_methods"
-msgstr "Alle verzendmethoden"
-
 msgid ""
 "Amount of days a customer can postpone a shipment. Default is 0 days with a "
 "maximum value of 14 days."
@@ -99,6 +96,9 @@ msgstr ""
 "afgeleverd op het thuisadres en een handtekening is vereist."
 
 msgid "Calculated weight: %s"
+msgstr "Berekend gewicht: %s"
+
+msgid "calculated_order_weight"
 msgstr "Berekend gewicht: %s"
 
 msgid "Carrier"
@@ -218,9 +218,6 @@ msgstr "Digitale postzegel"
 
 msgid "Disabled"
 msgstr "Uitschakelen"
-
-msgid "settings_checkout_display_for"
-msgstr "Toon bij"
 
 msgid "Documents"
 msgstr "Documenten"
@@ -401,7 +398,7 @@ msgstr "Verzeker alle orders tot het geselecteerde bedrag."
 msgid "Insure from price"
 msgstr "Verzeker vanaf bedrag"
 
-msgid "Insured"
+msgid "insured"
 msgstr "Verzekerd"
 
 msgid "Insured for"
@@ -409,6 +406,12 @@ msgstr "Verzekerd voor"
 
 msgid "Insured shipment"
 msgstr "Verzekerde zending"
+
+msgid "insured_amount"
+msgstr "Verzekerd bedrag"
+
+msgid "insured_for"
+msgstr "Verzekerd voor"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -569,7 +572,7 @@ msgid "PostNL"
 msgstr "PostNL"
 
 msgid "PostNL delivery options"
-msgstr "PostNL bezorgopties "
+msgstr "PostNL bezorgopties"
 
 msgid "PostNL export settings"
 msgstr "PostNL export instellingen"
@@ -625,6 +628,30 @@ msgstr "Verstuur e-mail"
 msgid "Settings"
 msgstr "Instellingen"
 
+msgid "settings_checkout_display_for"
+msgstr "Toon bij"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "Alle verzendmethoden"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
+"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
+"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Verzendmethoden gekoppeld aan pakkettype"
+
+msgid "settings_checkout_price_format"
+msgstr "Prijzen tonen als"
+
+msgid "settings_checkout_surcharge"
+msgstr "Meerprijs"
+
+msgid "settings_checkout_total_price"
+msgstr "Totaalprijs"
+
 msgid "Shipment type"
 msgstr "Soort zending"
 
@@ -638,8 +665,65 @@ msgstr ""
 "voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
 "worden gecombineerd met ochtend- of avondlevering."
 
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Verzendmethoden gekoppeld aan pakkettype"
+msgid "shipment_options_insured"
+msgstr "Verzekerde zending"
+
+msgid "shipment_options_insured_amount"
+msgstr "Verzekeren tot maximaal"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Verzeker alle orders tot het geselecteerde bedrag."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Verzeker vanaf bedrag"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Verzeker alle orders met een totaal prijs hoger dan het ingevulde bedrag."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"Standaard zit er geen verzekering op zendingen. Als je alsnog een zending "
+"wilt verzekeren kan dat. Wij verzekeren het aankoopbedrag van een zending "
+"met een maximum van €5000. Verzekerde zendingen worden altijd alleen "
+"afgeleverd op het thuisadres en een handtekening is vereist."
+
+msgid "shipment_options_large_format"
+msgstr "Extra grote verpakking"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Activeer deze instelling als je zending groter is dan 100 x 70 x 50 cm, "
+"maar kleiner dan 175 x 78 x 58 cm. Dit kost meer. Let op! Als het pakket "
+"groter dan 175 x 78 x 58 cm of zwaarder dan 30kg is, wordt het gerekend als "
+"pallet."
+
+msgid "shipment_options_only_recipient"
+msgstr "Alleen thuisadres"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
+"optie."
+
+msgid "shipment_options_return"
+msgstr "Retour bij mislukte leverpoging"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"Standaard wordt een pakket 2x aangeboden. Bij 2 mislukte afleverpogingen, "
+"wordt het pakket bij het dichtstbijzijnde pickup point beschikbaar voor 2 "
+"weken. Daar kan het worden opgehaald met het bewijs dat is achtergelaten "
+"door de bezorger. Als je het pakket meteen retour wilt en NIET afgeleverd "
+"wil laten worden bij een pickup point, zet deze optie dan aan."
+
+msgid "shipment_options_signature"
+msgstr "Handtekening voor ontvangst"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
+"thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
+"een handtekening vereist."
 
 msgid "Show after billing details"
 msgstr "Toon na factuurgegevens"
@@ -665,9 +749,6 @@ msgid ""
 msgstr ""
 "De optie \"Toon bezorgdatum\" laat je klanten de bezorgdag zien in "
 "orderbevestigingen en Mijn Account."
-
-msgid "settings_checkout_price_format"
-msgstr "Prijzen tonen als"
 
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Toon Track & Trace code en link in Mijn Account."
@@ -699,9 +780,6 @@ msgstr "Straatnaam"
 msgid "Suffix"
 msgstr "Toev."
 
-msgid "settings_checkout_surcharge"
-msgstr "Meerprijs"
-
 msgid "The label has been printed."
 msgstr "Het label is geprint."
 
@@ -730,11 +808,14 @@ msgstr ""
 "thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
 "een handtekening vereist."
 
+msgid "The selected orders have not been exported to MyParcel yet!"
+msgstr "De geselecteerde bestellingen zijn nog niet geëxporteerd naar MyParcel!"
+
 msgid "The selected orders have not been exported to MyParcel yet! "
 msgstr "De geselecteerde bestellingen zijn nog niet geëxporteerd naar MyParcel!"
 
 msgid "Theme \"%s\" detected."
-msgstr "Thema “%s” gedetecteerd."
+msgstr "Thema \"%s\" gedetecteerd."
 
 msgid ""
 "These settings will be applied to PostNL shipments you create in the "
@@ -770,9 +851,6 @@ msgstr "Titel voor de barcode"
 msgid "Titles"
 msgstr "Titels"
 
-msgid "settings_checkout_total_price"
-msgstr "Totaalprijs"
-
 msgid "Total weight"
 msgstr "Totaal gewicht"
 
@@ -800,7 +878,7 @@ msgstr "Ongefrankeerd"
 msgid "View logs"
 msgstr "Logs weergeven"
 
-msgid "Weight"
+msgid "weight"
 msgstr "Gewicht"
 
 msgid ""
@@ -888,12 +966,6 @@ msgstr ""
 
 msgid "You can change the text before the barcode inside an note"
 msgstr "Je kunt de tekst veranderen voor de barcode in een notitie"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
-"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
-"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
 
 msgid ""
 "You can place a delivery title above the MyParcel options. When there is no "

--- a/languages/woocommerce-myparcel.pot
+++ b/languages/woocommerce-myparcel.pot
@@ -51,23 +51,23 @@ msgstr ""
 msgid "Digital stamp"
 msgstr ""
 
-#: includes/class-wcmp-data.php:95, includes/admin/settings/class-wcmp-settings-data.php:540, includes/admin/settings/class-wcmp-settings-data.php:895
+#: includes/class-wcmp-data.php:95, includes/admin/settings/class-wcmp-settings-data.php:522, includes/admin/settings/class-wcmp-settings-data.php:894
 msgid "Morning delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:96, includes/admin/settings/class-wcmp-settings-data.php:905
+#: includes/class-wcmp-data.php:96, includes/admin/settings/class-wcmp-settings-data.php:904
 msgid "Standard delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:97, includes/admin/settings/class-wcmp-settings-data.php:553, includes/admin/settings/class-wcmp-settings-data.php:911
+#: includes/class-wcmp-data.php:97, includes/admin/settings/class-wcmp-settings-data.php:535, includes/admin/settings/class-wcmp-settings-data.php:910
 msgid "Evening delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:98, includes/admin/settings/class-wcmp-settings-data.php:929
+#: includes/class-wcmp-data.php:98, includes/admin/settings/class-wcmp-settings-data.php:928
 msgid "Pickup"
 msgstr ""
 
-#: includes/class-wcmp-data.php:231, includes/admin/settings/class-wcmp-settings-data.php:82
+#: includes/class-wcmp-data.php:231, includes/admin/settings/class-wcmp-settings-data.php:85
 msgid "PostNL"
 msgstr ""
 
@@ -115,11 +115,11 @@ msgstr ""
 msgid "MyParcel shipment created:"
 msgstr ""
 
-#: includes/admin/class-wcmp-export-consignments.php:253
+#: includes/admin/class-wcmp-export-consignments.php:254
 msgid "No HS code found in MyParcel settings"
 msgstr ""
 
-#: includes/admin/class-wcmp-export-consignments.php:341, includes/admin/class-wcmp-export.php:571
+#: includes/admin/class-wcmp-export-consignments.php:350, includes/admin/class-wcmp-export.php:564
 msgid "No API key found in MyParcel settings"
 msgstr ""
 
@@ -131,331 +131,331 @@ msgstr ""
 msgid "You do not have sufficient permissions to access this page."
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:400
+#: includes/admin/class-wcmp-export.php:393
 msgid "%s shipments successfully exported to MyParcel"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:522
+#: includes/admin/class-wcmp-export.php:515
 msgid "The selected orders have not been exported to MyParcel yet! "
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:602
+#: includes/admin/class-wcmp-export.php:595
 msgid "No e-mail address found in order."
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1012
+#: includes/admin/class-wcmp-export.php:1005
 msgid "Unknown"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1075, includes/admin/views/html-send-return-email-form.php:53
+#: includes/admin/class-wcmp-export.php:1068, includes/admin/views/html-send-return-email-form.php:55
 msgid "Order"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1099
+#: includes/admin/class-wcmp-export.php:1092
 msgid "pending - concept"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1100
+#: includes/admin/class-wcmp-export.php:1093
 msgid "pending - registered"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1101
+#: includes/admin/class-wcmp-export.php:1094
 msgid "enroute - handed to carrier"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1102
+#: includes/admin/class-wcmp-export.php:1095
 msgid "enroute - sorting"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1103
+#: includes/admin/class-wcmp-export.php:1096
 msgid "enroute - distribution"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1104
+#: includes/admin/class-wcmp-export.php:1097
 msgid "enroute - customs"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1105
+#: includes/admin/class-wcmp-export.php:1098
 msgid "delivered - at recipient"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1106
+#: includes/admin/class-wcmp-export.php:1099
 msgid "delivered - ready for pickup"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1107
+#: includes/admin/class-wcmp-export.php:1100
 msgid "delivered - package picked up"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1108
+#: includes/admin/class-wcmp-export.php:1101
 msgid "printed - letter"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1109
+#: includes/admin/class-wcmp-export.php:1102
 msgid "printed - digital stamp"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1110
+#: includes/admin/class-wcmp-export.php:1103
 msgid "inactive - concept"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1111
+#: includes/admin/class-wcmp-export.php:1104
 msgid "inactive - registered"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1112
+#: includes/admin/class-wcmp-export.php:1105
 msgid "inactive - enroute - handed to carrier"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1113
+#: includes/admin/class-wcmp-export.php:1106
 msgid "inactive - enroute - sorting"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1114
+#: includes/admin/class-wcmp-export.php:1107
 msgid "inactive - enroute - distribution"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1115
+#: includes/admin/class-wcmp-export.php:1108
 msgid "inactive - enroute - customs"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1116
+#: includes/admin/class-wcmp-export.php:1109
 msgid "inactive - delivered - at recipient"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1117
+#: includes/admin/class-wcmp-export.php:1110
 msgid "inactive - delivered - ready for pickup"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1118
+#: includes/admin/class-wcmp-export.php:1111
 msgid "inactive - delivered - package picked up"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1119
+#: includes/admin/class-wcmp-export.php:1112
 msgid "inactive - unknown"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1125
+#: includes/admin/class-wcmp-export.php:1118
 msgid "Unknown status"
 msgstr ""
 
-#: includes/admin/class-wcmp-export.php:1593
+#: includes/admin/class-wcmp-export.php:1565
 msgid "The order(s) you have selected have invalid shipping countries."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:125
+#: includes/admin/class-wcmypa-admin.php:128
 msgid "Pickup location"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:305, includes/admin/class-wcmypa-admin.php:329
+#: includes/admin/class-wcmypa-admin.php:308, includes/admin/class-wcmypa-admin.php:332
 msgid "MyParcel: Export"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:306, includes/admin/class-wcmypa-admin.php:330
+#: includes/admin/class-wcmypa-admin.php:309, includes/admin/class-wcmypa-admin.php:333
 msgid "MyParcel: Print"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:307, includes/admin/class-wcmypa-admin.php:331
+#: includes/admin/class-wcmypa-admin.php:310, includes/admin/class-wcmypa-admin.php:334
 msgid "MyParcel: Export & Print"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:388
+#: includes/admin/class-wcmypa-admin.php:391
 msgid "Labels to skip"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:404
+#: includes/admin/class-wcmypa-admin.php:407
 msgid "Print"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:468, includes/admin/views/html-send-return-email-form.php:154
+#: includes/admin/class-wcmypa-admin.php:471, includes/admin/views/html-send-return-email-form.php:155
 msgid "Export to MyParcel"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:473, includes/admin/views/html-order-track-trace-table.php:66
+#: includes/admin/class-wcmypa-admin.php:476, includes/admin/views/html-order-track-trace-table.php:66
 msgid "Print MyParcel label"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:478
+#: includes/admin/class-wcmypa-admin.php:481
 msgid "Email return label"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:600, includes/admin/settings/class-wcmypa-settings.php:159, includes/admin/settings/class-wcmypa-settings.php:160
+#: includes/admin/class-wcmypa-admin.php:605, includes/admin/settings/class-wcmypa-settings.php:160, includes/admin/settings/class-wcmypa-settings.php:161
 msgid "MyParcel"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:713
+#: includes/admin/class-wcmypa-admin.php:718
 msgid "Default"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:714, includes/entities/settings-field-arguments.php:170
+#: includes/admin/class-wcmypa-admin.php:719, includes/entities/settings-field-arguments.php:170
 msgid "Disabled"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:715, includes/entities/settings-field-arguments.php:169
+#: includes/admin/class-wcmypa-admin.php:720, includes/entities/settings-field-arguments.php:169
 msgid "Enabled"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:799
+#: includes/admin/class-wcmypa-admin.php:804
 msgid "HS Code"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:803
+#: includes/admin/class-wcmypa-admin.php:808
 msgid "HS Codes are used for MyParcel world shipments, you can find the appropriate code on the %ssite of the Dutch Customs%s"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:814
+#: includes/admin/class-wcmypa-admin.php:819
 msgid "Country of origin"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:816
+#: includes/admin/class-wcmypa-admin.php:821
 msgid "Country of origin is required for world shipments. Defaults to shop base."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:820, includes/admin/OrderSettingsRows.php:251, includes/admin/settings/class-wcmp-settings-data.php:437
+#: includes/admin/class-wcmypa-admin.php:825, includes/admin/OrderSettingsRows.php:241, includes/admin/settings/class-wcmp-settings-data.php:431
 msgid "shipment_options_age_check"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:827, includes/admin/OrderSettingsRows.php:252, includes/admin/settings/class-wcmp-settings-data.php:439
+#: includes/admin/class-wcmypa-admin.php:832, includes/admin/OrderSettingsRows.php:242, includes/admin/settings/class-wcmp-settings-data.php:433
 msgid "shipment_options_age_check_help_text"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:870
+#: includes/admin/class-wcmypa-admin.php:875
 msgid "No label has been created yet."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:881
+#: includes/admin/class-wcmypa-admin.php:886
 msgid "The label has been printed."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:886
+#: includes/admin/class-wcmypa-admin.php:891
 msgid "Concept created but not printed."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:953
+#: includes/admin/class-wcmypa-admin.php:958
 msgid "MyParcel shipment:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:980, includes/admin/class-wcmypa-admin.php:993
+#: includes/admin/class-wcmypa-admin.php:985, includes/admin/class-wcmypa-admin.php:998
 msgid "Delivery type:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:981
+#: includes/admin/class-wcmypa-admin.php:986
 msgid "Pickup location:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:995
+#: includes/admin/class-wcmypa-admin.php:1000
 msgid "Extra options:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:1030, includes/admin/class-wcmypa-admin.php:1052
+#: includes/admin/class-wcmypa-admin.php:1035, includes/admin/class-wcmypa-admin.php:1057
 msgid "Delivery information:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:1158
+#: includes/admin/class-wcmypa-admin.php:1163
 msgid "(Unknown)"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:95
+#: includes/admin/OrderSettingsRows.php:96
 msgid "Carrier"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:103
+#: includes/admin/OrderSettingsRows.php:104
 msgid "Delivery type"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:111, includes/admin/views/html-order-return-shipment-options.php:21, includes/admin/views/html-order-shipment-summary.php:42
+#: includes/admin/OrderSettingsRows.php:112, includes/admin/views/html-order-return-shipment-options.php:23, includes/admin/views/html-order-shipment-summary.php:42
 msgid "Shipment type"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:118
+#: includes/admin/OrderSettingsRows.php:119
 msgid "Number of labels"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:137, includes/admin/settings/class-wcmp-settings-data.php:428
-msgid "Extra large size"
+#: includes/admin/OrderSettingsRows.php:138, includes/admin/settings/class-wcmp-settings-data.php:425
+msgid "shipment_options_large_format"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:138, includes/admin/settings/class-wcmp-settings-data.php:430
-msgid "Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet rate will be charged."
+#: includes/admin/OrderSettingsRows.php:139, includes/admin/settings/class-wcmp-settings-data.php:426
+msgid "shipment_options_large_format_help_text"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:154
+#: includes/admin/OrderSettingsRows.php:152
 msgid "Custom ID (top left on label)"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:194, includes/admin/views/html-send-return-email-form.php:66
-msgid "Weight"
+#: includes/admin/OrderSettingsRows.php:192, includes/admin/views/html-send-return-email-form.php:68
+msgid "weight"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:197, includes/admin/views/html-order-return-shipment-options.php:23
-msgid "Calculated weight: %s"
+#: includes/admin/OrderSettingsRows.php:194, includes/admin/views/html-order-return-shipment-options.php:25
+msgid "calculated_order_weight"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:219, includes/admin/settings/class-wcmp-settings-data.php:410, includes/admin/settings/class-wcmp-settings-data.php:566, includes/admin/settings/class-wcmp-settings-data.php:917
-msgid "Home address only"
+#: includes/admin/OrderSettingsRows.php:215, includes/admin/settings/class-wcmp-settings-data.php:413, includes/admin/settings/class-wcmp-settings-data.php:548, includes/admin/settings/class-wcmp-settings-data.php:916, includes/admin/views/html-order-shipment-summary.php:24
+msgid "shipment_options_only_recipient"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:220, includes/admin/settings/class-wcmp-settings-data.php:412
-msgid "If you don't want the parcel to be delivered at the neighbours, choose this option."
+#: includes/admin/OrderSettingsRows.php:216, includes/admin/settings/class-wcmp-settings-data.php:414
+msgid "shipment_options_only_recipient_help_text"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:235, includes/admin/settings/class-wcmp-settings-data.php:419, includes/admin/settings/class-wcmp-settings-data.php:579, includes/admin/settings/class-wcmp-settings-data.php:923, includes/admin/views/html-order-shipment-summary.php:23
-msgid "Signature on delivery"
+#: includes/admin/OrderSettingsRows.php:228, includes/admin/settings/class-wcmp-settings-data.php:419, includes/admin/settings/class-wcmp-settings-data.php:561, includes/admin/settings/class-wcmp-settings-data.php:922, includes/admin/views/html-order-shipment-summary.php:23
+msgid "shipment_options_signature"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:237, includes/admin/settings/class-wcmp-settings-data.php:421
-msgid "The parcel will be offered at the delivery address. If the recipient is not at home, the parcel will be delivered to the neighbours. In both cases, a signature will be required."
+#: includes/admin/OrderSettingsRows.php:229, includes/admin/settings/class-wcmp-settings-data.php:420
+msgid "shipment_options_signature_help_text"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:263, includes/admin/settings/class-wcmp-settings-data.php:443
-msgid "Return if no answer"
+#: includes/admin/OrderSettingsRows.php:253, includes/admin/settings/class-wcmp-settings-data.php:437
+msgid "shipment_options_return"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:265, includes/admin/settings/class-wcmp-settings-data.php:445
-msgid "By default, a parcel will be offered twice. After two unsuccessful delivery attempts, the parcel will be available at the nearest pickup point for two weeks. There it can be picked up by the recipient with the note that was left by the courier. If you want to receive the parcel back directly and NOT forward it to the pickup point, enable this option."
+#: includes/admin/OrderSettingsRows.php:254, includes/admin/settings/class-wcmp-settings-data.php:438
+msgid "shipment_options_return_help_text"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:278
-msgid "Insured"
+#: includes/admin/OrderSettingsRows.php:265
+msgid "insured"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:294
-msgid "Insurance amount"
+#: includes/admin/OrderSettingsRows.php:281
+msgid "insured_amount"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:217
+#: includes/frontend/class-wcmp-checkout.php:220
 msgid "Address details are not entered"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:218
+#: includes/frontend/class-wcmp-checkout.php:221
 msgid "City"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:219
+#: includes/frontend/class-wcmp-checkout.php:222
 msgid "Closed"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:225
+#: includes/frontend/class-wcmp-checkout.php:228
 msgid "House number"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:227
+#: includes/frontend/class-wcmp-checkout.php:230
 msgid "Opening hours"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:228
+#: includes/frontend/class-wcmp-checkout.php:231
 msgid "Pick up from"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:230
+#: includes/frontend/class-wcmp-checkout.php:233
 msgid "Postcode"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:231
+#: includes/frontend/class-wcmp-checkout.php:234
 msgid "Retry"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:233
+#: includes/frontend/class-wcmp-checkout.php:236
 msgid "Postcode/city combination unknown"
 msgstr ""
 
@@ -467,495 +467,507 @@ msgstr ""
 msgid "Track & Trace"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:77
+#: includes/admin/settings/class-wcmp-settings-data.php:80
 msgid "General"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:78, includes/admin/settings/class-wcmp-settings-data.php:211
+#: includes/admin/settings/class-wcmp-settings-data.php:81, includes/admin/settings/class-wcmp-settings-data.php:214
 msgid "Default export settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:79, includes/admin/settings/class-wcmp-settings-data.php:224
+#: includes/admin/settings/class-wcmp-settings-data.php:82, includes/admin/settings/class-wcmp-settings-data.php:227
 msgid "Checkout settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:185
+#: includes/admin/settings/class-wcmp-settings-data.php:188
 msgid "API settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:190
+#: includes/admin/settings/class-wcmp-settings-data.php:193
 msgid "General settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:195
+#: includes/admin/settings/class-wcmp-settings-data.php:198
 msgid "Diagnostic tools"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:229
+#: includes/admin/settings/class-wcmp-settings-data.php:232
 msgid "Titles"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:248
+#: includes/admin/settings/class-wcmp-settings-data.php:251
 msgid "PostNL export settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:249
+#: includes/admin/settings/class-wcmp-settings-data.php:252
 msgid "These settings will be applied to PostNL shipments you create in the backend."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:257
+#: includes/admin/settings/class-wcmp-settings-data.php:260
 msgid "PostNL delivery options"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:262
+#: includes/admin/settings/class-wcmp-settings-data.php:265
 msgid "PostNL pickup options"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:277
+#: includes/admin/settings/class-wcmp-settings-data.php:280
 msgid "Key"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:278
+#: includes/admin/settings/class-wcmp-settings-data.php:281
 msgid "api key"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:291
+#: includes/admin/settings/class-wcmp-settings-data.php:294
 msgid "Label display"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:294
+#: includes/admin/settings/class-wcmp-settings-data.php:297
 msgid "Download PDF"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:295
+#: includes/admin/settings/class-wcmp-settings-data.php:298
 msgid "Open the PDF in a new tab"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:300
+#: includes/admin/settings/class-wcmp-settings-data.php:303
 msgid "Label format"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:303
+#: includes/admin/settings/class-wcmp-settings-data.php:306
 msgid "Standard printer (A4)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:304
+#: includes/admin/settings/class-wcmp-settings-data.php:307
 msgid "Label Printer (A6)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:309
+#: includes/admin/settings/class-wcmp-settings-data.php:312
 msgid "Ask for print start position"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:317
+#: includes/admin/settings/class-wcmp-settings-data.php:320
 msgid "This option enables you to continue printing where you left off last time"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:324
+#: includes/admin/settings/class-wcmp-settings-data.php:327
 msgid "Track & Trace in email"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:326
+#: includes/admin/settings/class-wcmp-settings-data.php:329
 msgid "Add the Track & Trace code to emails to the customer.<br/><strong>Note!</strong> When you select this option, make sure you have not enabled the Track & Trace email in your MyParcel backend."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:333
+#: includes/admin/settings/class-wcmp-settings-data.php:336
 msgid "Track & Trace in My Account"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:335
+#: includes/admin/settings/class-wcmp-settings-data.php:338
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:339
+#: includes/admin/settings/class-wcmp-settings-data.php:342
 msgid "Process shipments directly"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:341
+#: includes/admin/settings/class-wcmp-settings-data.php:344
 msgid "When you enable this option, shipments will be directly processed when sent to MyParcel."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:348
+#: includes/admin/settings/class-wcmp-settings-data.php:351
 msgid "Order status automation"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:350
+#: includes/admin/settings/class-wcmp-settings-data.php:353
 msgid "Automatically set order status to a predefined status after successful MyParcel export.<br/>Make sure <strong>Process shipments directly</strong> is enabled when you use this option together with the <strong>Track & Trace in email</strong> option, otherwise the Track & Trace code will not be included in the customer email."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:359
+#: includes/admin/settings/class-wcmp-settings-data.php:362
 msgid "Automatic order status"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:365
+#: includes/admin/settings/class-wcmp-settings-data.php:368
 msgid "Place barcode inside note"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:367
+#: includes/admin/settings/class-wcmp-settings-data.php:370
 msgid "Place the barcode inside a note of the order"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:373
+#: includes/admin/settings/class-wcmp-settings-data.php:376
 msgid "Title before the barcode"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:374
+#: includes/admin/settings/class-wcmp-settings-data.php:377
 msgid "Track & trace code:"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:375
+#: includes/admin/settings/class-wcmp-settings-data.php:378
 msgid "You can change the text before the barcode inside an note"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:391
+#: includes/admin/settings/class-wcmp-settings-data.php:394
 msgid "Log API communication"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:395
+#: includes/admin/settings/class-wcmp-settings-data.php:398
 msgid "View logs"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:452
-msgid "Insured shipment"
+#: includes/admin/settings/class-wcmp-settings-data.php:443
+msgid "shipment_options_insured"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:454
-msgid "By default, there is no insurance on the shipments. If you still want to insure the shipment, you can do that. We insure the purchase value of the shipment, with a maximum insured value of € 5.000. Insured parcels always contain the options 'Home address only' en 'Signature for delivery'"
+#: includes/admin/settings/class-wcmp-settings-data.php:444
+msgid "shipment_options_insured_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:462
-msgid "Insure from price"
+#: includes/admin/settings/class-wcmp-settings-data.php:450
+msgid "shipment_options_insured_from_price"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:464
-msgid "Insure all orders that exceed this price point."
+#: includes/admin/settings/class-wcmp-settings-data.php:451
+msgid "shipment_options_insured_from_price_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:472
-msgid "Max insured amount"
+#: includes/admin/settings/class-wcmp-settings-data.php:457
+msgid "shipment_options_insured_amount"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:475
-msgid "Insure all parcels up to the selected amount."
+#: includes/admin/settings/class-wcmp-settings-data.php:458
+msgid "shipment_options_insured_amount_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:495
+#: includes/admin/settings/class-wcmp-settings-data.php:477
 msgid "Enable PostNL delivery"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:501
+#: includes/admin/settings/class-wcmp-settings-data.php:483
 msgid "Drop-off days"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:505
+#: includes/admin/settings/class-wcmp-settings-data.php:487
 msgid "Days of the week on which you hand over parcels to PostNL"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:510
+#: includes/admin/settings/class-wcmp-settings-data.php:492
 msgid "Cut-off time"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:511, includes/admin/settings/class-wcmp-settings-data.php:609
+#: includes/admin/settings/class-wcmp-settings-data.php:493, includes/admin/settings/class-wcmp-settings-data.php:591
 msgid "Time at which you stop processing orders for the day (format: hh:mm)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:520
+#: includes/admin/settings/class-wcmp-settings-data.php:502
 msgid "Drop-off delay"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:523
+#: includes/admin/settings/class-wcmp-settings-data.php:505
 msgid "Number of days you need to process an order."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:528
+#: includes/admin/settings/class-wcmp-settings-data.php:510
 msgid "Delivery days window"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:532
+#: includes/admin/settings/class-wcmp-settings-data.php:514
 msgid "Amount of days a customer can postpone a shipment. Default is 0 days with a maximum value of 14 days."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:581, includes/admin/settings/class-wcmp-settings-data.php:997
+#: includes/admin/settings/class-wcmp-settings-data.php:563, includes/admin/settings/class-wcmp-settings-data.php:996
 msgid "Enter an amount that is either positive or negative. For example, do you want to give a discount for using this function or do you want to charge extra for this delivery option."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:596
+#: includes/admin/settings/class-wcmp-settings-data.php:578
 msgid "Monday delivery"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:606
+#: includes/admin/settings/class-wcmp-settings-data.php:588
 msgid "Cut-off time on Saturday"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:625
+#: includes/admin/settings/class-wcmp-settings-data.php:607
 msgid "Enable PostNL pickup"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:645
+#: includes/admin/settings/class-wcmp-settings-data.php:627
 msgid "Package types"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:650
+#: includes/admin/settings/class-wcmp-settings-data.php:632
 msgid "Select one or more shipping methods for each MyParcel package type"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:657
+#: includes/admin/settings/class-wcmp-settings-data.php:639
 msgid "Connect customer email"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:659
+#: includes/admin/settings/class-wcmp-settings-data.php:641
 msgid "When you connect the customer's email, MyParcel can send a Track & Trace email to this address. In your MyParcel backend you can enable or disable this email and format it in your own style."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:666
+#: includes/admin/settings/class-wcmp-settings-data.php:648
 msgid "Connect customer phone"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:668
+#: includes/admin/settings/class-wcmp-settings-data.php:650
 msgid "When you connect the customer's phone number, the courier can use this for the delivery of the parcel. This greatly increases the delivery success rate for foreign shipments."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:675, includes/admin/views/html-order-shipment-summary.php:61
+#: includes/admin/settings/class-wcmp-settings-data.php:657, includes/admin/views/html-order-shipment-summary.php:61
 msgid "Label description"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:676
+#: includes/admin/settings/class-wcmp-settings-data.php:658
 msgid "With this option you can add a description to the shipment. This will be printed on the top left of the label, and you can use this to search or sort shipments in your backoffice. Because of limited space on the label which varies per package type, we recommend that you keep the label description as short as possible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:686
+#: includes/admin/settings/class-wcmp-settings-data.php:668
 msgid "Empty parcel weight"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:689
+#: includes/admin/settings/class-wcmp-settings-data.php:671
 msgid "Default weight of your empty parcel."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:696
+#: includes/admin/settings/class-wcmp-settings-data.php:678
 msgid "Default HS Code"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:697
+#: includes/admin/settings/class-wcmp-settings-data.php:679
 msgid "HS Codes are used for MyParcel world shipments, you can find the appropriate code on the site of the Dutch Customs."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:704
+#: includes/admin/settings/class-wcmp-settings-data.php:686
 msgid "Customs shipment type"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:707
+#: includes/admin/settings/class-wcmp-settings-data.php:689
 msgid "Commercial goods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:708
+#: includes/admin/settings/class-wcmp-settings-data.php:690
 msgid "Commercial samples"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:709
+#: includes/admin/settings/class-wcmp-settings-data.php:691
 msgid "Documents"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:710
+#: includes/admin/settings/class-wcmp-settings-data.php:692
 msgid "Gifts"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:711
+#: includes/admin/settings/class-wcmp-settings-data.php:693
 msgid "Return shipment"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:716
+#: includes/admin/settings/class-wcmp-settings-data.php:698
 msgid "Default country of origin"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:719
+#: includes/admin/settings/class-wcmp-settings-data.php:701
 msgid "Country of origin is required for world shipments. Defaults to shop base or NL. Example: 'NL', 'BE', 'DE'"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:725
+#: includes/admin/settings/class-wcmp-settings-data.php:707
 msgid "Automatic export"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:727
+#: includes/admin/settings/class-wcmp-settings-data.php:709
 msgid "With this setting enabled orders are exported to MyParcel automatically after payment."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:757
+#: includes/admin/settings/class-wcmp-settings-data.php:739
 msgid "MyParcel address fields"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:759
+#: includes/admin/settings/class-wcmp-settings-data.php:741
 msgid "When enabled the checkout will use the MyParcel address fields. This means there will be three separate fields for street name, number and suffix. Want to use the WooCommerce default fields? Leave this option unchecked."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:766
+#: includes/admin/settings/class-wcmp-settings-data.php:748
 msgid "Show delivery date"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:768
+#: includes/admin/settings/class-wcmp-settings-data.php:750
 msgid "Show delivery day options allow your customers to see the delivery day in order confirmation and My Account."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:775
+#: includes/admin/settings/class-wcmp-settings-data.php:757
 msgid "Enable MyParcel delivery options"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:777
+#: includes/admin/settings/class-wcmp-settings-data.php:759
 msgid "The MyParcel delivery options allow your customers to select whether they want their parcel delivered at home or to a pickup point. Depending on the settings you can allow them to select a date, time and even options like requiring a signature on delivery."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:785
+#: includes/admin/settings/class-wcmp-settings-data.php:767
 msgid "Enable delivery options for backorders"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:787
+#: includes/admin/settings/class-wcmp-settings-data.php:769
 msgid "When this option is enabled, delivery options and delivery day will be also shown for backorders."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:795
+#: includes/admin/settings/class-wcmp-settings-data.php:777
 msgid "settings_checkout_display_for"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:797
+#: includes/admin/settings/class-wcmp-settings-data.php:779
 msgid "settings_checkout_display_for_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:799
+#: includes/admin/settings/class-wcmp-settings-data.php:781
 msgid "settings_checkout_display_for_selected_methods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:800
+#: includes/admin/settings/class-wcmp-settings-data.php:782
 msgid "settings_checkout_display_for_all_methods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:806
+#: includes/admin/settings/class-wcmp-settings-data.php:788
 msgid "Checkout position"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:810
+#: includes/admin/settings/class-wcmp-settings-data.php:792
 msgid "Show after billing details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:814
+#: includes/admin/settings/class-wcmp-settings-data.php:796
 msgid "Show after shipping details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:818
+#: includes/admin/settings/class-wcmp-settings-data.php:800
 msgid "Show after customer details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:822
+#: includes/admin/settings/class-wcmp-settings-data.php:804
 msgid "Show after notes"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:826
+#: includes/admin/settings/class-wcmp-settings-data.php:808
 msgid "Show after subtotal"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:831
+#: includes/admin/settings/class-wcmp-settings-data.php:813
 msgid "You can change the place of the delivery options on the checkout page. By default it will be placed after shipping details."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:839
+#: includes/admin/settings/class-wcmp-settings-data.php:821
+msgid "settings_checkout_price_format"
+msgstr ""
+
+#: includes/admin/settings/class-wcmp-settings-data.php:825
+msgid "settings_checkout_total_price"
+msgstr ""
+
+#: includes/admin/settings/class-wcmp-settings-data.php:829
+msgid "settings_checkout_surcharge"
+msgstr ""
+
+#: includes/admin/settings/class-wcmp-settings-data.php:838
 msgid "Custom styles"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:878
+#: includes/admin/settings/class-wcmp-settings-data.php:877
 msgid "Delivery options title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:880
+#: includes/admin/settings/class-wcmp-settings-data.php:879
 msgid "You can place a delivery title above the MyParcel options. When there is no title, it will not be visible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:888
+#: includes/admin/settings/class-wcmp-settings-data.php:887
 msgid "Delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:889
+#: includes/admin/settings/class-wcmp-settings-data.php:888
 msgid "Delivered at home or at work"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:894
+#: includes/admin/settings/class-wcmp-settings-data.php:893
 msgid "Morning delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:900
+#: includes/admin/settings/class-wcmp-settings-data.php:899
 msgid "Standard delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:901
+#: includes/admin/settings/class-wcmp-settings-data.php:900
 msgid "When there is no title, the delivery time will automatically be visible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:910
+#: includes/admin/settings/class-wcmp-settings-data.php:909
 msgid "Evening delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:916
+#: includes/admin/settings/class-wcmp-settings-data.php:915
 msgid "Home address only title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:922
+#: includes/admin/settings/class-wcmp-settings-data.php:921
 msgid "Signature on delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:928
+#: includes/admin/settings/class-wcmp-settings-data.php:927
 msgid "Pickup title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:952
+#: includes/admin/settings/class-wcmp-settings-data.php:951
 msgid "Theme \"%s\" detected."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:954
+#: includes/admin/settings/class-wcmp-settings-data.php:953
 msgid "Apply preset."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:967
+#: includes/admin/settings/class-wcmp-settings-data.php:966
 msgid "Delivery date"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:968
+#: includes/admin/settings/class-wcmp-settings-data.php:967
 msgid "Order number"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:969
+#: includes/admin/settings/class-wcmp-settings-data.php:968
 msgid "Product id"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:970, includes/admin/views/html-send-return-email-form.php:65
+#: includes/admin/settings/class-wcmp-settings-data.php:969, includes/admin/views/html-send-return-email-form.php:67
 msgid "Product name"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:971
+#: includes/admin/settings/class-wcmp-settings-data.php:970
 msgid "Product quantity"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:972
+#: includes/admin/settings/class-wcmp-settings-data.php:971
 msgid "Product SKU"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:973
+#: includes/admin/settings/class-wcmp-settings-data.php:972
 msgid "Customer note"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:995
+#: includes/admin/settings/class-wcmp-settings-data.php:994
 msgid "Fee (optional)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:183
+#: includes/admin/settings/class-wcmypa-settings.php:184
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:203
+#: includes/admin/settings/class-wcmypa-settings.php:204
 msgid "WooCommerce MyParcel Settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:257
+#: includes/admin/settings/class-wcmypa-settings.php:258
 msgid "It looks like your shop is based in Netherlands. This plugin is for MyParcel. If you are using MyParcel Netherlands, download the %s plugin instead!"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:266
+#: includes/admin/settings/class-wcmypa-settings.php:267
 msgid "Hide this message"
 msgstr ""
 
@@ -963,30 +975,26 @@ msgstr ""
 msgid "Return email successfully sent to customer"
 msgstr ""
 
-#: includes/admin/views/html-order-return-shipment-options.php:58, includes/admin/views/html-order-shipment-options.php:63
+#: includes/admin/views/html-order-return-shipment-options.php:60, includes/admin/views/html-order-shipment-options.php:63
 msgid "Save"
 msgstr ""
 
-#: includes/admin/views/html-order-shipment-summary.php:24
-msgid "Only recipient"
-msgstr ""
-
 #: includes/admin/views/html-order-shipment-summary.php:55
-msgid "Insured for"
+msgid "insured_for"
 msgstr ""
 
 #: includes/admin/views/html-order-shipment-summary.php:84, includes/admin/views/html-order-track-trace-table.php:38
 msgid "Status"
 msgstr ""
 
-#: includes/admin/views/html-send-return-email-form.php:93
+#: includes/admin/views/html-send-return-email-form.php:94
 msgid "Total weight"
 msgstr ""
 
-#: includes/admin/views/html-send-return-email-form.php:115
+#: includes/admin/views/html-send-return-email-form.php:116
 msgid "This order does not contain valid street and house number data and cannot be exported because of this! This order was probably placed before the MyParcel plugin was activated. The address data can still be manually entered in the order screen."
 msgstr ""
 
-#: includes/admin/views/html-send-return-email-form.php:156
+#: includes/admin/views/html-send-return-email-form.php:157
 msgid "Send email"
 msgstr ""


### PR DESCRIPTION
- save weight in extraOptions['weight'] instead of own meta key
- never save converted weight over original weight
- save delivery options weight separately, don't overwrite actual order weight anymore
- fixes the following PHP warning:
  > Invalid argument supplied for foreach() in /includes/admin/settings/class-wcmp-shipping-methods.php on line 213