### PR TITLE
Fix HTML typo in generateThankYouConfirmation

### DIFF
--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -1036,7 +1036,7 @@ class WCMYPA_Admin
 
             foreach ($options as $key => $option) {
                 if ($option) {
-                    $htmlHeader .= "<tr'><td>$key</td><td>" . __($option, "woocommerce-myparcel") . "</td></tr>";
+                    $htmlHeader .= "<tr><td>$key</td><td>" . __($option, "woocommerce-myparcel") . "</td></tr>";
                 }
             }
 


### PR DESCRIPTION
This fixes an issue with incorrectly displayed HTML on the thank you page

![image](https://user-images.githubusercontent.com/13858111/111760883-8192ef00-889f-11eb-8eb5-79fc65cf33df.png)