### PR TITLE
Fix: show full delivery options for {{myparcel_delivery_options}}

### DIFF
--- a/includes/frontend/class-wcmp-frontend.php
+++ b/includes/frontend/class-wcmp-frontend.php
@@ -74,7 +74,7 @@ class WCMP_Frontend
     public function wpo_wcpdf_delivery_options(string $replacement, WC_Order $order): string
     {
         ob_start();
-        WCMYPA()->admin->showDeliveryDateForOrder($order);
+        WCMYPA()->admin->showShipmentConfirmation($order, false);
 
         return ob_get_clean();
     }


### PR DESCRIPTION
Fixes the PDF Invoices & Packing Slips part of #491 (see https://github.com/myparcelnl/woocommerce/issues/491#issuecomment-805881978)