### PR TITLE
My 27832 deliveryoptions map or list default

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "myparcelnl/sdk",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/sdk.git",
-                "reference": "7ebc6cbd6c5a19ce476a63b5bb4537b919497e43"
+                "reference": "9df9ab9f636a1ac7d29ab759d6ba0e0a278ebebd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/sdk/zipball/7ebc6cbd6c5a19ce476a63b5bb4537b919497e43",
-                "reference": "7ebc6cbd6c5a19ce476a63b5bb4537b919497e43",
+                "url": "https://api.github.com/repos/myparcelnl/sdk/zipball/9df9ab9f636a1ac7d29ab759d6ba0e0a278ebebd",
+                "reference": "9df9ab9f636a1ac7d29ab759d6ba0e0a278ebebd",
                 "shasum": ""
             },
             "require": {
@@ -65,7 +65,11 @@
                 "myparcel",
                 "postnl"
             ],
-            "time": "2021-02-22T09:40:03+00:00"
+            "support": {
+                "issues": "https://github.com/myparcelnl/sdk/issues",
+                "source": "https://github.com/myparcelnl/sdk/tree/v5.2.9"
+            },
+            "time": "2021-03-30T14:51:52+00:00"
         }
     ],
     "packages-dev": [],
@@ -76,5 +80,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/admin/settings/class-wcmp-settings-data.php
+++ b/includes/admin/settings/class-wcmp-settings-data.php
@@ -25,6 +25,9 @@ class WCMP_Settings_Data
     public const DISPLAY_TOTAL_PRICE     = "total_price";
     public const DISPLAY_SURCHARGE_PRICE = "surcharge";
 
+    public const PICKUP_LOCATIONS_VIEW_MAP  = "map";
+    public const PICKUP_LOCATIONS_VIEW_LIST = "list";
+
     public const CHANGE_STATUS_AFTER_PRINTING = "after_printing";
     public const CHANGE_STATUS_AFTER_EXPORT   = "after_export";
 
@@ -849,6 +852,23 @@ class WCMP_Settings_Data
                     ),
                     self::DISPLAY_SURCHARGE_PRICE => __(
                         "settings_checkout_surcharge",
+                        "woocommerce-myparcel"
+                    ),
+                ],
+            ],
+            [
+                "name"      => WCMYPA_Settings::SETTING_PICKUP_LOCATIONS_DEFAULT_VIEW,
+                "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
+                "label"     => __("settings_pickup_locations_default_view", "woocommerce-myparcel"),
+                "type"      => "select",
+                "default"   => self::PICKUP_LOCATIONS_VIEW_MAP,
+                "options"   => [
+                    self::PICKUP_LOCATIONS_VIEW_MAP     => __(
+                        "settings_pickup_locations_map",
+                        "woocommerce-myparcel"
+                    ),
+                    self::PICKUP_LOCATIONS_VIEW_LIST => __(
+                        "settings_pickup_locations_list",
                         "woocommerce-myparcel"
                     ),
                 ],

--- a/includes/admin/settings/class-wcmp-settings-data.php
+++ b/includes/admin/settings/class-wcmp-settings-data.php
@@ -863,12 +863,12 @@ class WCMP_Settings_Data
                 "type"      => "select",
                 "default"   => self::PICKUP_LOCATIONS_VIEW_MAP,
                 "options"   => [
-                    self::PICKUP_LOCATIONS_VIEW_MAP     => __(
-                        "settings_pickup_locations_map",
+                    self::PICKUP_LOCATIONS_VIEW_MAP  => __(
+                        "settings_pickup_locations_default_view_map",
                         "woocommerce-myparcel"
                     ),
                     self::PICKUP_LOCATIONS_VIEW_LIST => __(
-                        "settings_pickup_locations_list",
+                        "settings_pickup_locations_default_view_list",
                         "woocommerce-myparcel"
                     ),
                 ],

--- a/includes/admin/settings/class-wcmypa-settings.php
+++ b/includes/admin/settings/class-wcmypa-settings.php
@@ -69,6 +69,7 @@ class WCMYPA_Settings
     public const SETTING_DELIVERY_TITLE                        = "delivery_title";
     public const SETTING_HEADER_DELIVERY_OPTIONS_TITLE         = "header_delivery_options_title";
     public const SETTING_PICKUP_TITLE                          = "pickup_title";
+    public const SETTING_PICKUP_LOCATIONS_DEFAULT_VIEW         = "pickup_locations_default_view";
     public const SETTING_MORNING_DELIVERY_TITLE                = "morning_title";
     public const SETTING_EVENING_DELIVERY_TITLE                = "evening_title";
     public const SETTING_ONLY_RECIPIENT_TITLE                  = "only_recipient_title";

--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -292,6 +292,10 @@ class WCMP_Checkout
 
         return __(strip_tags($settings->getStringByName($title)), "woocommerce-myparcel");
     }
+
+    /**
+     * @return string
+     */
     public static function getPickupLocationsDefaultView(): string
     {
         $settings = WCMYPA()->setting_collection;

--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -203,7 +203,6 @@ class WCMP_Checkout
         $chosenShippingMethodPrice  = (float) $cartTotals['shipping_total'];
         $displayIncludingTax        = WC()->cart->display_prices_including_tax();
         $priceFormat                = self::getDeliveryOptionsTitle(WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_PRICE_FORMAT);
-        $pickupLocationsDefaultView = self::getPickupLocationsDefaultView();
 
         if ($displayIncludingTax) {
             $chosenShippingMethodPrice += (float) $cartTotals['shipping_tax'];
@@ -216,7 +215,7 @@ class WCMP_Checkout
                 "platform"                   => "myparcel",
                 "basePrice"                  => $chosenShippingMethodPrice,
                 "showPriceSurcharge"         => WCMP_Settings_Data::DISPLAY_SURCHARGE_PRICE === $priceFormat,
-                "pickupLocationsDefaultView" => $pickupLocationsDefaultView,
+                "pickupLocationsDefaultView" => self::getPickupLocationsDefaultView(),
             ],
             "strings" => [
                 "addressNotFound"       => __("Address details are not entered", "woocommerce-myparcel"),

--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -197,12 +197,13 @@ class WCMP_Checkout
      */
     public function getDeliveryOptionsConfig(): array
     {
-        $settings                  = WCMYPA()->setting_collection;
-        $carriers                  = $this->getCarriers();
-        $cartTotals                = WC()->session->get('cart_totals');
-        $chosenShippingMethodPrice = (float) $cartTotals['shipping_total'];
-        $displayIncludingTax       = WC()->cart->display_prices_including_tax();
-        $priceFormat               = self::getDeliveryOptionsTitle(WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_PRICE_FORMAT);
+        $settings                   = WCMYPA()->setting_collection;
+        $carriers                   = $this->getCarriers();
+        $cartTotals                 = WC()->session->get('cart_totals');
+        $chosenShippingMethodPrice  = (float) $cartTotals['shipping_total'];
+        $displayIncludingTax        = WC()->cart->display_prices_including_tax();
+        $priceFormat                = self::getDeliveryOptionsTitle(WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_PRICE_FORMAT);
+        $pickupLocationsDefaultView = self::getPickupLocationsDefaultView();
 
         if ($displayIncludingTax) {
             $chosenShippingMethodPrice += (float) $cartTotals['shipping_tax'];
@@ -210,11 +211,12 @@ class WCMP_Checkout
 
         $myParcelConfig = [
             "config" => [
-                "currency"           => get_woocommerce_currency(),
-                "locale"             => "nl-NL",
-                "platform"           => "myparcel",
-                "basePrice"          => $chosenShippingMethodPrice,
-                "showPriceSurcharge" => WCMP_Settings_Data::DISPLAY_SURCHARGE_PRICE === $priceFormat,
+                "currency"                   => get_woocommerce_currency(),
+                "locale"                     => "nl-NL",
+                "platform"                   => "myparcel",
+                "basePrice"                  => $chosenShippingMethodPrice,
+                "showPriceSurcharge"         => WCMP_Settings_Data::DISPLAY_SURCHARGE_PRICE === $priceFormat,
+                "pickupLocationsDefaultView" => $pickupLocationsDefaultView,
             ],
             "strings" => [
                 "addressNotFound"       => __("Address details are not entered", "woocommerce-myparcel"),
@@ -289,6 +291,12 @@ class WCMP_Checkout
         $settings = WCMYPA()->setting_collection;
 
         return __(strip_tags($settings->getStringByName($title)), "woocommerce-myparcel");
+    }
+    public static function getPickupLocationsDefaultView(): string
+    {
+        $settings = WCMYPA()->setting_collection;
+
+        return $settings->getStringByName(WCMYPA_Settings::SETTING_PICKUP_LOCATIONS_DEFAULT_VIEW);
     }
 
     /**

--- a/languages/woocommerce-myparcel-en_GB.po
+++ b/languages/woocommerce-myparcel-en_GB.po
@@ -150,10 +150,10 @@ msgstr "Weight"
 msgid "settings_pickup_locations_default_view"
 msgstr "Pickup locations default view"
 
-msgid "settings_pickup_locations_map"
+msgid "settings_pickup_locations_default_view_map"
 msgstr "Map"
 
-msgid "settings_pickup_locations_list"
+msgid "settings_pickup_locations_default_view_list"
 msgstr "List"
 
 msgid "(Unknown)"

--- a/languages/woocommerce-myparcel-en_GB.po
+++ b/languages/woocommerce-myparcel-en_GB.po
@@ -147,6 +147,15 @@ msgstr ""
 msgid "weight"
 msgstr "Weight"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locations default view"
+
+msgid "settings_pickup_locations_map"
+msgstr "Map"
+
+msgid "settings_pickup_locations_list"
+msgstr "List"
+
 msgid "(Unknown)"
 msgstr "(Unknown)"
 

--- a/languages/woocommerce-myparcel-en_US.po
+++ b/languages/woocommerce-myparcel-en_US.po
@@ -150,10 +150,10 @@ msgstr "Weight"
 msgid "settings_pickup_locations_default_view"
 msgstr "Pickup locations default view"
 
-msgid "settings_pickup_locations_map"
+msgid "settings_pickup_locations_default_view_map"
 msgstr "Map"
 
-msgid "settings_pickup_locations_list"
+msgid "settings_pickup_locations_default_view_list"
 msgstr "List"
 
 msgid "(Unknown)"

--- a/languages/woocommerce-myparcel-en_US.po
+++ b/languages/woocommerce-myparcel-en_US.po
@@ -147,6 +147,15 @@ msgstr ""
 msgid "weight"
 msgstr "Weight"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locations default view"
+
+msgid "settings_pickup_locations_map"
+msgstr "Map"
+
+msgid "settings_pickup_locations_list"
+msgstr "List"
+
 msgid "(Unknown)"
 msgstr "(Unknown)"
 

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -15,7 +15,7 @@ msgid "setting_automatic_order_status"
 msgstr "Statut de commande automatique"
 
 msgid "setting_change_order_status_after"
-msgstr "Bezig met laden..."
+msgstr "Modification de l'état de la commande après"
 
 msgid "setting_change_status_after_printing"
 msgstr "impression d'étiquettes"

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -151,7 +151,16 @@ msgstr ""
 "signature sera nécessaire."
 
 msgid "weight"
-msgstr "Poids"
+msgstr "Lester"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Lieux de ramassage vue défaut"
+
+msgid "settings_pickup_locations_map"
+msgstr "Carte"
+
+msgid "settings_pickup_locations_list"
+msgstr "Liste"
 
 msgid "(Unknown)"
 msgstr "(Inconnu)"

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -15,7 +15,7 @@ msgid "setting_automatic_order_status"
 msgstr "Statut de commande automatique"
 
 msgid "setting_change_order_status_after"
-msgstr "Modification de l'état de la commande après"
+msgstr "Bezig met laden..."
 
 msgid "setting_change_status_after_printing"
 msgstr "impression d'étiquettes"
@@ -41,7 +41,7 @@ msgid "insured"
 msgstr "Assuré"
 
 msgid "insured_amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "insured_for"
 msgstr "Montant assuré"
@@ -89,7 +89,7 @@ msgstr ""
 "combinée avec la livraison le matin ou le soir."
 
 msgid "shipment_options_insured"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid "shipment_options_insured_amount"
 msgstr "Max montant assuré"
@@ -151,15 +151,15 @@ msgstr ""
 "signature sera nécessaire."
 
 msgid "weight"
-msgstr "Lester"
+msgstr "Poids"
 
 msgid "settings_pickup_locations_default_view"
 msgstr "Lieux de ramassage vue défaut"
 
-msgid "settings_pickup_locations_map"
+msgid "settings_pickup_locations_default_view_map"
 msgstr "Carte"
 
-msgid "settings_pickup_locations_list"
+msgid "settings_pickup_locations_default_view_list"
 msgstr "Liste"
 
 msgid "(Unknown)"
@@ -206,7 +206,7 @@ msgid "Ask for print start position"
 msgstr "Demander la position de démarrage de l'impression"
 
 msgid "Automatic export"
-msgstr "exportation automatique"
+msgstr "Exportation automatique"
 
 msgid ""
 "Automatically set order status to a predefined status after successful "
@@ -316,7 +316,7 @@ msgid "Default"
 msgstr "Défaut"
 
 msgid "Default country of origin"
-msgstr "pays d'origine par défaut"
+msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"
 msgstr "Paramètres d'exportation standards"
@@ -325,7 +325,7 @@ msgid "Default HS Code"
 msgstr "Par défaut Code SH"
 
 msgid "Default weight of your empty parcel."
-msgstr "poids par défaut de votre colis vide."
+msgstr "Poids par défaut de votre colis vide."
 
 msgid "delivered - at recipient"
 msgstr "livré - chez le destinataire"
@@ -361,7 +361,7 @@ msgid "Diagnostic tools"
 msgstr "Outils de diagnostic"
 
 msgid "Digital stamp"
-msgstr "timbre numérique"
+msgstr "Timbre numérique"
 
 msgid "Disabled"
 msgstr "désactivé"
@@ -465,7 +465,7 @@ msgid "Hide this message"
 msgstr "Masquez ce message"
 
 msgid "Home address only"
-msgstr "qu'adresse du domicile"
+msgstr "Qu'adresse du domicile"
 
 msgid "Home address only title"
 msgstr "Adresse du domicile seul titre"
@@ -531,7 +531,7 @@ msgid "inactive - unknown"
 msgstr "inactif - inconnu"
 
 msgid "Insurance amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "Insure all orders that exceed this price point."
 msgstr "Assurer toutes les commandes qui dépassent ce prix."
@@ -546,7 +546,7 @@ msgid "Insured for"
 msgstr "Montant assuré"
 
 msgid "Insured shipment"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -585,7 +585,7 @@ msgid "Max insured amount"
 msgstr "Max montant assuré"
 
 msgid "Monday delivery"
-msgstr "livraison lundi"
+msgstr "Livraison lundi"
 
 msgid "Morning delivery"
 msgstr "Livraison le matin"

--- a/languages/woocommerce-myparcel-fr_FR.po
+++ b/languages/woocommerce-myparcel-fr_FR.po
@@ -15,7 +15,7 @@ msgid "setting_automatic_order_status"
 msgstr "Statut de commande automatique"
 
 msgid "setting_change_order_status_after"
-msgstr "Modification de l'état de la commande après"
+msgstr "Bezig met laden..."
 
 msgid "setting_change_status_after_printing"
 msgstr "impression d'étiquettes"
@@ -41,7 +41,7 @@ msgid "insured"
 msgstr "Assuré"
 
 msgid "insured_amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "insured_for"
 msgstr "Montant assuré"
@@ -89,7 +89,7 @@ msgstr ""
 "combinée avec la livraison le matin ou le soir."
 
 msgid "shipment_options_insured"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid "shipment_options_insured_amount"
 msgstr "Max montant assuré"
@@ -151,15 +151,15 @@ msgstr ""
 "signature sera nécessaire."
 
 msgid "weight"
-msgstr "Lester"
+msgstr "Poids"
 
 msgid "settings_pickup_locations_default_view"
 msgstr "Lieux de ramassage vue défaut"
 
-msgid "settings_pickup_locations_map"
+msgid "settings_pickup_locations_default_view_map"
 msgstr "Carte"
 
-msgid "settings_pickup_locations_list"
+msgid "settings_pickup_locations_default_view_list"
 msgstr "Liste"
 
 msgid "(Unknown)"
@@ -206,7 +206,7 @@ msgid "Ask for print start position"
 msgstr "Demander la position de démarrage de l'impression"
 
 msgid "Automatic export"
-msgstr "exportation automatique"
+msgstr "Exportation automatique"
 
 msgid ""
 "Automatically set order status to a predefined status after successful "
@@ -316,7 +316,7 @@ msgid "Default"
 msgstr "Défaut"
 
 msgid "Default country of origin"
-msgstr "pays d'origine par défaut"
+msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"
 msgstr "Paramètres d'exportation standards"
@@ -325,7 +325,7 @@ msgid "Default HS Code"
 msgstr "Par défaut Code SH"
 
 msgid "Default weight of your empty parcel."
-msgstr "poids par défaut de votre colis vide."
+msgstr "Poids par défaut de votre colis vide."
 
 msgid "delivered - at recipient"
 msgstr "livré - chez le destinataire"
@@ -361,7 +361,7 @@ msgid "Diagnostic tools"
 msgstr "Outils de diagnostic"
 
 msgid "Digital stamp"
-msgstr "timbre numérique"
+msgstr "Timbre numérique"
 
 msgid "Disabled"
 msgstr "désactivé"
@@ -431,7 +431,7 @@ msgid ""
 "extra for this delivery option."
 msgstr ""
 "Introduisez ici un montant positif ou négatif. Si vous souhaitez par "
-"exemple proposer une r��duction pour cette fonction ou décompter des frais "
+"exemple proposer une réduction pour cette fonction ou décompter des frais "
 "supplémentaires pour cette option de livraison."
 
 msgid "Evening delivery"
@@ -465,7 +465,7 @@ msgid "Hide this message"
 msgstr "Masquez ce message"
 
 msgid "Home address only"
-msgstr "qu'adresse du domicile"
+msgstr "Qu'adresse du domicile"
 
 msgid "Home address only title"
 msgstr "Adresse du domicile seul titre"
@@ -531,7 +531,7 @@ msgid "inactive - unknown"
 msgstr "inactif - inconnu"
 
 msgid "Insurance amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "Insure all orders that exceed this price point."
 msgstr "Assurer toutes les commandes qui dépassent ce prix."
@@ -546,7 +546,7 @@ msgid "Insured for"
 msgstr "Montant assuré"
 
 msgid "Insured shipment"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -585,7 +585,7 @@ msgid "Max insured amount"
 msgstr "Max montant assuré"
 
 msgid "Monday delivery"
-msgstr "livraison lundi"
+msgstr "Livraison lundi"
 
 msgid "Morning delivery"
 msgstr "Livraison le matin"

--- a/languages/woocommerce-myparcel-fr_FR.po
+++ b/languages/woocommerce-myparcel-fr_FR.po
@@ -15,7 +15,7 @@ msgid "setting_automatic_order_status"
 msgstr "Statut de commande automatique"
 
 msgid "setting_change_order_status_after"
-msgstr "Bezig met laden..."
+msgstr "Modification de l'état de la commande après"
 
 msgid "setting_change_status_after_printing"
 msgstr "impression d'étiquettes"

--- a/languages/woocommerce-myparcel-fr_FR.po
+++ b/languages/woocommerce-myparcel-fr_FR.po
@@ -151,7 +151,16 @@ msgstr ""
 "signature sera nécessaire."
 
 msgid "weight"
-msgstr "Poids"
+msgstr "Lester"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Lieux de ramassage vue défaut"
+
+msgid "settings_pickup_locations_map"
+msgstr "Carte"
+
+msgid "settings_pickup_locations_list"
+msgstr "Liste"
 
 msgid "(Unknown)"
 msgstr "(Inconnu)"
@@ -422,7 +431,7 @@ msgid ""
 "extra for this delivery option."
 msgstr ""
 "Introduisez ici un montant positif ou négatif. Si vous souhaitez par "
-"exemple proposer une réduction pour cette fonction ou décompter des frais "
+"exemple proposer une r��duction pour cette fonction ou décompter des frais "
 "supplémentaires pour cette option de livraison."
 
 msgid "Evening delivery"
@@ -820,7 +829,7 @@ msgid ""
 msgstr ""
 "Les options de livraison MyParcel permettent à vos clients de choisir s’ils "
 "souhaitent que leur colis soit livré à domicile ou à un point de retrait. "
-"En fonction des param��tres, vous pouvez leur permettre de sélectionner une "
+"En fonction des paramètres, vous pouvez leur permettre de sélectionner une "
 "date, une heure et même des options telles que la signature d'une signature."
 
 msgid "The order(s) you have selected have invalid shipping countries."

--- a/languages/woocommerce-myparcel-nl_BE.po
+++ b/languages/woocommerce-myparcel-nl_BE.po
@@ -149,6 +149,15 @@ msgstr ""
 msgid "weight"
 msgstr "Gewicht"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locaties standaard weergave"
+
+msgid "settings_pickup_locations_map"
+msgstr "Kaart"
+
+msgid "settings_pickup_locations_list"
+msgstr "Lijst"
+
 msgid "(Unknown)"
 msgstr "(Onbekend)"
 

--- a/languages/woocommerce-myparcel-nl_BE.po
+++ b/languages/woocommerce-myparcel-nl_BE.po
@@ -152,10 +152,10 @@ msgstr "Gewicht"
 msgid "settings_pickup_locations_default_view"
 msgstr "Pickup locaties standaard weergave"
 
-msgid "settings_pickup_locations_map"
+msgid "settings_pickup_locations_default_view_map"
 msgstr "Kaart"
 
-msgid "settings_pickup_locations_list"
+msgid "settings_pickup_locations_default_view_list"
 msgstr "Lijst"
 
 msgid "(Unknown)"

--- a/languages/woocommerce-myparcel-nl_NL.po
+++ b/languages/woocommerce-myparcel-nl_NL.po
@@ -149,6 +149,15 @@ msgstr ""
 msgid "weight"
 msgstr "Gewicht"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locaties standaard weergave"
+
+msgid "settings_pickup_locations_map"
+msgstr "Kaart"
+
+msgid "settings_pickup_locations_list"
+msgstr "Lijst"
+
 msgid "(Unknown)"
 msgstr "(Onbekend)"
 

--- a/languages/woocommerce-myparcel-nl_NL.po
+++ b/languages/woocommerce-myparcel-nl_NL.po
@@ -152,10 +152,10 @@ msgstr "Gewicht"
 msgid "settings_pickup_locations_default_view"
 msgstr "Pickup locaties standaard weergave"
 
-msgid "settings_pickup_locations_map"
+msgid "settings_pickup_locations_default_view_map"
 msgstr "Kaart"
 
-msgid "settings_pickup_locations_list"
+msgid "settings_pickup_locations_default_view_list"
 msgstr "Lijst"
 
 msgid "(Unknown)"

--- a/languages/woocommerce-myparcel.pot
+++ b/languages/woocommerce-myparcel.pot
@@ -51,23 +51,23 @@ msgstr ""
 msgid "Digital stamp"
 msgstr ""
 
-#: includes/class-wcmp-data.php:95, includes/admin/settings/class-wcmp-settings-data.php:541, includes/admin/settings/class-wcmp-settings-data.php:915
+#: includes/class-wcmp-data.php:95, includes/admin/settings/class-wcmp-settings-data.php:544, includes/admin/settings/class-wcmp-settings-data.php:935
 msgid "Morning delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:96, includes/admin/settings/class-wcmp-settings-data.php:925
+#: includes/class-wcmp-data.php:96, includes/admin/settings/class-wcmp-settings-data.php:945
 msgid "Standard delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:97, includes/admin/settings/class-wcmp-settings-data.php:554, includes/admin/settings/class-wcmp-settings-data.php:931
+#: includes/class-wcmp-data.php:97, includes/admin/settings/class-wcmp-settings-data.php:557, includes/admin/settings/class-wcmp-settings-data.php:951
 msgid "Evening delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:98, includes/admin/settings/class-wcmp-settings-data.php:949
+#: includes/class-wcmp-data.php:98, includes/admin/settings/class-wcmp-settings-data.php:969
 msgid "Pickup"
 msgstr ""
 
-#: includes/class-wcmp-data.php:231, includes/admin/settings/class-wcmp-settings-data.php:88
+#: includes/class-wcmp-data.php:231, includes/admin/settings/class-wcmp-settings-data.php:91
 msgid "PostNL"
 msgstr ""
 
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Email return label"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:605, includes/admin/settings/class-wcmypa-settings.php:161, includes/admin/settings/class-wcmypa-settings.php:162
+#: includes/admin/class-wcmypa-admin.php:605, includes/admin/settings/class-wcmypa-settings.php:162, includes/admin/settings/class-wcmypa-settings.php:163
 msgid "MyParcel"
 msgstr ""
 
@@ -311,11 +311,11 @@ msgstr ""
 msgid "Country of origin is required for world shipments. Defaults to shop base."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:824, includes/admin/OrderSettingsRows.php:241, includes/admin/settings/class-wcmp-settings-data.php:450
+#: includes/admin/class-wcmypa-admin.php:824, includes/admin/OrderSettingsRows.php:241, includes/admin/settings/class-wcmp-settings-data.php:453
 msgid "shipment_options_age_check"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:831, includes/admin/OrderSettingsRows.php:242, includes/admin/settings/class-wcmp-settings-data.php:452
+#: includes/admin/class-wcmypa-admin.php:831, includes/admin/OrderSettingsRows.php:242, includes/admin/settings/class-wcmp-settings-data.php:455
 msgid "shipment_options_age_check_help_text"
 msgstr ""
 
@@ -367,11 +367,11 @@ msgstr ""
 msgid "Number of labels"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:138, includes/admin/settings/class-wcmp-settings-data.php:444
+#: includes/admin/OrderSettingsRows.php:138, includes/admin/settings/class-wcmp-settings-data.php:447
 msgid "shipment_options_large_format"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:139, includes/admin/settings/class-wcmp-settings-data.php:445
+#: includes/admin/OrderSettingsRows.php:139, includes/admin/settings/class-wcmp-settings-data.php:448
 msgid "shipment_options_large_format_help_text"
 msgstr ""
 
@@ -387,27 +387,27 @@ msgstr ""
 msgid "calculated_order_weight"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:215, includes/admin/settings/class-wcmp-settings-data.php:432, includes/admin/settings/class-wcmp-settings-data.php:567, includes/admin/settings/class-wcmp-settings-data.php:937, includes/admin/views/html-order-shipment-summary.php:24
+#: includes/admin/OrderSettingsRows.php:215, includes/admin/settings/class-wcmp-settings-data.php:435, includes/admin/settings/class-wcmp-settings-data.php:570, includes/admin/settings/class-wcmp-settings-data.php:957, includes/admin/views/html-order-shipment-summary.php:24
 msgid "shipment_options_only_recipient"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:216, includes/admin/settings/class-wcmp-settings-data.php:433
+#: includes/admin/OrderSettingsRows.php:216, includes/admin/settings/class-wcmp-settings-data.php:436
 msgid "shipment_options_only_recipient_help_text"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:228, includes/admin/settings/class-wcmp-settings-data.php:438, includes/admin/settings/class-wcmp-settings-data.php:580, includes/admin/settings/class-wcmp-settings-data.php:943, includes/admin/views/html-order-shipment-summary.php:23
+#: includes/admin/OrderSettingsRows.php:228, includes/admin/settings/class-wcmp-settings-data.php:441, includes/admin/settings/class-wcmp-settings-data.php:583, includes/admin/settings/class-wcmp-settings-data.php:963, includes/admin/views/html-order-shipment-summary.php:23
 msgid "shipment_options_signature"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:229, includes/admin/settings/class-wcmp-settings-data.php:439
+#: includes/admin/OrderSettingsRows.php:229, includes/admin/settings/class-wcmp-settings-data.php:442
 msgid "shipment_options_signature_help_text"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:253, includes/admin/settings/class-wcmp-settings-data.php:456
+#: includes/admin/OrderSettingsRows.php:253, includes/admin/settings/class-wcmp-settings-data.php:459
 msgid "shipment_options_return"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:254, includes/admin/settings/class-wcmp-settings-data.php:457
+#: includes/admin/OrderSettingsRows.php:254, includes/admin/settings/class-wcmp-settings-data.php:460
 msgid "shipment_options_return_help_text"
 msgstr ""
 
@@ -419,39 +419,39 @@ msgstr ""
 msgid "insured_amount"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:220
+#: includes/frontend/class-wcmp-checkout.php:222
 msgid "Address details are not entered"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:221
+#: includes/frontend/class-wcmp-checkout.php:223
 msgid "City"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:222
+#: includes/frontend/class-wcmp-checkout.php:224
 msgid "Closed"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:228
+#: includes/frontend/class-wcmp-checkout.php:230
 msgid "House number"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:230
+#: includes/frontend/class-wcmp-checkout.php:232
 msgid "Opening hours"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:231
+#: includes/frontend/class-wcmp-checkout.php:233
 msgid "Pick up from"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:233
+#: includes/frontend/class-wcmp-checkout.php:235
 msgid "Postcode"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:234
+#: includes/frontend/class-wcmp-checkout.php:236
 msgid "Retry"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:236
+#: includes/frontend/class-wcmp-checkout.php:238
 msgid "Postcode/city combination unknown"
 msgstr ""
 
@@ -463,523 +463,535 @@ msgstr ""
 msgid "Track & Trace"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:83
+#: includes/admin/settings/class-wcmp-settings-data.php:86
 msgid "General"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:84, includes/admin/settings/class-wcmp-settings-data.php:217
+#: includes/admin/settings/class-wcmp-settings-data.php:87, includes/admin/settings/class-wcmp-settings-data.php:220
 msgid "Default export settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:85, includes/admin/settings/class-wcmp-settings-data.php:230
+#: includes/admin/settings/class-wcmp-settings-data.php:88, includes/admin/settings/class-wcmp-settings-data.php:233
 msgid "Checkout settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:191
+#: includes/admin/settings/class-wcmp-settings-data.php:194
 msgid "API settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:196
+#: includes/admin/settings/class-wcmp-settings-data.php:199
 msgid "General settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:201
+#: includes/admin/settings/class-wcmp-settings-data.php:204
 msgid "Diagnostic tools"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:235
+#: includes/admin/settings/class-wcmp-settings-data.php:238
 msgid "Titles"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:254
+#: includes/admin/settings/class-wcmp-settings-data.php:257
 msgid "PostNL export settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:255
+#: includes/admin/settings/class-wcmp-settings-data.php:258
 msgid "These settings will be applied to PostNL shipments you create in the backend."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:263
+#: includes/admin/settings/class-wcmp-settings-data.php:266
 msgid "PostNL delivery options"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:268
+#: includes/admin/settings/class-wcmp-settings-data.php:271
 msgid "PostNL pickup options"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:283
+#: includes/admin/settings/class-wcmp-settings-data.php:286
 msgid "Key"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:284
+#: includes/admin/settings/class-wcmp-settings-data.php:287
 msgid "api key"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:297
+#: includes/admin/settings/class-wcmp-settings-data.php:300
 msgid "Label display"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:300
+#: includes/admin/settings/class-wcmp-settings-data.php:303
 msgid "Download PDF"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:301
+#: includes/admin/settings/class-wcmp-settings-data.php:304
 msgid "Open the PDF in a new tab"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:306
+#: includes/admin/settings/class-wcmp-settings-data.php:309
 msgid "Label format"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:309
+#: includes/admin/settings/class-wcmp-settings-data.php:312
 msgid "Standard printer (A4)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:310
+#: includes/admin/settings/class-wcmp-settings-data.php:313
 msgid "Label Printer (A6)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:315
+#: includes/admin/settings/class-wcmp-settings-data.php:318
 msgid "Ask for print start position"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:323
+#: includes/admin/settings/class-wcmp-settings-data.php:326
 msgid "This option enables you to continue printing where you left off last time"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:330
+#: includes/admin/settings/class-wcmp-settings-data.php:333
 msgid "Track & Trace in email"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:332
+#: includes/admin/settings/class-wcmp-settings-data.php:335
 msgid "Add the Track & Trace code to emails to the customer.<br/><strong>Note!</strong> When you select this option, make sure you have not enabled the Track & Trace email in your MyParcel backend."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:339
+#: includes/admin/settings/class-wcmp-settings-data.php:342
 msgid "Track & Trace in My Account"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:341
+#: includes/admin/settings/class-wcmp-settings-data.php:344
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:345
+#: includes/admin/settings/class-wcmp-settings-data.php:348
 msgid "Process shipments directly"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:347
+#: includes/admin/settings/class-wcmp-settings-data.php:350
 msgid "When you enable this option, shipments will be directly processed when sent to MyParcel."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:354
+#: includes/admin/settings/class-wcmp-settings-data.php:357
 msgid "Order status automation"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:356
+#: includes/admin/settings/class-wcmp-settings-data.php:359
 msgid "Automatically set order status to a predefined status after successful MyParcel export.<br/>Make sure <strong>Process shipments directly</strong> is enabled when you use this option together with the <strong>Track & Trace in email</strong> option, otherwise the Track & Trace code will not be included in the customer email."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:365
+#: includes/admin/settings/class-wcmp-settings-data.php:368
 msgid "setting_change_order_status_after"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:369
+#: includes/admin/settings/class-wcmp-settings-data.php:372
 msgid "setting_change_status_after_printing"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:370
+#: includes/admin/settings/class-wcmp-settings-data.php:373
 msgid "setting_change_status_after_export"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:372
+#: includes/admin/settings/class-wcmp-settings-data.php:375
 msgid "setting_change_status_after_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:381
+#: includes/admin/settings/class-wcmp-settings-data.php:384
 msgid "setting_automatic_order_status"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:387
+#: includes/admin/settings/class-wcmp-settings-data.php:390
 msgid "Place barcode inside note"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:389
+#: includes/admin/settings/class-wcmp-settings-data.php:392
 msgid "Place the barcode inside a note of the order"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:395
+#: includes/admin/settings/class-wcmp-settings-data.php:398
 msgid "Title before the barcode"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:396
+#: includes/admin/settings/class-wcmp-settings-data.php:399
 msgid "Track & trace code:"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:397
+#: includes/admin/settings/class-wcmp-settings-data.php:400
 msgid "You can change the text before the barcode inside an note"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:413
+#: includes/admin/settings/class-wcmp-settings-data.php:416
 msgid "Log API communication"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:417
+#: includes/admin/settings/class-wcmp-settings-data.php:420
 msgid "View logs"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:462
+#: includes/admin/settings/class-wcmp-settings-data.php:465
 msgid "shipment_options_insured"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:463
+#: includes/admin/settings/class-wcmp-settings-data.php:466
 msgid "shipment_options_insured_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:469
+#: includes/admin/settings/class-wcmp-settings-data.php:472
 msgid "shipment_options_insured_from_price"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:470
+#: includes/admin/settings/class-wcmp-settings-data.php:473
 msgid "shipment_options_insured_from_price_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:476
+#: includes/admin/settings/class-wcmp-settings-data.php:479
 msgid "shipment_options_insured_amount"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:477
+#: includes/admin/settings/class-wcmp-settings-data.php:480
 msgid "shipment_options_insured_amount_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:496
+#: includes/admin/settings/class-wcmp-settings-data.php:499
 msgid "Enable PostNL delivery"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:502
+#: includes/admin/settings/class-wcmp-settings-data.php:505
 msgid "Drop-off days"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:506
+#: includes/admin/settings/class-wcmp-settings-data.php:509
 msgid "Days of the week on which you hand over parcels to PostNL"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:511
+#: includes/admin/settings/class-wcmp-settings-data.php:514
 msgid "Cut-off time"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:512, includes/admin/settings/class-wcmp-settings-data.php:610
+#: includes/admin/settings/class-wcmp-settings-data.php:515, includes/admin/settings/class-wcmp-settings-data.php:613
 msgid "Time at which you stop processing orders for the day (format: hh:mm)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:521
+#: includes/admin/settings/class-wcmp-settings-data.php:524
 msgid "Drop-off delay"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:524
+#: includes/admin/settings/class-wcmp-settings-data.php:527
 msgid "Number of days you need to process an order."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:529
+#: includes/admin/settings/class-wcmp-settings-data.php:532
 msgid "Delivery days window"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:533
+#: includes/admin/settings/class-wcmp-settings-data.php:536
 msgid "Amount of days a customer can postpone a shipment. Default is 0 days with a maximum value of 14 days."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:582, includes/admin/settings/class-wcmp-settings-data.php:1017
+#: includes/admin/settings/class-wcmp-settings-data.php:585, includes/admin/settings/class-wcmp-settings-data.php:1037
 msgid "Enter an amount that is either positive or negative. For example, do you want to give a discount for using this function or do you want to charge extra for this delivery option."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:597
+#: includes/admin/settings/class-wcmp-settings-data.php:600
 msgid "Monday delivery"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:607
+#: includes/admin/settings/class-wcmp-settings-data.php:610
 msgid "Cut-off time on Saturday"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:626
+#: includes/admin/settings/class-wcmp-settings-data.php:629
 msgid "Enable PostNL pickup"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:646
+#: includes/admin/settings/class-wcmp-settings-data.php:649
 msgid "Package types"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:651
+#: includes/admin/settings/class-wcmp-settings-data.php:654
 msgid "Select one or more shipping methods for each MyParcel package type"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:658
+#: includes/admin/settings/class-wcmp-settings-data.php:661
 msgid "Connect customer email"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:660
+#: includes/admin/settings/class-wcmp-settings-data.php:663
 msgid "When you connect the customer's email, MyParcel can send a Track & Trace email to this address. In your MyParcel backend you can enable or disable this email and format it in your own style."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:667
+#: includes/admin/settings/class-wcmp-settings-data.php:670
 msgid "Connect customer phone"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:669
+#: includes/admin/settings/class-wcmp-settings-data.php:672
 msgid "When you connect the customer's phone number, the courier can use this for the delivery of the parcel. This greatly increases the delivery success rate for foreign shipments."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:676, includes/admin/views/html-order-shipment-summary.php:61
+#: includes/admin/settings/class-wcmp-settings-data.php:679, includes/admin/views/html-order-shipment-summary.php:61
 msgid "Label description"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:677
+#: includes/admin/settings/class-wcmp-settings-data.php:680
 msgid "With this option you can add a description to the shipment. This will be printed on the top left of the label, and you can use this to search or sort shipments in your backoffice. Because of limited space on the label which varies per package type, we recommend that you keep the label description as short as possible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:689
+#: includes/admin/settings/class-wcmp-settings-data.php:692
 msgid "Empty parcel weight"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:692
+#: includes/admin/settings/class-wcmp-settings-data.php:695
 msgid "Default weight of your empty parcel."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:699
+#: includes/admin/settings/class-wcmp-settings-data.php:702
 msgid "Default HS Code"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:700
+#: includes/admin/settings/class-wcmp-settings-data.php:703
 msgid "HS Codes are used for MyParcel world shipments, you can find the appropriate code on the site of the Dutch Customs."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:707
+#: includes/admin/settings/class-wcmp-settings-data.php:710
 msgid "Customs shipment type"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:710
+#: includes/admin/settings/class-wcmp-settings-data.php:713
 msgid "Commercial goods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:711
+#: includes/admin/settings/class-wcmp-settings-data.php:714
 msgid "Commercial samples"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:712
+#: includes/admin/settings/class-wcmp-settings-data.php:715
 msgid "Documents"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:713
+#: includes/admin/settings/class-wcmp-settings-data.php:716
 msgid "Gifts"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:714
+#: includes/admin/settings/class-wcmp-settings-data.php:717
 msgid "Return shipment"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:719
+#: includes/admin/settings/class-wcmp-settings-data.php:722
 msgid "Default country of origin"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:722
+#: includes/admin/settings/class-wcmp-settings-data.php:725
 msgid "Country of origin is required for world shipments. Defaults to shop base or NL. Example: 'NL', 'BE', 'DE'"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:728
+#: includes/admin/settings/class-wcmp-settings-data.php:731
 msgid "Automatic export"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:730
+#: includes/admin/settings/class-wcmp-settings-data.php:733
 msgid "With this setting enabled orders are exported to MyParcel automatically after payment."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:760
+#: includes/admin/settings/class-wcmp-settings-data.php:763
 msgid "MyParcel address fields"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:762
+#: includes/admin/settings/class-wcmp-settings-data.php:765
 msgid "When enabled the checkout will use the MyParcel address fields. This means there will be three separate fields for street name, number and suffix. Want to use the WooCommerce default fields? Leave this option unchecked."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:769
+#: includes/admin/settings/class-wcmp-settings-data.php:772
 msgid "Show delivery date"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:771
+#: includes/admin/settings/class-wcmp-settings-data.php:774
 msgid "Show delivery day options allow your customers to see the delivery day in order confirmation and My Account."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:778
+#: includes/admin/settings/class-wcmp-settings-data.php:781
 msgid "Enable MyParcel delivery options"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:780
+#: includes/admin/settings/class-wcmp-settings-data.php:783
 msgid "The MyParcel delivery options allow your customers to select whether they want their parcel delivered at home or to a pickup point. Depending on the settings you can allow them to select a date, time and even options like requiring a signature on delivery."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:788
+#: includes/admin/settings/class-wcmp-settings-data.php:791
 msgid "Enable delivery options for backorders"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:790
+#: includes/admin/settings/class-wcmp-settings-data.php:793
 msgid "When this option is enabled, delivery options and delivery day will be also shown for backorders."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:798
+#: includes/admin/settings/class-wcmp-settings-data.php:801
 msgid "settings_checkout_display_for"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:800
+#: includes/admin/settings/class-wcmp-settings-data.php:803
 msgid "settings_checkout_display_for_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:802
+#: includes/admin/settings/class-wcmp-settings-data.php:805
 msgid "settings_checkout_display_for_selected_methods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:803
+#: includes/admin/settings/class-wcmp-settings-data.php:806
 msgid "settings_checkout_display_for_all_methods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:809
+#: includes/admin/settings/class-wcmp-settings-data.php:812
 msgid "Checkout position"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:813
+#: includes/admin/settings/class-wcmp-settings-data.php:816
 msgid "Show after billing details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:817
+#: includes/admin/settings/class-wcmp-settings-data.php:820
 msgid "Show after shipping details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:821
+#: includes/admin/settings/class-wcmp-settings-data.php:824
 msgid "Show after customer details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:825
+#: includes/admin/settings/class-wcmp-settings-data.php:828
 msgid "Show after notes"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:829
+#: includes/admin/settings/class-wcmp-settings-data.php:832
 msgid "Show after subtotal"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:834
+#: includes/admin/settings/class-wcmp-settings-data.php:837
 msgid "You can change the place of the delivery options on the checkout page. By default it will be placed after shipping details."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:842
+#: includes/admin/settings/class-wcmp-settings-data.php:845
 msgid "settings_checkout_price_format"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:846
+#: includes/admin/settings/class-wcmp-settings-data.php:849
 msgid "settings_checkout_total_price"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:850
+#: includes/admin/settings/class-wcmp-settings-data.php:853
 msgid "settings_checkout_surcharge"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:859
+#: includes/admin/settings/class-wcmp-settings-data.php:862
+msgid "settings_pickup_locations_default_view"
+msgstr ""
+
+#: includes/admin/settings/class-wcmp-settings-data.php:866
+msgid "settings_pickup_locations_map"
+msgstr ""
+
+#: includes/admin/settings/class-wcmp-settings-data.php:870
+msgid "settings_pickup_locations_list"
+msgstr ""
+
+#: includes/admin/settings/class-wcmp-settings-data.php:879
 msgid "Custom styles"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:898
+#: includes/admin/settings/class-wcmp-settings-data.php:918
 msgid "Delivery options title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:900
+#: includes/admin/settings/class-wcmp-settings-data.php:920
 msgid "You can place a delivery title above the MyParcel options. When there is no title, it will not be visible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:908
+#: includes/admin/settings/class-wcmp-settings-data.php:928
 msgid "Delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:909
+#: includes/admin/settings/class-wcmp-settings-data.php:929
 msgid "Delivered at home or at work"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:914
+#: includes/admin/settings/class-wcmp-settings-data.php:934
 msgid "Morning delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:920
+#: includes/admin/settings/class-wcmp-settings-data.php:940
 msgid "Standard delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:921
+#: includes/admin/settings/class-wcmp-settings-data.php:941
 msgid "When there is no title, the delivery time will automatically be visible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:930
+#: includes/admin/settings/class-wcmp-settings-data.php:950
 msgid "Evening delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:936
+#: includes/admin/settings/class-wcmp-settings-data.php:956
 msgid "Home address only title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:942
+#: includes/admin/settings/class-wcmp-settings-data.php:962
 msgid "Signature on delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:948
+#: includes/admin/settings/class-wcmp-settings-data.php:968
 msgid "Pickup title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:972
+#: includes/admin/settings/class-wcmp-settings-data.php:992
 msgid "Theme \"%s\" detected."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:974
+#: includes/admin/settings/class-wcmp-settings-data.php:994
 msgid "Apply preset."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:987
+#: includes/admin/settings/class-wcmp-settings-data.php:1007
 msgid "Delivery date"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:988
+#: includes/admin/settings/class-wcmp-settings-data.php:1008
 msgid "Order number"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:989
+#: includes/admin/settings/class-wcmp-settings-data.php:1009
 msgid "Product id"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:990, includes/admin/views/html-send-return-email-form.php:67
+#: includes/admin/settings/class-wcmp-settings-data.php:1010, includes/admin/views/html-send-return-email-form.php:67
 msgid "Product name"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:991
+#: includes/admin/settings/class-wcmp-settings-data.php:1011
 msgid "Product quantity"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:992
+#: includes/admin/settings/class-wcmp-settings-data.php:1012
 msgid "Product SKU"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:993
+#: includes/admin/settings/class-wcmp-settings-data.php:1013
 msgid "Customer note"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:1015
+#: includes/admin/settings/class-wcmp-settings-data.php:1035
 msgid "Fee (optional)"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:185
+#: includes/admin/settings/class-wcmypa-settings.php:186
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:205
+#: includes/admin/settings/class-wcmypa-settings.php:206
 msgid "WooCommerce MyParcel Settings"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:259
+#: includes/admin/settings/class-wcmypa-settings.php:260
 msgid "It looks like your shop is based in Netherlands. This plugin is for MyParcel. If you are using MyParcel Netherlands, download the %s plugin instead!"
 msgstr ""
 
-#: includes/admin/settings/class-wcmypa-settings.php:268
+#: includes/admin/settings/class-wcmypa-settings.php:269
 msgid "Hide this message"
 msgstr ""
 

--- a/languages/woocommerce-myparcel.pot
+++ b/languages/woocommerce-myparcel.pot
@@ -419,39 +419,39 @@ msgstr ""
 msgid "insured_amount"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:222
+#: includes/frontend/class-wcmp-checkout.php:221
 msgid "Address details are not entered"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:223
+#: includes/frontend/class-wcmp-checkout.php:222
 msgid "City"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:224
+#: includes/frontend/class-wcmp-checkout.php:223
 msgid "Closed"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:230
+#: includes/frontend/class-wcmp-checkout.php:229
 msgid "House number"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:232
+#: includes/frontend/class-wcmp-checkout.php:231
 msgid "Opening hours"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:233
+#: includes/frontend/class-wcmp-checkout.php:232
 msgid "Pick up from"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:235
+#: includes/frontend/class-wcmp-checkout.php:234
 msgid "Postcode"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:236
+#: includes/frontend/class-wcmp-checkout.php:235
 msgid "Retry"
 msgstr ""
 
-#: includes/frontend/class-wcmp-checkout.php:238
+#: includes/frontend/class-wcmp-checkout.php:237
 msgid "Postcode/city combination unknown"
 msgstr ""
 
@@ -884,11 +884,11 @@ msgid "settings_pickup_locations_default_view"
 msgstr ""
 
 #: includes/admin/settings/class-wcmp-settings-data.php:866
-msgid "settings_pickup_locations_map"
+msgid "settings_pickup_locations_default_view_map"
 msgstr ""
 
 #: includes/admin/settings/class-wcmp-settings-data.php:870
-msgid "settings_pickup_locations_list"
+msgid "settings_pickup_locations_default_view_list"
 msgstr ""
 
 #: includes/admin/settings/class-wcmp-settings-data.php:879


### PR DESCRIPTION
Added a list (select) with 'map' and 'list' in the settings checkout settings tab below 'show prices as', default 'map'
added method getPickupLocationsDefaultView() in class-wcmp-checkout to yield this value
translation strings added in google sheet: settings_pickup_locations_default_view, settings_pickup_locations_map, settings_pickup_locations_list