### PR TITLE
feat: Display product country of origin as list, default settings cou…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "myparcelnl/sdk",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/sdk.git",
-                "reference": "7ebc6cbd6c5a19ce476a63b5bb4537b919497e43"
+                "reference": "9df9ab9f636a1ac7d29ab759d6ba0e0a278ebebd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/sdk/zipball/7ebc6cbd6c5a19ce476a63b5bb4537b919497e43",
-                "reference": "7ebc6cbd6c5a19ce476a63b5bb4537b919497e43",
+                "url": "https://api.github.com/repos/myparcelnl/sdk/zipball/9df9ab9f636a1ac7d29ab759d6ba0e0a278ebebd",
+                "reference": "9df9ab9f636a1ac7d29ab759d6ba0e0a278ebebd",
                 "shasum": ""
             },
             "require": {
@@ -65,7 +65,11 @@
                 "myparcel",
                 "postnl"
             ],
-            "time": "2021-02-22T09:40:03+00:00"
+            "support": {
+                "issues": "https://github.com/myparcelnl/sdk/issues",
+                "source": "https://github.com/myparcelnl/sdk/tree/v5.2.9"
+            },
+            "time": "2021-03-30T14:51:52+00:00"
         }
     ],
     "packages-dev": [],
@@ -76,5 +80,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -698,27 +698,22 @@ class WCMYPA_Admin
     {
         echo '<div class="options_group">';
         foreach ($this->getProductOptions() as $productOption) {
-            if ($productOption['type'] === 'text') {
+            $type = $productOption["type"];
+            if ("text" === $type) {
                 woocommerce_wp_text_input(
                     [
-                        'id'          => $productOption['id'],
-                        'label'       => $productOption['label'],
-                        'description' => $productOption['description'],
+                        "id"          => $productOption["id"],
+                        "label"       => $productOption["label"],
+                        "description" => $productOption["description"],
                     ]
                 );
-            }
-
-            if ($productOption['type'] === 'select') {
+            } elseif ("select" === $type) {
                 woocommerce_wp_select(
                     [
-                        'id'          => $productOption['id'],
-                        'label'       => $productOption['label'],
-                        'options' => [
-                            null                           => __("Default", "woocommerce-myparcel"),
-                            self::PRODUCT_OPTIONS_DISABLED => __("Disabled", "woocommerce-myparcel"),
-                            self::PRODUCT_OPTIONS_ENABLED  => __("Enabled", "woocommerce-myparcel"),
-                        ],
-                        'description' => $productOption['description'],
+                        "id"          => $productOption["id"],
+                        "label"       => $productOption["label"],
+                        "options"     => $productOption["options"],
+                        "description" => $productOption["description"],
                     ]
                 );
             }
@@ -815,18 +810,26 @@ class WCMYPA_Admin
             ],
             'Country-of-origin' => [
                 'id'          => self::META_COUNTRY_OF_ORIGIN,
-                'label'       => __('Country of origin', 'woocommerce-myparcel'),
-                'type'        => 'text',
-                'description' => wc_help_tip(__('Country of origin is required for world shipments. Defaults to shop base.', 'woocommerce-myparcel')),
+                'label'       => __('country_of_origin', 'woocommerce-myparcel'),
+                'type'        => 'select',
+                'options'     => array_merge(
+                    [
+                      null => __("Default", "woocommerce-myparcel"),
+                    ],
+                    (new WC_Countries())->get_countries()
+                ),
+                'description' => wc_help_tip(
+                    __('setting_country_of_origin_help_text', 'woocommerce-myparcel')
+                ),
             ],
             'Age-check'         => [
                 'id'          => self::META_AGE_CHECK,
                 'label'       => __('shipment_options_age_check', 'woocommerce-myparcel'),
                 'type'        => 'select',
                 'options'     => [
-                    'Default',
-                    'Enabled',
-                    'Disabled',
+                    null                           => __("Default", "woocommerce-myparcel"),
+                    self::PRODUCT_OPTIONS_DISABLED => __("Disabled", "woocommerce-myparcel"),
+                    self::PRODUCT_OPTIONS_ENABLED  => __("Enabled", "woocommerce-myparcel"),
                 ],
                 'description' => wc_help_tip(__('shipment_options_age_check_help_text', 'woocommerce-myparcel')),
             ],

--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -698,22 +698,22 @@ class WCMYPA_Admin
     {
         echo '<div class="options_group">';
         foreach ($this->getProductOptions() as $productOption) {
-            $type = $productOption["type"];
-            if ("text" === $type) {
+            $type = $productOption['type'];
+            if ('text' === $type) {
                 woocommerce_wp_text_input(
                     [
-                        "id"          => $productOption["id"],
-                        "label"       => $productOption["label"],
-                        "description" => $productOption["description"],
+                        'id'          => $productOption['id'],
+                        'label'       => $productOption['label'],
+                        'description' => $productOption['description'],
                     ]
                 );
-            } elseif ("select" === $type) {
+            } elseif ('select' === $type) {
                 woocommerce_wp_select(
                     [
-                        "id"          => $productOption["id"],
-                        "label"       => $productOption["label"],
-                        "options"     => $productOption["options"],
-                        "description" => $productOption["description"],
+                        'id'          => $productOption['id'],
+                        'label'       => $productOption['label'],
+                        'options'     => $productOption['options'],
+                        'description' => $productOption['description'],
                     ]
                 );
             }
@@ -810,11 +810,11 @@ class WCMYPA_Admin
             ],
             'Country-of-origin' => [
                 'id'          => self::META_COUNTRY_OF_ORIGIN,
-                'label'       => __('country_of_origin', 'woocommerce-myparcel'),
+                'label'       => __('product_options_country_of_origin', 'woocommerce-myparcel'),
                 'type'        => 'select',
                 'options'     => array_merge(
                     [
-                      null => __("Default", "woocommerce-myparcel"),
+                      null => __('Default', 'woocommerce-myparcel'),
                     ],
                     (new WC_Countries())->get_countries()
                 ),
@@ -827,9 +827,9 @@ class WCMYPA_Admin
                 'label'       => __('shipment_options_age_check', 'woocommerce-myparcel'),
                 'type'        => 'select',
                 'options'     => [
-                    null                           => __("Default", "woocommerce-myparcel"),
-                    self::PRODUCT_OPTIONS_DISABLED => __("Disabled", "woocommerce-myparcel"),
-                    self::PRODUCT_OPTIONS_ENABLED  => __("Enabled", "woocommerce-myparcel"),
+                    null                           => __('Default', 'woocommerce-myparcel'),
+                    self::PRODUCT_OPTIONS_DISABLED => __('Disabled', 'woocommerce-myparcel'),
+                    self::PRODUCT_OPTIONS_ENABLED  => __('Enabled', 'woocommerce-myparcel'),
                 ],
                 'description' => wc_help_tip(__('shipment_options_age_check_help_text', 'woocommerce-myparcel')),
             ],

--- a/includes/admin/settings/class-wcmp-settings-data.php
+++ b/includes/admin/settings/class-wcmp-settings-data.php
@@ -716,12 +716,14 @@ class WCMP_Settings_Data
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_COUNTRY_OF_ORIGIN,
-                "label"     => __("Default country of origin", "woocommerce-myparcel"),
+                "label"     => __("setting_country_of_origin_default", "woocommerce-myparcel"),
                 "type"      => "select",
                 "options"   => (new WC_Countries())->get_countries(),
+                "default"   => (new WC_Countries())->get_base_country(),
                 "help-text" => __(
-                  "Country of origin is required for world shipments. Defaults to shop base or NL. Example: 'NL', 'BE', 'DE'", "woocommerce-myparcel"
-              ),
+                    "setting_country_of_origin_help_text",
+                    "woocommerce-myparcel"
+                ),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT,

--- a/includes/admin/settings/class-wcmp-settings-data.php
+++ b/includes/admin/settings/class-wcmp-settings-data.php
@@ -715,14 +715,14 @@ class WCMP_Settings_Data
                 ],
             ],
             [
-                "name"      => WCMYPA_Settings::SETTING_COUNTRY_OF_ORIGIN,
-                "label"     => __("setting_country_of_origin_default", "woocommerce-myparcel"),
-                "type"      => "select",
-                "options"   => (new WC_Countries())->get_countries(),
-                "default"   => (new WC_Countries())->get_base_country(),
-                "help-text" => __(
-                    "setting_country_of_origin_help_text",
-                    "woocommerce-myparcel"
+                'name'      => WCMYPA_Settings::SETTING_COUNTRY_OF_ORIGIN,
+                'label'     => __('setting_country_of_origin', 'woocommerce-myparcel'),
+                'type'      => 'select',
+                'options'   => (new WC_Countries())->get_countries(),
+                'default'   => (new WC_Countries())->get_base_country(),
+                'help-text' => __(
+                    'setting_country_of_origin_help_text',
+                    'woocommerce-myparcel'
                 ),
             ],
             [

--- a/languages/woocommerce-myparcel-en_GB.po
+++ b/languages/woocommerce-myparcel-en_GB.po
@@ -147,6 +147,15 @@ msgstr ""
 msgid "weight"
 msgstr "Weight"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locations default view"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Map"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "List"
+
 msgid "(Unknown)"
 msgstr "(Unknown)"
 
@@ -263,15 +272,11 @@ msgstr "Connect customer email"
 msgid "Connect customer phone"
 msgstr "Connect customer phone"
 
-msgid "Country of origin"
+msgid "country_of_origin"
 msgstr "Country of origin"
 
-msgid ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
-msgstr ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
+msgid "setting_country_of_origin_help_text"
+msgstr "Country of origin is required for world shipments. Defaults to shop base."
 
 msgid "Custom ID (top left on label)"
 msgstr "Custom ID (top left on label)"
@@ -297,7 +302,7 @@ msgstr "Days of the week on which you hand over parcels to PostNL"
 msgid "Default"
 msgstr "Default"
 
-msgid "Default country of origin"
+msgid "setting_country_of_origin_default"
 msgstr "Default country of origin"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-en_GB.po
+++ b/languages/woocommerce-myparcel-en_GB.po
@@ -272,7 +272,7 @@ msgstr "Connect customer email"
 msgid "Connect customer phone"
 msgstr "Connect customer phone"
 
-msgid "country_of_origin"
+msgid "product_options_country_of_origin"
 msgstr "Country of origin"
 
 msgid "setting_country_of_origin_help_text"
@@ -302,7 +302,7 @@ msgstr "Days of the week on which you hand over parcels to PostNL"
 msgid "Default"
 msgstr "Default"
 
-msgid "setting_country_of_origin_default"
+msgid "setting_country_of_origin"
 msgstr "Default country of origin"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-en_US.po
+++ b/languages/woocommerce-myparcel-en_US.po
@@ -273,7 +273,7 @@ msgstr "Connect customer email"
 msgid "Connect customer phone"
 msgstr "Connect customer phone"
 
-msgid "country_of_origin"
+msgid "product_options_country_of_origin"
 msgstr "Country of origin"
 
 msgid "setting_country_of_origin_help_text"
@@ -303,7 +303,7 @@ msgstr "Days of the week on which you hand over parcels to PostNL"
 msgid "Default"
 msgstr "Default"
 
-msgid "setting_country_of_origin_default"
+msgid "setting_country_of_origin"
 msgstr "Default country of origin"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-en_US.po
+++ b/languages/woocommerce-myparcel-en_US.po
@@ -147,6 +147,15 @@ msgstr ""
 msgid "weight"
 msgstr "Weight"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locations default view"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Map"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "List"
+
 msgid "(Unknown)"
 msgstr "(Unknown)"
 
@@ -264,15 +273,11 @@ msgstr "Connect customer email"
 msgid "Connect customer phone"
 msgstr "Connect customer phone"
 
-msgid "Country of origin"
+msgid "country_of_origin"
 msgstr "Country of origin"
 
-msgid ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
-msgstr ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
+msgid "setting_country_of_origin_help_text"
+msgstr "Country of origin is required for world shipments. Defaults to shop base."
 
 msgid "Custom ID (top left on label)"
 msgstr "Custom ID (top left on label)"
@@ -298,7 +303,7 @@ msgstr "Days of the week on which you hand over parcels to PostNL"
 msgid "Default"
 msgstr "Default"
 
-msgid "Default country of origin"
+msgid "setting_country_of_origin_default"
 msgstr "Default country of origin"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -41,7 +41,7 @@ msgid "insured"
 msgstr "Assuré"
 
 msgid "insured_amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "insured_for"
 msgstr "Montant assuré"
@@ -89,7 +89,7 @@ msgstr ""
 "combinée avec la livraison le matin ou le soir."
 
 msgid "shipment_options_insured"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid "shipment_options_insured_amount"
 msgstr "Max montant assuré"
@@ -153,6 +153,15 @@ msgstr ""
 msgid "weight"
 msgstr "Poids"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Lieux de ramassage vue défaut"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Carte"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Liste"
+
 msgid "(Unknown)"
 msgstr "(Inconnu)"
 
@@ -197,7 +206,7 @@ msgid "Ask for print start position"
 msgstr "Demander la position de démarrage de l'impression"
 
 msgid "Automatic export"
-msgstr "exportation automatique"
+msgstr "Exportation automatique"
 
 msgid ""
 "Automatically set order status to a predefined status after successful "
@@ -272,15 +281,13 @@ msgstr "Associer l'adresse e-mail du client"
 msgid "Connect customer phone"
 msgstr "Associer le numéro de téléphone du client"
 
-msgid "Country of origin"
+msgid "country_of_origin"
 msgstr "Pays d'origine"
 
-msgid ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
+msgid "setting_country_of_origin_help_text"
 msgstr ""
 "Pays d'origine est requis pour les envois du monde. Par défaut pour faire "
-"du shopping base ou NL. Exemple: 'NL', 'BE', 'DE'"
+"du shopping base."
 
 msgid "Custom ID (top left on label)"
 msgstr "ID personnalisés (en haut à gauche sur l'étiquette)"
@@ -306,8 +313,8 @@ msgstr "Jours de la semaine où vous la main sur les colis à PostNL"
 msgid "Default"
 msgstr "Défaut"
 
-msgid "Default country of origin"
-msgstr "pays d'origine par défaut"
+msgid "setting_country_of_origin_default"
+msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"
 msgstr "Paramètres d'exportation standards"
@@ -316,7 +323,7 @@ msgid "Default HS Code"
 msgstr "Par défaut Code SH"
 
 msgid "Default weight of your empty parcel."
-msgstr "poids par défaut de votre colis vide."
+msgstr "Poids par défaut de votre colis vide."
 
 msgid "delivered - at recipient"
 msgstr "livré - chez le destinataire"
@@ -352,7 +359,7 @@ msgid "Diagnostic tools"
 msgstr "Outils de diagnostic"
 
 msgid "Digital stamp"
-msgstr "timbre numérique"
+msgstr "Timbre numérique"
 
 msgid "Disabled"
 msgstr "désactivé"
@@ -456,7 +463,7 @@ msgid "Hide this message"
 msgstr "Masquez ce message"
 
 msgid "Home address only"
-msgstr "qu'adresse du domicile"
+msgstr "Qu'adresse du domicile"
 
 msgid "Home address only title"
 msgstr "Adresse du domicile seul titre"
@@ -522,7 +529,7 @@ msgid "inactive - unknown"
 msgstr "inactif - inconnu"
 
 msgid "Insurance amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "Insure all orders that exceed this price point."
 msgstr "Assurer toutes les commandes qui dépassent ce prix."
@@ -537,7 +544,7 @@ msgid "Insured for"
 msgstr "Montant assuré"
 
 msgid "Insured shipment"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -576,7 +583,7 @@ msgid "Max insured amount"
 msgstr "Max montant assuré"
 
 msgid "Monday delivery"
-msgstr "livraison lundi"
+msgstr "Livraison lundi"
 
 msgid "Morning delivery"
 msgstr "Livraison le matin"
@@ -1006,7 +1013,7 @@ msgid "You can track your order with the following Track & Trace link:"
 msgstr "Vous pouvez suivre votre commande via le code Track & Trace suivant :"
 
 msgid "You do not have sufficient permissions to access this page."
-msgstr "Vous n'avez pas les droits suffisants pour accéder à cette page."
+msgstr "Vous n'avez pas les droits suffisants pour acc��der à cette page."
 
 msgid "You have not selected any orders!"
 msgstr "Vous n'avez sélectionné aucune commande !"

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -281,7 +281,7 @@ msgstr "Associer l'adresse e-mail du client"
 msgid "Connect customer phone"
 msgstr "Associer le numéro de téléphone du client"
 
-msgid "country_of_origin"
+msgid "product_options_country_of_origin"
 msgstr "Pays d'origine"
 
 msgid "setting_country_of_origin_help_text"
@@ -313,7 +313,7 @@ msgstr "Jours de la semaine où vous la main sur les colis à PostNL"
 msgid "Default"
 msgstr "Défaut"
 
-msgid "setting_country_of_origin_default"
+msgid "setting_country_of_origin"
 msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"
@@ -1013,7 +1013,7 @@ msgid "You can track your order with the following Track & Trace link:"
 msgstr "Vous pouvez suivre votre commande via le code Track & Trace suivant :"
 
 msgid "You do not have sufficient permissions to access this page."
-msgstr "Vous n'avez pas les droits suffisants pour acc��der à cette page."
+msgstr "Vous n'avez pas les droits suffisants pour accéder à cette page."
 
 msgid "You have not selected any orders!"
 msgstr "Vous n'avez sélectionné aucune commande !"

--- a/languages/woocommerce-myparcel-fr_FR.po
+++ b/languages/woocommerce-myparcel-fr_FR.po
@@ -41,7 +41,7 @@ msgid "insured"
 msgstr "Assuré"
 
 msgid "insured_amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "insured_for"
 msgstr "Montant assuré"
@@ -89,7 +89,7 @@ msgstr ""
 "combinée avec la livraison le matin ou le soir."
 
 msgid "shipment_options_insured"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid "shipment_options_insured_amount"
 msgstr "Max montant assuré"
@@ -153,6 +153,15 @@ msgstr ""
 msgid "weight"
 msgstr "Poids"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Lieux de ramassage vue défaut"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Carte"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Liste"
+
 msgid "(Unknown)"
 msgstr "(Inconnu)"
 
@@ -197,7 +206,7 @@ msgid "Ask for print start position"
 msgstr "Demander la position de démarrage de l'impression"
 
 msgid "Automatic export"
-msgstr "exportation automatique"
+msgstr "Exportation automatique"
 
 msgid ""
 "Automatically set order status to a predefined status after successful "
@@ -272,15 +281,13 @@ msgstr "Associer l'adresse e-mail du client"
 msgid "Connect customer phone"
 msgstr "Associer le numéro de téléphone du client"
 
-msgid "Country of origin"
+msgid "country_of_origin"
 msgstr "Pays d'origine"
 
-msgid ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
+msgid "setting_country_of_origin_help_text"
 msgstr ""
 "Pays d'origine est requis pour les envois du monde. Par défaut pour faire "
-"du shopping base ou NL. Exemple: 'NL', 'BE', 'DE'"
+"du shopping base."
 
 msgid "Custom ID (top left on label)"
 msgstr "ID personnalisés (en haut à gauche sur l'étiquette)"
@@ -306,8 +313,8 @@ msgstr "Jours de la semaine où vous la main sur les colis à PostNL"
 msgid "Default"
 msgstr "Défaut"
 
-msgid "Default country of origin"
-msgstr "pays d'origine par défaut"
+msgid "setting_country_of_origin_default"
+msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"
 msgstr "Paramètres d'exportation standards"
@@ -316,7 +323,7 @@ msgid "Default HS Code"
 msgstr "Par défaut Code SH"
 
 msgid "Default weight of your empty parcel."
-msgstr "poids par défaut de votre colis vide."
+msgstr "Poids par défaut de votre colis vide."
 
 msgid "delivered - at recipient"
 msgstr "livré - chez le destinataire"
@@ -352,7 +359,7 @@ msgid "Diagnostic tools"
 msgstr "Outils de diagnostic"
 
 msgid "Digital stamp"
-msgstr "timbre numérique"
+msgstr "Timbre numérique"
 
 msgid "Disabled"
 msgstr "désactivé"
@@ -456,7 +463,7 @@ msgid "Hide this message"
 msgstr "Masquez ce message"
 
 msgid "Home address only"
-msgstr "qu'adresse du domicile"
+msgstr "Qu'adresse du domicile"
 
 msgid "Home address only title"
 msgstr "Adresse du domicile seul titre"
@@ -522,7 +529,7 @@ msgid "inactive - unknown"
 msgstr "inactif - inconnu"
 
 msgid "Insurance amount"
-msgstr "montant d'assurance"
+msgstr "Montant d'assurance"
 
 msgid "Insure all orders that exceed this price point."
 msgstr "Assurer toutes les commandes qui dépassent ce prix."
@@ -537,7 +544,7 @@ msgid "Insured for"
 msgstr "Montant assuré"
 
 msgid "Insured shipment"
-msgstr "expédition assuré"
+msgstr "Expédition assuré"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -576,7 +583,7 @@ msgid "Max insured amount"
 msgstr "Max montant assuré"
 
 msgid "Monday delivery"
-msgstr "livraison lundi"
+msgstr "Livraison lundi"
 
 msgid "Morning delivery"
 msgstr "Livraison le matin"
@@ -820,7 +827,7 @@ msgid ""
 msgstr ""
 "Les options de livraison MyParcel permettent à vos clients de choisir s’ils "
 "souhaitent que leur colis soit livré à domicile ou à un point de retrait. "
-"En fonction des param��tres, vous pouvez leur permettre de sélectionner une "
+"En fonction des paramètres, vous pouvez leur permettre de sélectionner une "
 "date, une heure et même des options telles que la signature d'une signature."
 
 msgid "The order(s) you have selected have invalid shipping countries."

--- a/languages/woocommerce-myparcel-fr_FR.po
+++ b/languages/woocommerce-myparcel-fr_FR.po
@@ -281,7 +281,7 @@ msgstr "Associer l'adresse e-mail du client"
 msgid "Connect customer phone"
 msgstr "Associer le numéro de téléphone du client"
 
-msgid "country_of_origin"
+msgid "product_options_country_of_origin"
 msgstr "Pays d'origine"
 
 msgid "setting_country_of_origin_help_text"
@@ -313,7 +313,7 @@ msgstr "Jours de la semaine où vous la main sur les colis à PostNL"
 msgid "Default"
 msgstr "Défaut"
 
-msgid "setting_country_of_origin_default"
+msgid "setting_country_of_origin"
 msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-nl_BE.po
+++ b/languages/woocommerce-myparcel-nl_BE.po
@@ -149,6 +149,15 @@ msgstr ""
 msgid "weight"
 msgstr "Gewicht"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locaties standaard weergave"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Kaart"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Lijst"
+
 msgid "(Unknown)"
 msgstr "(Onbekend)"
 
@@ -264,15 +273,13 @@ msgstr "Koppel e-mailadres klant"
 msgid "Connect customer phone"
 msgstr "Koppel telefoonnummer klant"
 
-msgid "Country of origin"
+msgid "country_of_origin"
 msgstr "Land van herkomst"
 
-msgid ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
+msgid "setting_country_of_origin_help_text"
 msgstr ""
 "Land van herkomst is verplicht voor wereldzendingen. Standaard wordt de "
-"shoplocatie gebruikt. Voorbeeld: 'NL', 'BE', 'DE'"
+"shoplocatie gebruikt."
 
 msgid "Custom ID (top left on label)"
 msgstr "Aangepast ID (linksboven op label)"
@@ -298,7 +305,7 @@ msgstr "Dagen van de week waarop je je pakket afgeeft bij PostNL"
 msgid "Default"
 msgstr "Standaard"
 
-msgid "Default country of origin"
+msgid "setting_country_of_origin_default"
 msgstr "Standaard land van herkomst"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-nl_BE.po
+++ b/languages/woocommerce-myparcel-nl_BE.po
@@ -273,7 +273,7 @@ msgstr "Koppel e-mailadres klant"
 msgid "Connect customer phone"
 msgstr "Koppel telefoonnummer klant"
 
-msgid "country_of_origin"
+msgid "product_options_country_of_origin"
 msgstr "Land van herkomst"
 
 msgid "setting_country_of_origin_help_text"
@@ -305,7 +305,7 @@ msgstr "Dagen van de week waarop je je pakket afgeeft bij PostNL"
 msgid "Default"
 msgstr "Standaard"
 
-msgid "setting_country_of_origin_default"
+msgid "setting_country_of_origin"
 msgstr "Standaard land van herkomst"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-nl_NL.po
+++ b/languages/woocommerce-myparcel-nl_NL.po
@@ -149,6 +149,15 @@ msgstr ""
 msgid "weight"
 msgstr "Gewicht"
 
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locaties standaard weergave"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Kaart"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Lijst"
+
 msgid "(Unknown)"
 msgstr "(Onbekend)"
 
@@ -264,15 +273,13 @@ msgstr "Koppel e-mailadres klant"
 msgid "Connect customer phone"
 msgstr "Koppel telefoonnummer klant"
 
-msgid "Country of origin"
+msgid "country_of_origin"
 msgstr "Land van herkomst"
 
-msgid ""
-"Country of origin is required for world shipments. Defaults to shop base or "
-"NL. Example: 'NL', 'BE', 'DE'"
+msgid "setting_country_of_origin_help_text"
 msgstr ""
 "Land van herkomst is verplicht voor wereldzendingen. Standaard wordt de "
-"shoplocatie gebruikt. Voorbeeld: 'NL', 'BE', 'DE'"
+"shoplocatie gebruikt."
 
 msgid "Custom ID (top left on label)"
 msgstr "Aangepast ID (linksboven op label)"
@@ -298,7 +305,7 @@ msgstr "Dagen van de week waarop je je pakket afgeeft bij PostNL"
 msgid "Default"
 msgstr "Standaard"
 
-msgid "Default country of origin"
+msgid "setting_country_of_origin_default"
 msgstr "Standaard land van herkomst"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel-nl_NL.po
+++ b/languages/woocommerce-myparcel-nl_NL.po
@@ -273,7 +273,7 @@ msgstr "Koppel e-mailadres klant"
 msgid "Connect customer phone"
 msgstr "Koppel telefoonnummer klant"
 
-msgid "country_of_origin"
+msgid "product_options_country_of_origin"
 msgstr "Land van herkomst"
 
 msgid "setting_country_of_origin_help_text"
@@ -305,7 +305,7 @@ msgstr "Dagen van de week waarop je je pakket afgeeft bij PostNL"
 msgid "Default"
 msgstr "Standaard"
 
-msgid "setting_country_of_origin_default"
+msgid "setting_country_of_origin"
 msgstr "Standaard land van herkomst"
 
 msgid "Default export settings"

--- a/languages/woocommerce-myparcel.pot
+++ b/languages/woocommerce-myparcel.pot
@@ -292,10 +292,10 @@ msgid "HS Codes are used for MyParcel world shipments, you can find the appropri
 msgstr ""
 
 #: includes/admin/class-wcmypa-admin.php:813
-msgid "country_of_origin"
+msgid "product_options_country_of_origin"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:817, includes/admin/class-wcmypa-admin.php:838
+#: includes/admin/class-wcmypa-admin.php:817, includes/admin/class-wcmypa-admin.php:830
 msgid "Default"
 msgstr ""
 
@@ -303,51 +303,51 @@ msgstr ""
 msgid "setting_country_of_origin_help_text"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:830, includes/admin/OrderSettingsRows.php:241, includes/admin/settings/class-wcmp-settings-data.php:450
+#: includes/admin/class-wcmypa-admin.php:827, includes/admin/OrderSettingsRows.php:241, includes/admin/settings/class-wcmp-settings-data.php:450
 msgid "shipment_options_age_check"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:839, includes/entities/settings-field-arguments.php:170
+#: includes/admin/class-wcmypa-admin.php:831, includes/entities/settings-field-arguments.php:170
 msgid "Disabled"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:840, includes/entities/settings-field-arguments.php:169
+#: includes/admin/class-wcmypa-admin.php:832, includes/entities/settings-field-arguments.php:169
 msgid "Enabled"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:842, includes/admin/OrderSettingsRows.php:242, includes/admin/settings/class-wcmp-settings-data.php:452
+#: includes/admin/class-wcmypa-admin.php:834, includes/admin/OrderSettingsRows.php:242, includes/admin/settings/class-wcmp-settings-data.php:452
 msgid "shipment_options_age_check_help_text"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:885
+#: includes/admin/class-wcmypa-admin.php:877
 msgid "No label has been created yet."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:896
+#: includes/admin/class-wcmypa-admin.php:888
 msgid "The label has been printed."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:901
+#: includes/admin/class-wcmypa-admin.php:893
 msgid "Concept created but not printed."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:968
+#: includes/admin/class-wcmypa-admin.php:960
 msgid "MyParcel shipment:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:997, includes/admin/class-wcmypa-admin.php:1010
+#: includes/admin/class-wcmypa-admin.php:989, includes/admin/class-wcmypa-admin.php:1002
 msgid "delivery_type"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:998
+#: includes/admin/class-wcmypa-admin.php:990
 msgid "pickup_location"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:1055, includes/admin/class-wcmypa-admin.php:1077
+#: includes/admin/class-wcmypa-admin.php:1047, includes/admin/class-wcmypa-admin.php:1069
 msgid "Delivery information:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:1183
+#: includes/admin/class-wcmypa-admin.php:1175
 msgid "(Unknown)"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgid "Return shipment"
 msgstr ""
 
 #: includes/admin/settings/class-wcmp-settings-data.php:719
-msgid "setting_country_of_origin_default"
+msgid "setting_country_of_origin"
 msgstr ""
 
 #: includes/admin/settings/class-wcmp-settings-data.php:730

--- a/languages/woocommerce-myparcel.pot
+++ b/languages/woocommerce-myparcel.pot
@@ -51,19 +51,19 @@ msgstr ""
 msgid "Digital stamp"
 msgstr ""
 
-#: includes/class-wcmp-data.php:95, includes/admin/settings/class-wcmp-settings-data.php:541, includes/admin/settings/class-wcmp-settings-data.php:915
+#: includes/class-wcmp-data.php:95, includes/admin/settings/class-wcmp-settings-data.php:541, includes/admin/settings/class-wcmp-settings-data.php:917
 msgid "Morning delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:96, includes/admin/settings/class-wcmp-settings-data.php:925
+#: includes/class-wcmp-data.php:96, includes/admin/settings/class-wcmp-settings-data.php:927
 msgid "Standard delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:97, includes/admin/settings/class-wcmp-settings-data.php:554, includes/admin/settings/class-wcmp-settings-data.php:931
+#: includes/class-wcmp-data.php:97, includes/admin/settings/class-wcmp-settings-data.php:554, includes/admin/settings/class-wcmp-settings-data.php:933
 msgid "Evening delivery"
 msgstr ""
 
-#: includes/class-wcmp-data.php:98, includes/admin/settings/class-wcmp-settings-data.php:949
+#: includes/class-wcmp-data.php:98, includes/admin/settings/class-wcmp-settings-data.php:951
 msgid "Pickup"
 msgstr ""
 
@@ -283,71 +283,71 @@ msgstr ""
 msgid "MyParcel"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:717
-msgid "Default"
-msgstr ""
-
-#: includes/admin/class-wcmypa-admin.php:718, includes/entities/settings-field-arguments.php:170
-msgid "Disabled"
-msgstr ""
-
-#: includes/admin/class-wcmypa-admin.php:719, includes/entities/settings-field-arguments.php:169
-msgid "Enabled"
-msgstr ""
-
-#: includes/admin/class-wcmypa-admin.php:803
+#: includes/admin/class-wcmypa-admin.php:798
 msgid "HS Code"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:807
+#: includes/admin/class-wcmypa-admin.php:802
 msgid "HS Codes are used for MyParcel world shipments, you can find the appropriate code on the %ssite of the Dutch Customs%s"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:818
-msgid "Country of origin"
+#: includes/admin/class-wcmypa-admin.php:813
+msgid "country_of_origin"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:820
-msgid "Country of origin is required for world shipments. Defaults to shop base."
+#: includes/admin/class-wcmypa-admin.php:817, includes/admin/class-wcmypa-admin.php:838
+msgid "Default"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:824, includes/admin/OrderSettingsRows.php:241, includes/admin/settings/class-wcmp-settings-data.php:450
+#: includes/admin/class-wcmypa-admin.php:822, includes/admin/settings/class-wcmp-settings-data.php:723
+msgid "setting_country_of_origin_help_text"
+msgstr ""
+
+#: includes/admin/class-wcmypa-admin.php:830, includes/admin/OrderSettingsRows.php:241, includes/admin/settings/class-wcmp-settings-data.php:450
 msgid "shipment_options_age_check"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:831, includes/admin/OrderSettingsRows.php:242, includes/admin/settings/class-wcmp-settings-data.php:452
+#: includes/admin/class-wcmypa-admin.php:839, includes/entities/settings-field-arguments.php:170
+msgid "Disabled"
+msgstr ""
+
+#: includes/admin/class-wcmypa-admin.php:840, includes/entities/settings-field-arguments.php:169
+msgid "Enabled"
+msgstr ""
+
+#: includes/admin/class-wcmypa-admin.php:842, includes/admin/OrderSettingsRows.php:242, includes/admin/settings/class-wcmp-settings-data.php:452
 msgid "shipment_options_age_check_help_text"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:874
+#: includes/admin/class-wcmypa-admin.php:885
 msgid "No label has been created yet."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:885
+#: includes/admin/class-wcmypa-admin.php:896
 msgid "The label has been printed."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:890
+#: includes/admin/class-wcmypa-admin.php:901
 msgid "Concept created but not printed."
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:957
+#: includes/admin/class-wcmypa-admin.php:968
 msgid "MyParcel shipment:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:986, includes/admin/class-wcmypa-admin.php:999
+#: includes/admin/class-wcmypa-admin.php:997, includes/admin/class-wcmypa-admin.php:1010
 msgid "delivery_type"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:987
+#: includes/admin/class-wcmypa-admin.php:998
 msgid "pickup_location"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:1044, includes/admin/class-wcmypa-admin.php:1066
+#: includes/admin/class-wcmypa-admin.php:1055, includes/admin/class-wcmypa-admin.php:1077
 msgid "Delivery information:"
 msgstr ""
 
-#: includes/admin/class-wcmypa-admin.php:1172
+#: includes/admin/class-wcmypa-admin.php:1183
 msgid "(Unknown)"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgstr ""
 msgid "calculated_order_weight"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:215, includes/admin/settings/class-wcmp-settings-data.php:432, includes/admin/settings/class-wcmp-settings-data.php:567, includes/admin/settings/class-wcmp-settings-data.php:937, includes/admin/views/html-order-shipment-summary.php:24
+#: includes/admin/OrderSettingsRows.php:215, includes/admin/settings/class-wcmp-settings-data.php:432, includes/admin/settings/class-wcmp-settings-data.php:567, includes/admin/settings/class-wcmp-settings-data.php:939, includes/admin/views/html-order-shipment-summary.php:24
 msgid "shipment_options_only_recipient"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "shipment_options_only_recipient_help_text"
 msgstr ""
 
-#: includes/admin/OrderSettingsRows.php:228, includes/admin/settings/class-wcmp-settings-data.php:438, includes/admin/settings/class-wcmp-settings-data.php:580, includes/admin/settings/class-wcmp-settings-data.php:943, includes/admin/views/html-order-shipment-summary.php:23
+#: includes/admin/OrderSettingsRows.php:228, includes/admin/settings/class-wcmp-settings-data.php:438, includes/admin/settings/class-wcmp-settings-data.php:580, includes/admin/settings/class-wcmp-settings-data.php:945, includes/admin/views/html-order-shipment-summary.php:23
 msgid "shipment_options_signature"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "Amount of days a customer can postpone a shipment. Default is 0 days with a maximum value of 14 days."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:582, includes/admin/settings/class-wcmp-settings-data.php:1017
+#: includes/admin/settings/class-wcmp-settings-data.php:582, includes/admin/settings/class-wcmp-settings-data.php:1019
 msgid "Enter an amount that is either positive or negative. For example, do you want to give a discount for using this function or do you want to charge extra for this delivery option."
 msgstr ""
 
@@ -776,194 +776,190 @@ msgid "Return shipment"
 msgstr ""
 
 #: includes/admin/settings/class-wcmp-settings-data.php:719
-msgid "Default country of origin"
-msgstr ""
-
-#: includes/admin/settings/class-wcmp-settings-data.php:722
-msgid "Country of origin is required for world shipments. Defaults to shop base or NL. Example: 'NL', 'BE', 'DE'"
-msgstr ""
-
-#: includes/admin/settings/class-wcmp-settings-data.php:728
-msgid "Automatic export"
+msgid "setting_country_of_origin_default"
 msgstr ""
 
 #: includes/admin/settings/class-wcmp-settings-data.php:730
+msgid "Automatic export"
+msgstr ""
+
+#: includes/admin/settings/class-wcmp-settings-data.php:732
 msgid "With this setting enabled orders are exported to MyParcel automatically after payment."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:760
+#: includes/admin/settings/class-wcmp-settings-data.php:762
 msgid "MyParcel address fields"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:762
+#: includes/admin/settings/class-wcmp-settings-data.php:764
 msgid "When enabled the checkout will use the MyParcel address fields. This means there will be three separate fields for street name, number and suffix. Want to use the WooCommerce default fields? Leave this option unchecked."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:769
+#: includes/admin/settings/class-wcmp-settings-data.php:771
 msgid "Show delivery date"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:771
+#: includes/admin/settings/class-wcmp-settings-data.php:773
 msgid "Show delivery day options allow your customers to see the delivery day in order confirmation and My Account."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:778
+#: includes/admin/settings/class-wcmp-settings-data.php:780
 msgid "Enable MyParcel delivery options"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:780
+#: includes/admin/settings/class-wcmp-settings-data.php:782
 msgid "The MyParcel delivery options allow your customers to select whether they want their parcel delivered at home or to a pickup point. Depending on the settings you can allow them to select a date, time and even options like requiring a signature on delivery."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:788
+#: includes/admin/settings/class-wcmp-settings-data.php:790
 msgid "Enable delivery options for backorders"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:790
+#: includes/admin/settings/class-wcmp-settings-data.php:792
 msgid "When this option is enabled, delivery options and delivery day will be also shown for backorders."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:798
+#: includes/admin/settings/class-wcmp-settings-data.php:800
 msgid "settings_checkout_display_for"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:800
+#: includes/admin/settings/class-wcmp-settings-data.php:802
 msgid "settings_checkout_display_for_help_text"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:802
+#: includes/admin/settings/class-wcmp-settings-data.php:804
 msgid "settings_checkout_display_for_selected_methods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:803
+#: includes/admin/settings/class-wcmp-settings-data.php:805
 msgid "settings_checkout_display_for_all_methods"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:809
+#: includes/admin/settings/class-wcmp-settings-data.php:811
 msgid "Checkout position"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:813
+#: includes/admin/settings/class-wcmp-settings-data.php:815
 msgid "Show after billing details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:817
+#: includes/admin/settings/class-wcmp-settings-data.php:819
 msgid "Show after shipping details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:821
+#: includes/admin/settings/class-wcmp-settings-data.php:823
 msgid "Show after customer details"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:825
+#: includes/admin/settings/class-wcmp-settings-data.php:827
 msgid "Show after notes"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:829
+#: includes/admin/settings/class-wcmp-settings-data.php:831
 msgid "Show after subtotal"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:834
+#: includes/admin/settings/class-wcmp-settings-data.php:836
 msgid "You can change the place of the delivery options on the checkout page. By default it will be placed after shipping details."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:842
+#: includes/admin/settings/class-wcmp-settings-data.php:844
 msgid "settings_checkout_price_format"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:846
+#: includes/admin/settings/class-wcmp-settings-data.php:848
 msgid "settings_checkout_total_price"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:850
+#: includes/admin/settings/class-wcmp-settings-data.php:852
 msgid "settings_checkout_surcharge"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:859
+#: includes/admin/settings/class-wcmp-settings-data.php:861
 msgid "Custom styles"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:898
+#: includes/admin/settings/class-wcmp-settings-data.php:900
 msgid "Delivery options title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:900
+#: includes/admin/settings/class-wcmp-settings-data.php:902
 msgid "You can place a delivery title above the MyParcel options. When there is no title, it will not be visible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:908
+#: includes/admin/settings/class-wcmp-settings-data.php:910
 msgid "Delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:909
+#: includes/admin/settings/class-wcmp-settings-data.php:911
 msgid "Delivered at home or at work"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:914
+#: includes/admin/settings/class-wcmp-settings-data.php:916
 msgid "Morning delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:920
+#: includes/admin/settings/class-wcmp-settings-data.php:922
 msgid "Standard delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:921
+#: includes/admin/settings/class-wcmp-settings-data.php:923
 msgid "When there is no title, the delivery time will automatically be visible."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:930
+#: includes/admin/settings/class-wcmp-settings-data.php:932
 msgid "Evening delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:936
+#: includes/admin/settings/class-wcmp-settings-data.php:938
 msgid "Home address only title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:942
+#: includes/admin/settings/class-wcmp-settings-data.php:944
 msgid "Signature on delivery title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:948
+#: includes/admin/settings/class-wcmp-settings-data.php:950
 msgid "Pickup title"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:972
+#: includes/admin/settings/class-wcmp-settings-data.php:974
 msgid "Theme \"%s\" detected."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:974
+#: includes/admin/settings/class-wcmp-settings-data.php:976
 msgid "Apply preset."
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:987
+#: includes/admin/settings/class-wcmp-settings-data.php:989
 msgid "Delivery date"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:988
+#: includes/admin/settings/class-wcmp-settings-data.php:990
 msgid "Order number"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:989
+#: includes/admin/settings/class-wcmp-settings-data.php:991
 msgid "Product id"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:990, includes/admin/views/html-send-return-email-form.php:67
+#: includes/admin/settings/class-wcmp-settings-data.php:992, includes/admin/views/html-send-return-email-form.php:67
 msgid "Product name"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:991
+#: includes/admin/settings/class-wcmp-settings-data.php:993
 msgid "Product quantity"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:992
+#: includes/admin/settings/class-wcmp-settings-data.php:994
 msgid "Product SKU"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:993
+#: includes/admin/settings/class-wcmp-settings-data.php:995
 msgid "Customer note"
 msgstr ""
 
-#: includes/admin/settings/class-wcmp-settings-data.php:1015
+#: includes/admin/settings/class-wcmp-settings-data.php:1017
 msgid "Fee (optional)"
 msgstr ""
 


### PR DESCRIPTION
…ntry of origin to wc basecountry
In class-wcmypa-admin:
Moved default list array age check to the product options array (->getProductOtions 'Age-check') where it belongs, so it doesn't override other options one might supply in ->productOptionsFields
In options array changed text to select list for country-of-origin, with default option NULL
In class-wcmypa-settings-data:
Added default base_country to country-of-origin select list so the country of the woocommerce shop will be displayed by default upon installation of the myparcel plugin.
Changed strings in translations to keys: setting_country_of_origin_help_text, setting_country_of_origin_default, country_of_origin