### PR TITLE
fix: errors about empty shipping class

### DIFF
--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -891,11 +891,7 @@ class WCMP_Export
             return null;
         }
 
-        // get shipping classes from order
-        $foundShippingClasses = $this->find_order_shipping_classes($order);
-        $highest_class = $this->getShippingClass($shippingMethod, $foundShippingClasses);
-
-        return $highest_class;
+        return $shippingMethodId;
     }
 
     /**

--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -415,20 +415,20 @@ class WCMP_Checkout
      */
     private function getShippingMethodsAllowingDeliveryOptions(): array
     {
-        $allowedMethods = [];
-        $displayFor     = WCMYPA()->setting_collection->getByName(WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_DISPLAY);
+        $allowedMethods               = [];
+        $displayFor                   = WCMYPA()->setting_collection->getByName(WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_DISPLAY);
+        $shippingMethodsByPackageType = WCMYPA()->setting_collection->getByName(WCMYPA_Settings::SETTING_SHIPPING_METHODS_PACKAGE_TYPES);
 
-        if (WCMP_Settings_Data::DISPLAY_FOR_ALL_METHODS === $displayFor) {
+        if (WCMP_Settings_Data::DISPLAY_FOR_ALL_METHODS === $displayFor || ! $shippingMethodsByPackageType) {
             return $allowedMethods;
         }
 
-        $shippingMethodsByPackageType = WCMYPA()->setting_collection->getByName(WCMYPA_Settings::SETTING_SHIPPING_METHODS_PACKAGE_TYPES);
-        $shippingMethodsForPackage    = $shippingMethodsByPackageType[AbstractConsignment::PACKAGE_TYPE_PACKAGE_NAME];
+        $shippingMethodsForPackage = $shippingMethodsByPackageType[AbstractConsignment::PACKAGE_TYPE_PACKAGE_NAME];
 
         foreach ($shippingMethodsForPackage as $shippingMethod) {
             [$methodId] = self::splitShippingMethodString($shippingMethod);
 
-            if (!in_array($methodId, WCMP_Export::DISALLOWED_SHIPPING_METHODS)) {
+            if (! in_array($methodId, WCMP_Export::DISALLOWED_SHIPPING_METHODS)) {
                 $allowedMethods[] = $shippingMethod;
             }
         }


### PR DESCRIPTION
- fix: Warning: Invalid argument supplied for foreach() on class-wcmp-checkout.php on line 428

- the method `find_order_shipping_classes` is no longer needed because the shipping class is fetched through the `getShippingMethod`