### PR TITLE
feat: choose an order status that will automatically export shipment(…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55c60685364320c33cc31c4f98f2bfdd",
+    "content-hash": "4bfd5069039e00c77337ac28f6a9e24c",
     "packages": [
         {
             "name": "myparcelnl/sdk",

--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -79,11 +79,16 @@ class WCMP_Export
      */
     public function exportByOrderId(int $orderId): void
     {
-        $automaticExport = WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT);
+        if (! $orderId) {
+            return;
+        }
 
-        if ($orderId && $automaticExport) {
-            $export = new self();
-            $export->addShipments([(string) $orderId], 0, false);
+        $order  = WCX::get_order($orderId);
+        $export = new self();
+        $return = $export->addShipments([(string) $orderId], 0, false);
+
+        if (isset($return['success'])) {
+            $order->add_order_note($return['success']);
         }
     }
 

--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -83,11 +83,10 @@ class WCMP_Export
             return;
         }
 
-        $order  = WCX::get_order($orderId);
-        $export = new self();
-        $return = $export->addShipments([(string) $orderId], 0, false);
+        $return = $this->addShipments([(string) $orderId], 0, false);
 
         if (isset($return['success'])) {
+            $order = WCX::get_order($orderId);
             $order->add_order_note($return['success']);
         }
     }

--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -230,12 +230,16 @@ class WCMYPA_Admin
      */
     public function automaticExportOrder($orderId, ?string $oldStatus = null, ?string $newStatus = null): void
     {
-        if (! WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT)){
+        if (! WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT)) {
             return;
         }
 
-        $forStatus = WCMYPA()->setting_collection->getByName(WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT_STATUS);
-        if ($forStatus === ($newStatus ?? WCMP_Settings_Data::NOT_ACTIVE)) {
+        $newStatus             = $newStatus ?? WCMP_Settings_Data::NOT_ACTIVE;
+        $automaticExportStatus = WCMYPA()->setting_collection->getByName(
+            WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT_STATUS
+        );
+
+        if ($automaticExportStatus === $newStatus) {
             (new WCMP_Export())->exportByOrderId($orderId);
         }
     }

--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -221,29 +221,23 @@ class WCMYPA_Admin
 
     /**
      * @param             $orderId
-     * @param string|null $old_status
-     * @param string|null $new_status will be passed when order status change triggers this method
+     * @param string|null $oldStatus
+     * @param string|null $newStatus will be passed when order status change triggers this method
      *
      * @throws \ErrorException
      * @throws \MyParcelNL\Sdk\src\Exception\ApiException
      * @throws \MyParcelNL\Sdk\src\Exception\MissingFieldException
      */
-    public function automaticExportOrder($orderId, ?string $old_status = null, ?string $new_status = null): void
+    public function automaticExportOrder($orderId, ?string $oldStatus = null, ?string $newStatus = null): void
     {
         if (! WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT)){
             return;
         }
 
-        $for_status = WCMYPA()->setting_collection->getByName(WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT_STATUS);
-        if (isset($new_status)) {
-            if ($new_status !== $for_status) {
-                return;
-            }
-        } elseif (WCMP_Settings_Data::NOT_ACTIVE !== $for_status) {
-            return;
+        $forStatus = WCMYPA()->setting_collection->getByName(WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT_STATUS);
+        if ($forStatus === ($newStatus ?? WCMP_Settings_Data::NOT_ACTIVE)) {
+            (new WCMP_Export())->exportByOrderId($orderId);
         }
-
-        (new WCMP_Export())->exportByOrderId($orderId);
     }
 
     /**

--- a/includes/admin/settings/class-wcmp-settings-data.php
+++ b/includes/admin/settings/class-wcmp-settings-data.php
@@ -737,6 +737,18 @@ class WCMP_Settings_Data
                     "woocommerce-myparcel"
                 ),
             ],
+            [
+                'name'      => WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT_STATUS,
+                'condition' => WCMYPA_Settings::SETTING_AUTOMATIC_EXPORT,
+                'label'     => __('setting_export_automatic_status', 'woocommerce-myparcel'),
+                'class'     => ['wcmp__child'],
+                'type'      => 'select',
+                'default'   => self::NOT_ACTIVE,
+                'options'   =>
+                    [self::NOT_ACTIVE => __('not_active', 'woocommerce-myparcel')]
+                    + WCMP_Settings_Callbacks::get_order_status_options(),
+                'help_text' => __('setting_export_automatic_status_help_text', 'woocommerce-myparcel'),
+            ],
 //            [
 //                "name"      => WCMYPA_Settings::SETTING_RETURN_IN_THE_BOX,
 //                "label"     => __("Print return label directly", "woocommerce-myparcel"),

--- a/includes/admin/settings/class-wcmypa-settings.php
+++ b/includes/admin/settings/class-wcmypa-settings.php
@@ -54,6 +54,7 @@ class WCMYPA_Settings
     public const SETTING_PACKAGE_CONTENT                = "package_contents";
     public const SETTING_COUNTRY_OF_ORIGIN              = "country_of_origin";
     public const SETTING_AUTOMATIC_EXPORT               = "export_automatic";
+    public const SETTING_AUTOMATIC_EXPORT_STATUS        = "export_automatic_status";
     public const SETTING_RETURN_IN_THE_BOX              = "return_in_the_box";
 
     /**

--- a/languages/woocommerce-myparcel-en_GB.po
+++ b/languages/woocommerce-myparcel-en_GB.po
@@ -11,178 +11,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language: en_GB\n"
 
-msgid "setting_automatic_order_status"
-msgstr "Automatic order status"
-
-msgid "setting_change_order_status_after"
-msgstr "Change order status after"
-
-msgid "setting_change_status_after_printing"
-msgstr "Printing label"
-
-msgid "setting_change_status_after_export"
-msgstr "Export order"
-
-msgid "setting_change_status_after_help_text"
-msgstr "Change the order status after export or after printing the shipping label."
-
-msgid "calculated_order_weight"
-msgstr "Calculated weight: %s"
-
-msgid "delivery_type"
-msgstr "Delivery type:"
-
-msgid "extra_options"
-msgstr "Extra options:"
-
-msgid "insured"
-msgstr "Insured"
-
-msgid "insured_amount"
-msgstr "Insurance amount"
-
-msgid "insured_for"
-msgstr "Insured for"
-
-msgid "myparcel_shipment_created"
-msgstr "MyParcel shipment created:"
-
-msgid "pickup_location"
-msgstr "Pickup location:"
-
-msgid "settings_checkout_display_for"
-msgstr "Display for"
-
-msgid "settings_checkout_display_for_all_methods"
-msgstr "All shipping methods"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"You can link the delivery options to specific shipping methods by adding "
-"them to the package types in \"Standard export settings\". The delivery "
-"options are not visible for foreign addresses."
-
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Shipping methods associated with package type"
-
-msgid "settings_checkout_price_format"
-msgstr "Show prices as"
-
-msgid "settings_checkout_surcharge"
-msgstr "Surcharge"
-
-msgid "settings_checkout_total_price"
-msgstr "Total price"
-
-msgid "shipment_options_age_check"
-msgstr "Age check 18+"
-
-msgid "shipment_options_age_check_help_text"
-msgstr ""
-"The age check is intended for parcel shipments for which the recipient must "
-"show 18+ by means of a proof of identity. The options \"Signature for "
-"receipt\" and \"Delivery only at recipient\" are included with this option. "
-"This option can't be combined with morning or evening delivery."
-
-msgid "shipment_options_insured"
-msgstr "Insured shipment"
-
-msgid "shipment_options_insured_amount"
-msgstr "Max insured amount"
-
-msgid "shipment_options_insured_amount_help_text"
-msgstr "Insure all parcels up to the selected amount."
-
-msgid "shipment_options_insured_from_price"
-msgstr "Insure from price"
-
-msgid "shipment_options_insured_from_price_help_text"
-msgstr "Insure all orders that exceed this price point."
-
-msgid "shipment_options_insured_help_text"
-msgstr ""
-"By default, there is no insurance on the shipments. If you still want to "
-"insure the shipment, you can do that. We insure the purchase value of the "
-"shipment, with a maximum insured value of € 5.000. Insured parcels always "
-"contain the options 'Home address only' en 'Signature for delivery'"
-
-msgid "shipment_options_large_format"
-msgstr "Extra large size"
-
-msgid "shipment_options_large_format_help_text"
-msgstr ""
-"Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but "
-"smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the "
-"parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet "
-"rate will be charged."
-
-msgid "shipment_options_only_recipient"
-msgstr "Home address only"
-
-msgid "shipment_options_only_recipient_help_text"
-msgstr ""
-"If you don't want the parcel to be delivered at the neighbours, choose this "
-"option."
-
-msgid "shipment_options_return"
-msgstr "Return if no answer"
-
-msgid "shipment_options_return_help_text"
-msgstr ""
-"By default, a parcel will be offered twice. After two unsuccessful delivery "
-"attempts, the parcel will be available at the nearest pickup point for two "
-"weeks. There it can be picked up by the recipient with the note that was "
-"left by the courier. If you want to receive the parcel back directly and "
-"NOT forward it to the pickup point, enable this option."
-
-msgid "shipment_options_signature"
-msgstr "Signature on delivery"
-
-msgid "shipment_options_signature_help_text"
-msgstr ""
-"The parcel will be offered at the delivery address. If the recipient is not "
-"at home, the parcel will be delivered to the neighbours. In both cases, a "
-"signature will be required."
-
-msgid "weight"
-msgstr "Weight"
-
-msgid "error_api_for_order_%s_no_shipments_created"
-msgstr "MyParcel API error at order %s, no shipments created."
-
-msgid "error_api_no_shipments_created"
-msgstr "MyParcel API error, no shipments created."
-
-msgid "export_orderid_%1$s_failed_because_%2$s"
-msgstr "Order %1$s not exported to MyParcel. %2$s"
-
-msgid "error_colli_weight_%1$s_but_max_%2$s"
-msgstr "Packages weigh %1$s kg, maximum allowed is %2$s kg."
-
-msgid "error_collo_weight_%1$s_but_max_%2$s"
-msgstr "Shipment weighs %1$s kg, maximum allowed is %2$s kg."
-
-msgid "export_hint_change_parcel"
-msgstr "Change the parcel type or create multiple labels."
-
-msgid "Invalid postal code"
-msgstr "Invalid postal code"
-
-msgid "Missing country"
-msgstr "Country is missing"
-
-msgid "Missing number"
-msgstr "Number is missing"
-
-msgid "settings_pickup_locations_default_view"
-msgstr "Pickup locations default view"
-
-msgid "settings_pickup_locations_default_view_map"
-msgstr "Map"
-
-msgid "settings_pickup_locations_default_view_list"
-msgstr "List"
-
 msgid "(Unknown)"
 msgstr "(Unknown)"
 
@@ -269,6 +97,9 @@ msgstr ""
 msgid "Calculated weight: %s"
 msgstr "Calculated weight: %s"
 
+msgid "calculated_order_weight"
+msgstr "Calculated weight: %s"
+
 msgid "Carrier"
 msgstr "Carrier"
 
@@ -299,12 +130,6 @@ msgstr "Connect customer email"
 msgid "Connect customer phone"
 msgstr "Connect customer phone"
 
-msgid "product_options_country_of_origin"
-msgstr "Country of origin"
-
-msgid "setting_country_of_origin_help_text"
-msgstr "Country of origin is required for world shipments. Defaults to shop base."
-
 msgid "Custom ID (top left on label)"
 msgstr "Custom ID (top left on label)"
 
@@ -328,9 +153,6 @@ msgstr "Days of the week on which you hand over parcels to PostNL"
 
 msgid "Default"
 msgstr "Default"
-
-msgid "setting_country_of_origin"
-msgstr "Default country of origin"
 
 msgid "Default export settings"
 msgstr "Default export settings"
@@ -370,6 +192,9 @@ msgstr "Delivery title"
 
 msgid "Delivery type"
 msgstr "Delivery type"
+
+msgid "delivery_type"
+msgstr "Delivery type:"
 
 msgid "Diagnostic tools"
 msgstr "Diagnostic tools"
@@ -448,6 +273,15 @@ msgstr ""
 "want to give a discount for using this function or do you want to charge "
 "extra for this delivery option."
 
+msgid "error_api_for_order_%s_no_shipments_created"
+msgstr "MyParcel API error at order %s, no shipments created."
+
+msgid "error_api_no_shipments_created"
+msgstr "MyParcel API error, no shipments created."
+
+msgid "error_collo_weight_%1$s_but_max_%2$s"
+msgstr "Weight per package is %1$s kg, maximum allowed is %2$s kg."
+
 msgid "Evening delivery"
 msgstr "Evening delivery"
 
@@ -460,8 +294,17 @@ msgstr "Export options"
 msgid "Export to MyParcel"
 msgstr "Export to MyParcel"
 
+msgid "export_hint_change_parcel"
+msgstr "Change the parcel type or create multiple labels."
+
+msgid "export_orderid_%1$s_failed_because_%2$s"
+msgstr "Order %1$s not exported to MyParcel. %2$s"
+
 msgid "Extra large size"
 msgstr "Extra large size"
+
+msgid "extra_options"
+msgstr "Extra options:"
 
 msgid "Fee (optional)"
 msgstr "Fee (optional)"
@@ -556,11 +399,23 @@ msgstr "Insure all parcels up to the selected amount."
 msgid "Insure from price"
 msgstr "Insure from price"
 
+msgid "insured"
+msgstr "Insured"
+
 msgid "Insured for"
 msgstr "Insured for"
 
 msgid "Insured shipment"
 msgstr "Insured shipment"
+
+msgid "insured_amount"
+msgstr "Insurance amount"
+
+msgid "insured_for"
+msgstr "Insured for"
+
+msgid "Invalid postal code"
+msgstr "Invalid postal code"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -598,6 +453,12 @@ msgstr "Mailbox"
 msgid "Max insured amount"
 msgstr "Max insured amount"
 
+msgid "Missing country"
+msgstr "Country is missing"
+
+msgid "Missing number"
+msgstr "Number is missing"
+
 msgid "Monday delivery"
 msgstr "Monday delivery"
 
@@ -615,6 +476,9 @@ msgstr "MyParcel address fields"
 
 msgid "MyParcel shipment:"
 msgstr "MyParcel shipment:"
+
+msgid "myparcel_shipment_created"
+msgstr "MyParcel shipment created:"
 
 msgid "MyParcel: Export"
 msgstr "MyParcel: Export"
@@ -639,6 +503,9 @@ msgstr "No label has been created yet."
 
 msgid "No."
 msgstr "No."
+
+msgid "not_active"
+msgstr "Not active"
 
 msgid "Number"
 msgstr "Number"
@@ -693,6 +560,9 @@ msgstr "Pickup location"
 
 msgid "Pickup title"
 msgstr "Pickup title"
+
+msgid "pickup_location"
+msgstr "Pickup location:"
 
 msgid "Place barcode inside note"
 msgstr "Place barcode inside note"
@@ -751,6 +621,9 @@ msgstr "Product quantity"
 msgid "Product SKU"
 msgstr "Product SKU"
 
+msgid "product_options_country_of_origin"
+msgstr "Country of origin"
+
 msgid "Retry"
 msgstr "Retry"
 
@@ -769,11 +642,143 @@ msgstr "Select one or more shipping methods for each MyParcel package type"
 msgid "Send email"
 msgstr "Send email"
 
+msgid "setting_automatic_order_status"
+msgstr "Automatic order status"
+
+msgid "setting_change_order_status_after"
+msgstr "Change order status after"
+
+msgid "setting_change_status_after_export"
+msgstr "Export order"
+
+msgid "setting_change_status_after_help_text"
+msgstr "Change the order status after export or after printing the shipping label."
+
+msgid "setting_change_status_after_printing"
+msgstr "Printing label"
+
+msgid "setting_country_of_origin"
+msgstr "Default country of origin"
+
+msgid "setting_country_of_origin_help_text"
+msgstr "Country of origin is required for world shipments. Defaults to shop base."
+
+msgid "setting_export_automatic_status"
+msgstr "Automatic export for order status"
+
+msgid "setting_export_automatic_status_help_text"
+msgstr ""
+"Creates a shipment in MyParcel when the status of an order changes. Make "
+"sure to check 'Process shipments directly' to receive the barcode."
+
 msgid "Settings"
 msgstr "Settings"
 
+msgid "settings_checkout_display_for"
+msgstr "Display for"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "All shipping methods"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"You can link the delivery options to specific shipping methods by adding "
+"them to the package types in \"Standard export settings\". The delivery "
+"options are not visible for foreign addresses."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Shipping methods associated with package type"
+
+msgid "settings_checkout_price_format"
+msgstr "Show prices as"
+
+msgid "settings_checkout_surcharge"
+msgstr "Surcharge"
+
+msgid "settings_checkout_total_price"
+msgstr "Total price"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locations default view"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "List"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Map"
+
 msgid "Shipment type"
 msgstr "Shipment type"
+
+msgid "shipment_options_age_check"
+msgstr "Age check 18+"
+
+msgid "shipment_options_age_check_help_text"
+msgstr ""
+"The age check is intended for parcel shipments for which the recipient must "
+"show 18+ by means of a proof of identity. The options \"Signature for "
+"receipt\" and \"Delivery only at recipient\" are included with this option. "
+"This option can't be combined with morning or evening delivery."
+
+msgid "shipment_options_insured"
+msgstr "Insured shipment"
+
+msgid "shipment_options_insured_amount"
+msgstr "Max insured amount"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Insure all parcels up to the selected amount."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Insure from price"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Insure all orders that exceed this price point."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"By default, there is no insurance on the shipments. If you still want to "
+"insure the shipment, you can do that. We insure the purchase value of the "
+"shipment, with a maximum insured value of € 5.000. Insured parcels always "
+"contain the options 'Home address only' en 'Signature for delivery'"
+
+msgid "shipment_options_large_format"
+msgstr "Extra large size"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but "
+"smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the "
+"parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet "
+"rate will be charged."
+
+msgid "shipment_options_only_recipient"
+msgstr "Home address only"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"If you don't want the parcel to be delivered at the neighbours, choose this "
+"option."
+
+msgid "shipment_options_return"
+msgstr "Return if no answer"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"By default, a parcel will be offered twice. After two unsuccessful delivery "
+"attempts, the parcel will be available at the nearest pickup point for two "
+"weeks. There it can be picked up by the recipient with the note that was "
+"left by the courier. If you want to receive the parcel back directly and "
+"NOT forward it to the pickup point, enable this option."
+
+msgid "shipment_options_signature"
+msgstr "Signature on delivery"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"The parcel will be offered at the delivery address. If the recipient is not "
+"at home, the parcel will be delivered to the neighbours. In both cases, a "
+"signature will be required."
 
 msgid "Show after billing details"
 msgstr "Show after billing details"
@@ -921,6 +926,9 @@ msgstr "Unpaid letter"
 
 msgid "View logs"
 msgstr "View logs"
+
+msgid "weight"
+msgstr "Weight"
 
 msgid ""
 "When enabled the checkout will use the MyParcel address fields. This means "

--- a/languages/woocommerce-myparcel-en_US.po
+++ b/languages/woocommerce-myparcel-en_US.po
@@ -11,178 +11,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language: en_US\n"
 
-msgid "setting_automatic_order_status"
-msgstr "Automatic order status"
-
-msgid "setting_change_order_status_after"
-msgstr "Change order status after"
-
-msgid "setting_change_status_after_printing"
-msgstr "Printing label"
-
-msgid "setting_change_status_after_export"
-msgstr "Export order"
-
-msgid "setting_change_status_after_help_text"
-msgstr "Change the order status after export or after printing the shipping label."
-
-msgid "calculated_order_weight"
-msgstr "Calculated weight: %s"
-
-msgid "delivery_type"
-msgstr "Delivery type:"
-
-msgid "extra_options"
-msgstr "Extra options:"
-
-msgid "insured"
-msgstr "Insured"
-
-msgid "insured_amount"
-msgstr "Insurance amount"
-
-msgid "insured_for"
-msgstr "Insured for"
-
-msgid "myparcel_shipment_created"
-msgstr "MyParcel shipment created:"
-
-msgid "pickup_location"
-msgstr "Pickup location:"
-
-msgid "settings_checkout_display_for"
-msgstr "Display for"
-
-msgid "settings_checkout_display_for_all_methods"
-msgstr "All shipping methods"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"You can link the delivery options to specific shipping methods by adding "
-"them to the package types in \"Standard export settings\". The delivery "
-"options are not visible for foreign addresses."
-
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Shipping methods associated with package type"
-
-msgid "settings_checkout_price_format"
-msgstr "Show prices as"
-
-msgid "settings_checkout_surcharge"
-msgstr "Surcharge"
-
-msgid "settings_checkout_total_price"
-msgstr "Total price"
-
-msgid "shipment_options_age_check"
-msgstr "Age check 18+"
-
-msgid "shipment_options_age_check_help_text"
-msgstr ""
-"The age check is intended for parcel shipments for which the recipient must "
-"show 18+ by means of a proof of identity. The options \"Signature for "
-"receipt\" and \"Delivery only at recipient\" are included with this option. "
-"This option can't be combined with morning or evening delivery."
-
-msgid "shipment_options_insured"
-msgstr "Insured shipment"
-
-msgid "shipment_options_insured_amount"
-msgstr "Max insured amount"
-
-msgid "shipment_options_insured_amount_help_text"
-msgstr "Insure all parcels up to the selected amount."
-
-msgid "shipment_options_insured_from_price"
-msgstr "Insure from price"
-
-msgid "shipment_options_insured_from_price_help_text"
-msgstr "Insure all orders that exceed this price point."
-
-msgid "shipment_options_insured_help_text"
-msgstr ""
-"By default, there is no insurance on the shipments. If you still want to "
-"insure the shipment, you can do that. We insure the purchase value of the "
-"shipment, with a maximum insured value of € 5.000. Insured parcels always "
-"contain the options 'Home address only' en 'Signature for delivery'"
-
-msgid "shipment_options_large_format"
-msgstr "Extra large size"
-
-msgid "shipment_options_large_format_help_text"
-msgstr ""
-"Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but "
-"smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the "
-"parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet "
-"rate will be charged."
-
-msgid "shipment_options_only_recipient"
-msgstr "Home address only"
-
-msgid "shipment_options_only_recipient_help_text"
-msgstr ""
-"If you don't want the parcel to be delivered at the neighbours, choose this "
-"option."
-
-msgid "shipment_options_return"
-msgstr "Return if no answer"
-
-msgid "shipment_options_return_help_text"
-msgstr ""
-"By default, a parcel will be offered twice. After two unsuccessful delivery "
-"attempts, the parcel will be available at the nearest pickup point for two "
-"weeks. There it can be picked up by the recipient with the note that was "
-"left by the courier. If you want to receive the parcel back directly and "
-"NOT forward it to the pickup point, enable this option."
-
-msgid "shipment_options_signature"
-msgstr "Signature on delivery"
-
-msgid "shipment_options_signature_help_text"
-msgstr ""
-"The parcel will be offered at the delivery address. If the recipient is not "
-"at home, the parcel will be delivered to the neighbours. In both cases, a "
-"signature will be required."
-
-msgid "weight"
-msgstr "Weight"
-
-msgid "error_api_for_order_%s_no_shipments_created"
-msgstr "MyParcel API error at order %s, no shipments created."
-
-msgid "error_api_no_shipments_created"
-msgstr "MyParcel API error, no shipments created."
-
-msgid "export_orderid_%1$s_failed_because_%2$s"
-msgstr "Order %1$s not exported to MyParcel. %2$s"
-
-msgid "error_colli_weight_%1$s_but_max_%2$s"
-msgstr "Packages weigh %1$s kg, maximum allowed is %2$s kg."
-
-msgid "error_collo_weight_%1$s_but_max_%2$s"
-msgstr "Shipment weighs %1$s kg, maximum allowed is %2$s kg."
-
-msgid "export_hint_change_parcel"
-msgstr "Change the parcel type or create multiple labels."
-
-msgid "Invalid postal code"
-msgstr "Invalid postal code"
-
-msgid "Missing country"
-msgstr "Country is missing"
-
-msgid "Missing number"
-msgstr "Number is missing"
-
-msgid "settings_pickup_locations_default_view"
-msgstr "Pickup locations default view"
-
-msgid "settings_pickup_locations_default_view_map"
-msgstr "Map"
-
-msgid "settings_pickup_locations_default_view_list"
-msgstr "List"
-
 msgid "(Unknown)"
 msgstr "(Unknown)"
 
@@ -270,6 +98,9 @@ msgstr ""
 msgid "Calculated weight: %s"
 msgstr "Calculated weight: %s"
 
+msgid "calculated_order_weight"
+msgstr "Calculated weight: %s"
+
 msgid "Carrier"
 msgstr "Carrier"
 
@@ -300,12 +131,6 @@ msgstr "Connect customer email"
 msgid "Connect customer phone"
 msgstr "Connect customer phone"
 
-msgid "product_options_country_of_origin"
-msgstr "Country of origin"
-
-msgid "setting_country_of_origin_help_text"
-msgstr "Country of origin is required for world shipments. Defaults to shop base."
-
 msgid "Custom ID (top left on label)"
 msgstr "Custom ID (top left on label)"
 
@@ -329,9 +154,6 @@ msgstr "Days of the week on which you hand over parcels to PostNL"
 
 msgid "Default"
 msgstr "Default"
-
-msgid "setting_country_of_origin"
-msgstr "Default country of origin"
 
 msgid "Default export settings"
 msgstr "Default export settings"
@@ -371,6 +193,9 @@ msgstr "Delivery title"
 
 msgid "Delivery type"
 msgstr "Delivery type"
+
+msgid "delivery_type"
+msgstr "Delivery type:"
 
 msgid "Diagnostic tools"
 msgstr "Diagnostic tools"
@@ -449,6 +274,15 @@ msgstr ""
 "want to give a discount for using this function or do you want to charge "
 "extra for this delivery option."
 
+msgid "error_api_for_order_%s_no_shipments_created"
+msgstr "MyParcel API error at order %s, no shipments created."
+
+msgid "error_api_no_shipments_created"
+msgstr "MyParcel API error, no shipments created."
+
+msgid "error_collo_weight_%1$s_but_max_%2$s"
+msgstr "Weight per package is %1$s kg, maximum allowed is %2$s kg."
+
 msgid "Evening delivery"
 msgstr "Evening delivery"
 
@@ -461,8 +295,17 @@ msgstr "Export options"
 msgid "Export to MyParcel"
 msgstr "Export to MyParcel"
 
+msgid "export_hint_change_parcel"
+msgstr "Change the parcel type or create multiple labels."
+
+msgid "export_orderid_%1$s_failed_because_%2$s"
+msgstr "Order %1$s not exported to MyParcel. %2$s"
+
 msgid "Extra large size"
 msgstr "Extra large size"
+
+msgid "extra_options"
+msgstr "Extra options:"
 
 msgid "Fee (optional)"
 msgstr "Fee (optional)"
@@ -557,11 +400,23 @@ msgstr "Insure all parcels up to the selected amount."
 msgid "Insure from price"
 msgstr "Insure from price"
 
+msgid "insured"
+msgstr "Insured"
+
 msgid "Insured for"
 msgstr "Insured for"
 
 msgid "Insured shipment"
 msgstr "Insured shipment"
+
+msgid "insured_amount"
+msgstr "Insurance amount"
+
+msgid "insured_for"
+msgstr "Insured for"
+
+msgid "Invalid postal code"
+msgstr "Invalid postal code"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -599,6 +454,12 @@ msgstr "Mailbox"
 msgid "Max insured amount"
 msgstr "Max insured amount"
 
+msgid "Missing country"
+msgstr "Country is missing"
+
+msgid "Missing number"
+msgstr "Number is missing"
+
 msgid "Monday delivery"
 msgstr "Monday delivery"
 
@@ -616,6 +477,9 @@ msgstr "MyParcel address fields"
 
 msgid "MyParcel shipment:"
 msgstr "MyParcel shipment:"
+
+msgid "myparcel_shipment_created"
+msgstr "MyParcel shipment created:"
 
 msgid "MyParcel: Export"
 msgstr "MyParcel: Export"
@@ -640,6 +504,9 @@ msgstr "No label has been created yet."
 
 msgid "No."
 msgstr "No."
+
+msgid "not_active"
+msgstr "Not active"
 
 msgid "Number"
 msgstr "Number"
@@ -694,6 +561,9 @@ msgstr "Pickup location"
 
 msgid "Pickup title"
 msgstr "Pickup title"
+
+msgid "pickup_location"
+msgstr "Pickup location:"
 
 msgid "Place barcode inside note"
 msgstr "Place barcode inside note"
@@ -752,6 +622,9 @@ msgstr "Product quantity"
 msgid "Product SKU"
 msgstr "Product SKU"
 
+msgid "product_options_country_of_origin"
+msgstr "Country of origin"
+
 msgid "Retry"
 msgstr "Retry"
 
@@ -770,11 +643,143 @@ msgstr "Select one or more shipping methods for each MyParcel package type"
 msgid "Send email"
 msgstr "Send email"
 
+msgid "setting_automatic_order_status"
+msgstr "Automatic order status"
+
+msgid "setting_change_order_status_after"
+msgstr "Change order status after"
+
+msgid "setting_change_status_after_export"
+msgstr "Export order"
+
+msgid "setting_change_status_after_help_text"
+msgstr "Change the order status after export or after printing the shipping label."
+
+msgid "setting_change_status_after_printing"
+msgstr "Printing label"
+
+msgid "setting_country_of_origin"
+msgstr "Default country of origin"
+
+msgid "setting_country_of_origin_help_text"
+msgstr "Country of origin is required for world shipments. Defaults to shop base."
+
+msgid "setting_export_automatic_status"
+msgstr "Automatic export for order status"
+
+msgid "setting_export_automatic_status_help_text"
+msgstr ""
+"Creates a shipment in MyParcel when the status of an order changes. Make "
+"sure to check 'Process shipments directly' to receive the barcode."
+
 msgid "Settings"
 msgstr "Settings"
 
+msgid "settings_checkout_display_for"
+msgstr "Display for"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "All shipping methods"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"You can link the delivery options to specific shipping methods by adding "
+"them to the package types in \"Standard export settings\". The delivery "
+"options are not visible for foreign addresses."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Shipping methods associated with package type"
+
+msgid "settings_checkout_price_format"
+msgstr "Show prices as"
+
+msgid "settings_checkout_surcharge"
+msgstr "Surcharge"
+
+msgid "settings_checkout_total_price"
+msgstr "Total price"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locations default view"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "List"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Map"
+
 msgid "Shipment type"
 msgstr "Shipment type"
+
+msgid "shipment_options_age_check"
+msgstr "Age check 18+"
+
+msgid "shipment_options_age_check_help_text"
+msgstr ""
+"The age check is intended for parcel shipments for which the recipient must "
+"show 18+ by means of a proof of identity. The options \"Signature for "
+"receipt\" and \"Delivery only at recipient\" are included with this option. "
+"This option can't be combined with morning or evening delivery."
+
+msgid "shipment_options_insured"
+msgstr "Insured shipment"
+
+msgid "shipment_options_insured_amount"
+msgstr "Max insured amount"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Insure all parcels up to the selected amount."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Insure from price"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Insure all orders that exceed this price point."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"By default, there is no insurance on the shipments. If you still want to "
+"insure the shipment, you can do that. We insure the purchase value of the "
+"shipment, with a maximum insured value of € 5.000. Insured parcels always "
+"contain the options 'Home address only' en 'Signature for delivery'"
+
+msgid "shipment_options_large_format"
+msgstr "Extra large size"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Enable this option when your shipment is bigger than 100 x 70 x 50 cm, but "
+"smaller than 175 x 78 x 58 cm. An extra fee will be charged. Note! If the "
+"parcel is bigger than 175 x 78 x 58 of or heavier than 30 kg, the pallet "
+"rate will be charged."
+
+msgid "shipment_options_only_recipient"
+msgstr "Home address only"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"If you don't want the parcel to be delivered at the neighbours, choose this "
+"option."
+
+msgid "shipment_options_return"
+msgstr "Return if no answer"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"By default, a parcel will be offered twice. After two unsuccessful delivery "
+"attempts, the parcel will be available at the nearest pickup point for two "
+"weeks. There it can be picked up by the recipient with the note that was "
+"left by the courier. If you want to receive the parcel back directly and "
+"NOT forward it to the pickup point, enable this option."
+
+msgid "shipment_options_signature"
+msgstr "Signature on delivery"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"The parcel will be offered at the delivery address. If the recipient is not "
+"at home, the parcel will be delivered to the neighbours. In both cases, a "
+"signature will be required."
 
 msgid "Show after billing details"
 msgstr "Show after billing details"
@@ -922,6 +927,9 @@ msgstr "Unpaid letter"
 
 msgid "View logs"
 msgstr "View logs"
+
+msgid "weight"
+msgstr "Weight"
 
 msgid ""
 "When enabled the checkout will use the MyParcel address fields. This means "

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -11,184 +11,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language: fr_BE\n"
 
-msgid "setting_automatic_order_status"
-msgstr "Statut de commande automatique"
-
-msgid "setting_change_order_status_after"
-msgstr "Modification de l'état de la commande après"
-
-msgid "setting_change_status_after_printing"
-msgstr "impression d'étiquettes"
-
-msgid "setting_change_status_after_export"
-msgstr "pour l'exportation"
-
-msgid "setting_change_status_after_help_text"
-msgstr ""
-"Modifier l'état de la commande après l'exportation ou après l'impression de "
-"l'étiquette d'expédition."
-
-msgid "calculated_order_weight"
-msgstr "Poids calculé : %s"
-
-msgid "delivery_type"
-msgstr "Type de livraison:"
-
-msgid "extra_options"
-msgstr "Options supplémentaires:"
-
-msgid "insured"
-msgstr "Assuré"
-
-msgid "insured_amount"
-msgstr "Montant d'assurance"
-
-msgid "insured_for"
-msgstr "Montant assuré"
-
-msgid "myparcel_shipment_created"
-msgstr "Envoi MyParcel créé :"
-
-msgid "pickup_location"
-msgstr "Lieu de ramassage"
-
-msgid "settings_checkout_display_for"
-msgstr "Afficher pour"
-
-msgid "settings_checkout_display_for_all_methods"
-msgstr "Tous les modes d'expédition"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"Vous pouvez lier les options de livraison à des méthodes d'expédition "
-"spécifiques en les ajoutant aux types de colis sous \"Paramètres "
-"d'exportation standard\". Les options de livraison ne sont pas visibles aux "
-"adresses étrangères."
-
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Mode d'expédition couplé au type de colis"
-
-msgid "settings_checkout_price_format"
-msgstr "Afficher les prix en"
-
-msgid "settings_checkout_surcharge"
-msgstr "Surtaxe"
-
-msgid "settings_checkout_total_price"
-msgstr "Prix ​​total"
-
-msgid "shipment_options_age_check"
-msgstr "Vérification de l'âge"
-
-msgid "shipment_options_age_check_help_text"
-msgstr ""
-"Le contrôle d'âge est destiné aux envois de colis pour lesquels le "
-"destinataire doit montrer qu'ils ont plus de 18 ans au moyen d'une preuve "
-"d'identité. Avec ceci L'option 'signature pour réception' et 'livraison "
-"uniquement chez le destinataire' sont inclus. Cette option ne peut pas être "
-"combinée avec la livraison le matin ou le soir."
-
-msgid "shipment_options_insured"
-msgstr "Expédition assuré"
-
-msgid "shipment_options_insured_amount"
-msgstr "Max montant assuré"
-
-msgid "shipment_options_insured_amount_help_text"
-msgstr "Assurer tous les colis jusqu'à la quantité sélectionnée."
-
-msgid "shipment_options_insured_from_price"
-msgstr "Insure à partir des prix"
-
-msgid "shipment_options_insured_from_price_help_text"
-msgstr "Assurer toutes les commandes qui dépassent ce prix."
-
-msgid "shipment_options_insured_help_text"
-msgstr ""
-"Par défaut, il n'y a pas d'assurance sur les livraisons. Si vous voulez "
-"toujours assurer l'expédition, vous pouvez le faire. Nous assurons la "
-"valeur d'achat de l'expédition, avec une valeur assurée maximum de € 5.000. "
-"Les colis assurés contiennent toujours les options Adresse Accueil "
-"uniquement 'en « Signature pour la livraison »"
-
-msgid "shipment_options_large_format"
-msgstr "Très grande taille"
-
-msgid "shipment_options_large_format_help_text"
-msgstr ""
-"Activez cette option lorsque votre envoi est supérieure à 100 x 70 x 50 cm, "
-"mais plus petit que 175 x 78 x 58 cm. Des frais supplémentaires seront "
-"facturés. Noter! Si le colis est plus grand que 175 x 78 x 58 ou plus lourd "
-"que 30 kg, le taux palette sera facturé."
-
-msgid "shipment_options_only_recipient"
-msgstr "Seul destinataire"
-
-msgid "shipment_options_only_recipient_help_text"
-msgstr ""
-"Si vous ne voulez pas que le colis soit livré aux voisins, choisissez cette "
-"option."
-
-msgid "shipment_options_return"
-msgstr "Retour si aucune réponse"
-
-msgid "shipment_options_return_help_text"
-msgstr ""
-"Par défaut, une parcelle sera offert deux fois. Après deux tentatives "
-"infructueuses de livraison, le colis sera disponible au point le plus "
-"proche pick-up pendant deux semaines. Là, il peut être repris par le "
-"destinataire de la note qui a été laissé par le courrier. Si vous souhaitez "
-"recevoir le colis de retour directement et non en avant au point de "
-"ramassage, activez cette option."
-
-msgid "shipment_options_signature"
-msgstr "Signature pour réception"
-
-msgid "shipment_options_signature_help_text"
-msgstr ""
-"Le colis sera offert à l'adresse de livraison. Si le destinataire est pas à "
-"la maison, le colis sera livré aux voisins. Dans les deux cas, une "
-"signature sera nécessaire."
-
-msgid "weight"
-msgstr "Poids"
-
-msgid "error_api_for_order_%s_no_shipments_created"
-msgstr ""
-
-msgid "error_api_no_shipments_created"
-msgstr ""
-
-msgid "export_orderid_%1$s_failed_because_%2$s"
-msgstr ""
-
-msgid "error_colli_weight_%1$s_but_max_%2$s"
-msgstr ""
-
-msgid "error_collo_weight_%1$s_but_max_%2$s"
-msgstr ""
-
-msgid "export_hint_change_parcel"
-msgstr ""
-
-msgid "Invalid postal code"
-msgstr "Code postal incorrect"
-
-msgid "Missing country"
-msgstr "Pays manque"
-
-msgid "Missing number"
-msgstr "Numéro manque"
-
-msgid "settings_pickup_locations_default_view"
-msgstr "Lieux de ramassage vue défaut"
-
-msgid "settings_pickup_locations_default_view_map"
-msgstr "Carte"
-
-msgid "settings_pickup_locations_default_view_list"
-msgstr "Liste"
-
 msgid "(Unknown)"
 msgstr "(Inconnu)"
 
@@ -258,7 +80,7 @@ msgid ""
 msgstr ""
 "Par défaut, une parcelle sera offert deux fois. Après deux tentatives "
 "infructueuses de livraison, le colis sera disponible au point le plus "
-"proche pick-up pendant deux semaines. Là, il peut être repris par le "
+"proche pick-up pendant deux semaines. Là, il peut ��tre repris par le "
 "destinataire de la note qui a été laissé par le courrier. Si vous souhaitez "
 "recevoir le colis de retour directement et non en avant au point de "
 "ramassage, activez cette option."
@@ -276,6 +98,9 @@ msgstr ""
 "uniquement 'en « Signature pour la livraison »"
 
 msgid "Calculated weight: %s"
+msgstr "Poids calculé : %s"
+
+msgid "calculated_order_weight"
 msgstr "Poids calculé : %s"
 
 msgid "Carrier"
@@ -308,16 +133,8 @@ msgstr "Associer l'adresse e-mail du client"
 msgid "Connect customer phone"
 msgstr "Associer le numéro de téléphone du client"
 
-msgid "product_options_country_of_origin"
-msgstr "Pays d'origine"
-
-msgid "setting_country_of_origin_help_text"
-msgstr ""
-"Pays d'origine est requis pour les envois du monde. Par défaut pour faire "
-"du shopping base."
-
 msgid "Custom ID (top left on label)"
-msgstr "ID personnalisés (en haut à gauche sur l'étiquette)"
+msgstr "ID personnalisés (angle supérieur gauche sur l 'étiquette)"
 
 msgid "Custom styles"
 msgstr "Styles personnalisés (CSS)"
@@ -339,9 +156,6 @@ msgstr "Jours de la semaine où vous la main sur les colis à PostNL"
 
 msgid "Default"
 msgstr "Défaut"
-
-msgid "setting_country_of_origin"
-msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"
 msgstr "Paramètres d'exportation standards"
@@ -381,6 +195,9 @@ msgstr "Titre de la livraison"
 
 msgid "Delivery type"
 msgstr "Type de livraison"
+
+msgid "delivery_type"
+msgstr "Type de livraison:"
 
 msgid "Diagnostic tools"
 msgstr "Outils de diagnostic"
@@ -459,6 +276,15 @@ msgstr ""
 "exemple proposer une réduction pour cette fonction ou décompter des frais "
 "supplémentaires pour cette option de livraison."
 
+msgid "error_api_for_order_%s_no_shipments_created"
+msgstr "MyParcel API erreur au commande %s, aucun envoi n'a été créé."
+
+msgid "error_api_no_shipments_created"
+msgstr "MyParcel API erreur, aucun envoi n'a été créé."
+
+msgid "error_collo_weight_%1$s_but_max_%2$s"
+msgstr "Poids par paquet est de %1$s kg, maximum est %2$s kg."
+
 msgid "Evening delivery"
 msgstr "Livraison en soirée"
 
@@ -471,8 +297,17 @@ msgstr "Options d'exportation"
 msgid "Export to MyParcel"
 msgstr "Exporter vers MyParcel"
 
+msgid "export_hint_change_parcel"
+msgstr "Modifiez le type de paquet ou générez plusieurs étiquettes."
+
+msgid "export_orderid_%1$s_failed_because_%2$s"
+msgstr "Commande %1$s non pas exporté vers MyParcel. %2$s"
+
 msgid "Extra large size"
 msgstr "Très grande taille"
+
+msgid "extra_options"
+msgstr "Options supplémentaires:"
 
 msgid "Fee (optional)"
 msgstr "Frais (optionnel)"
@@ -567,11 +402,23 @@ msgstr "Assurer tous les colis jusqu'à la quantité sélectionnée."
 msgid "Insure from price"
 msgstr "Insure à partir des prix"
 
+msgid "insured"
+msgstr "Assuré"
+
 msgid "Insured for"
 msgstr "Montant assuré"
 
 msgid "Insured shipment"
 msgstr "Expédition assuré"
+
+msgid "insured_amount"
+msgstr "Montant d'assurance"
+
+msgid "insured_for"
+msgstr "Montant assuré"
+
+msgid "Invalid postal code"
+msgstr "Code postal incorrect"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -609,6 +456,12 @@ msgstr "Boites aux lettres"
 msgid "Max insured amount"
 msgstr "Max montant assuré"
 
+msgid "Missing country"
+msgstr "Pays manque"
+
+msgid "Missing number"
+msgstr "Numéro manque"
+
 msgid "Monday delivery"
 msgstr "Livraison lundi"
 
@@ -626,6 +479,9 @@ msgstr "Champs adresse MyParcel"
 
 msgid "MyParcel shipment:"
 msgstr "Envoi MyParcel:"
+
+msgid "myparcel_shipment_created"
+msgstr "Envoi MyParcel créé :"
 
 msgid "MyParcel: Export"
 msgstr "MyParcel: Exporter"
@@ -650,6 +506,9 @@ msgstr "Label pas encore créé."
 
 msgid "No."
 msgstr "Numéro"
+
+msgid "not_active"
+msgstr "Non actif"
 
 msgid "Number"
 msgstr "Numéro"
@@ -704,6 +563,9 @@ msgstr "Lieu de ramassage"
 
 msgid "Pickup title"
 msgstr "Titre du ramassage"
+
+msgid "pickup_location"
+msgstr "Lieu de ramassage"
 
 msgid "Place barcode inside note"
 msgstr "Conserver le code-barres dans une note"
@@ -762,6 +624,9 @@ msgstr "La quantité de produit"
 msgid "Product SKU"
 msgstr "SKU du produit"
 
+msgid "product_options_country_of_origin"
+msgstr "Pays d'origine"
+
 msgid "Retry"
 msgstr "Réessayez"
 
@@ -782,11 +647,151 @@ msgstr ""
 msgid "Send email"
 msgstr "Envoyer l'e-mail"
 
+msgid "setting_automatic_order_status"
+msgstr "Statut de commande automatique"
+
+msgid "setting_change_order_status_after"
+msgstr "Modification de l'état de la commande après"
+
+msgid "setting_change_status_after_export"
+msgstr "pour l'exportation"
+
+msgid "setting_change_status_after_help_text"
+msgstr ""
+"Modifier l'état de la commande après l'exportation ou après l'impression de "
+"l'étiquette d'expédition."
+
+msgid "setting_change_status_after_printing"
+msgstr "impression d'étiquettes"
+
+msgid "setting_country_of_origin"
+msgstr "Pays d'origine par défaut"
+
+msgid "setting_country_of_origin_help_text"
+msgstr ""
+"Pays d'origine est requis pour les envois du monde. Par défaut pour faire "
+"du shopping base."
+
+msgid "setting_export_automatic_status"
+msgstr "Export automatique suivant l'état de commande"
+
+msgid "setting_export_automatic_status_help_text"
+msgstr ""
+"Crea un envoi dans MyParcel quand l'état du commande change. Pour recevoir "
+"le barcode sélectionnez 'Traiter immédiatement les envois' aussi."
+
 msgid "Settings"
 msgstr "Paramètres"
 
+msgid "settings_checkout_display_for"
+msgstr "Afficher pour"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "Tous les modes d'expédition"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"Vous pouvez lier les options de livraison à des méthodes d'expédition "
+"spécifiques en les ajoutant aux types de colis sous \"Paramètres "
+"d'exportation standard\". Les options de livraison ne sont pas visibles aux "
+"adresses étrangères."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Mode d'expédition couplé au type de colis"
+
+msgid "settings_checkout_price_format"
+msgstr "Afficher les prix en"
+
+msgid "settings_checkout_surcharge"
+msgstr "Surtaxe"
+
+msgid "settings_checkout_total_price"
+msgstr "Prix ​​total"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Lieux de ramassage vue défaut"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Liste"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Carte"
+
 msgid "Shipment type"
 msgstr "Types d'expédition"
+
+msgid "shipment_options_age_check"
+msgstr "Vérification de l'âge"
+
+msgid "shipment_options_age_check_help_text"
+msgstr ""
+"Le contrôle d'âge est destiné aux envois de colis pour lesquels le "
+"destinataire doit montrer qu'ils ont plus de 18 ans au moyen d'une preuve "
+"d'identité. Avec ceci L'option 'signature pour réception' et 'livraison "
+"uniquement chez le destinataire' sont inclus. Cette option ne peut pas être "
+"combinée avec la livraison le matin ou le soir."
+
+msgid "shipment_options_insured"
+msgstr "Expédition assuré"
+
+msgid "shipment_options_insured_amount"
+msgstr "Max montant assuré"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Assurer tous les colis jusqu'à la quantité sélectionnée."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Insure à partir des prix"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Assurer toutes les commandes qui dépassent ce prix."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"Par défaut, il n'y a pas d'assurance sur les livraisons. Si vous voulez "
+"toujours assurer l'expédition, vous pouvez le faire. Nous assurons la "
+"valeur d'achat de l'expédition, avec une valeur assurée maximum de € 5.000. "
+"Les colis assurés contiennent toujours les options Adresse Accueil "
+"uniquement 'en « Signature pour la livraison »"
+
+msgid "shipment_options_large_format"
+msgstr "Très grande taille"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Activez cette option lorsque votre envoi est supérieure à 100 x 70 x 50 cm, "
+"mais plus petit que 175 x 78 x 58 cm. Des frais supplémentaires seront "
+"facturés. Noter! Si le colis est plus grand que 175 x 78 x 58 ou plus lourd "
+"que 30 kg, le taux palette sera facturé."
+
+msgid "shipment_options_only_recipient"
+msgstr "Seul destinataire"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"Si vous ne voulez pas que le colis soit livré aux voisins, choisissez cette "
+"option."
+
+msgid "shipment_options_return"
+msgstr "Retour si aucune réponse"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"Par défaut, une parcelle sera offert deux fois. Après deux tentatives "
+"infructueuses de livraison, le colis sera disponible au point le plus "
+"proche pick-up pendant deux semaines. Là, il peut être repris par le "
+"destinataire de la note qui a été laissé par le courrier. Si vous souhaitez "
+"recevoir le colis de retour directement et non en avant au point de "
+"ramassage, activez cette option."
+
+msgid "shipment_options_signature"
+msgstr "Signature pour réception"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"Le colis sera offert à l'adresse de livraison. Si le destinataire est pas à "
+"la maison, le colis sera livré aux voisins. Dans les deux cas, une "
+"signature sera nécessaire."
 
 msgid "Show after billing details"
 msgstr "Afficher après les données de facturation"
@@ -938,6 +943,9 @@ msgstr "lettre sans solde"
 
 msgid "View logs"
 msgstr "Afficher les logs"
+
+msgid "weight"
+msgstr "Poids"
 
 msgid ""
 "When enabled the checkout will use the MyParcel address fields. This means "

--- a/languages/woocommerce-myparcel-fr_FR.po
+++ b/languages/woocommerce-myparcel-fr_FR.po
@@ -11,166 +11,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language: fr_FR\n"
 
-msgid "setting_automatic_order_status"
-msgstr "Statut de commande automatique"
-
-msgid "setting_change_order_status_after"
-msgstr "Modification de l'état de la commande après"
-
-msgid "setting_change_status_after_printing"
-msgstr "impression d'étiquettes"
-
-msgid "setting_change_status_after_export"
-msgstr "pour l'exportation"
-
-msgid "setting_change_status_after_help_text"
-msgstr ""
-"Modifier l'état de la commande après l'exportation ou après l'impression de "
-"l'étiquette d'expédition."
-
-msgid "calculated_order_weight"
-msgstr "Poids calculé : %s"
-
-msgid "delivery_type"
-msgstr "Type de livraison:"
-
-msgid "extra_options"
-msgstr "Options supplémentaires:"
-
-msgid "insured"
-msgstr "Assuré"
-
-msgid "insured_amount"
-msgstr "Montant d'assurance"
-
-msgid "insured_for"
-msgstr "Montant assuré"
-
-msgid "myparcel_shipment_created"
-msgstr "Envoi MyParcel créé :"
-
-msgid "pickup_location"
-msgstr "Lieu de ramassage"
-
-msgid "settings_checkout_display_for"
-msgstr "Afficher pour"
-
-msgid "settings_checkout_display_for_all_methods"
-msgstr "Tous les modes d'expédition"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"Vous pouvez lier les options de livraison à des méthodes d'expédition "
-"spécifiques en les ajoutant aux types de colis sous \"Paramètres "
-"d'exportation standard\". Les options de livraison ne sont pas visibles aux "
-"adresses étrangères."
-
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Mode d'expédition couplé au type de colis"
-
-msgid "settings_checkout_price_format"
-msgstr "Afficher les prix en"
-
-msgid "settings_checkout_surcharge"
-msgstr "Surtaxe"
-
-msgid "settings_checkout_total_price"
-msgstr "Prix ​​total"
-
-msgid "shipment_options_age_check"
-msgstr "Vérification de l'âge"
-
-msgid "shipment_options_age_check_help_text"
-msgstr ""
-"Le contrôle d'âge est destiné aux envois de colis pour lesquels le "
-"destinataire doit montrer qu'ils ont plus de 18 ans au moyen d'une preuve "
-"d'identité. Avec ceci L'option 'signature pour réception' et 'livraison "
-"uniquement chez le destinataire' sont inclus. Cette option ne peut pas être "
-"combinée avec la livraison le matin ou le soir."
-
-msgid "shipment_options_insured"
-msgstr "Expédition assuré"
-
-msgid "shipment_options_insured_amount"
-msgstr "Max montant assuré"
-
-msgid "shipment_options_insured_amount_help_text"
-msgstr "Assurer tous les colis jusqu'à la quantité sélectionnée."
-
-msgid "shipment_options_insured_from_price"
-msgstr "Insure à partir des prix"
-
-msgid "shipment_options_insured_from_price_help_text"
-msgstr "Assurer toutes les commandes qui dépassent ce prix."
-
-msgid "shipment_options_insured_help_text"
-msgstr ""
-"Par défaut, il n'y a pas d'assurance sur les livraisons. Si vous voulez "
-"toujours assurer l'expédition, vous pouvez le faire. Nous assurons la "
-"valeur d'achat de l'expédition, avec une valeur assurée maximum de € 5.000. "
-"Les colis assurés contiennent toujours les options Adresse Accueil "
-"uniquement 'en « Signature pour la livraison »"
-
-msgid "shipment_options_large_format"
-msgstr "Très grande taille"
-
-msgid "shipment_options_large_format_help_text"
-msgstr ""
-"Activez cette option lorsque votre envoi est supérieure à 100 x 70 x 50 cm, "
-"mais plus petit que 175 x 78 x 58 cm. Des frais supplémentaires seront "
-"facturés. Noter! Si le colis est plus grand que 175 x 78 x 58 ou plus lourd "
-"que 30 kg, le taux palette sera facturé."
-
-msgid "shipment_options_only_recipient"
-msgstr "Seul destinataire"
-
-msgid "shipment_options_only_recipient_help_text"
-msgstr ""
-"Si vous ne voulez pas que le colis soit livré aux voisins, choisissez cette "
-"option."
-
-msgid "shipment_options_return"
-msgstr "Retour si aucune réponse"
-
-msgid "shipment_options_return_help_text"
-msgstr ""
-"Par défaut, une parcelle sera offert deux fois. Après deux tentatives "
-"infructueuses de livraison, le colis sera disponible au point le plus "
-"proche pick-up pendant deux semaines. Là, il peut être repris par le "
-"destinataire de la note qui a été laissé par le courrier. Si vous souhaitez "
-"recevoir le colis de retour directement et non en avant au point de "
-"ramassage, activez cette option."
-
-msgid "shipment_options_signature"
-msgstr "Signature pour réception"
-
-msgid "shipment_options_signature_help_text"
-msgstr ""
-"Le colis sera offert à l'adresse de livraison. Si le destinataire est pas à "
-"la maison, le colis sera livré aux voisins. Dans les deux cas, une "
-"signature sera nécessaire."
-
-msgid "weight"
-msgstr "Poids"
-
-msgid "Invalid postal code"
-msgstr "Code postal incorrect"
-
-msgid "Missing country"
-msgstr "Pays manque"
-
-msgid "Missing number"
-msgstr "Numéro manque"
-
-msgid "settings_pickup_locations_default_view"
-msgstr "Lieux de ramassage vue défaut"
-
-msgid "settings_pickup_locations_default_view_map"
-msgstr "Carte"
-
-msgid "settings_pickup_locations_default_view_list"
-msgstr "Liste"
-
 msgid "(Unknown)"
 msgstr "(Inconnu)"
 
@@ -260,6 +100,9 @@ msgstr ""
 msgid "Calculated weight: %s"
 msgstr "Poids calculé : %s"
 
+msgid "calculated_order_weight"
+msgstr "Poids calculé : %s"
+
 msgid "Carrier"
 msgstr "Transporteur"
 
@@ -288,18 +131,10 @@ msgid "Connect customer email"
 msgstr "Associer l'adresse e-mail du client"
 
 msgid "Connect customer phone"
-msgstr "Associer le numéro de téléphone du client"
-
-msgid "product_options_country_of_origin"
-msgstr "Pays d'origine"
-
-msgid "setting_country_of_origin_help_text"
-msgstr ""
-"Pays d'origine est requis pour les envois du monde. Par défaut pour faire "
-"du shopping base."
+msgstr "Associer le numéro de tél��phone du client"
 
 msgid "Custom ID (top left on label)"
-msgstr "ID personnalisés (en haut à gauche sur l'étiquette)"
+msgstr "ID personnalisés (angle supérieur gauche sur l 'étiquette)"
 
 msgid "Custom styles"
 msgstr "Styles personnalisés (CSS)"
@@ -321,9 +156,6 @@ msgstr "Jours de la semaine où vous la main sur les colis à PostNL"
 
 msgid "Default"
 msgstr "Défaut"
-
-msgid "setting_country_of_origin"
-msgstr "Pays d'origine par défaut"
 
 msgid "Default export settings"
 msgstr "Paramètres d'exportation standards"
@@ -363,6 +195,9 @@ msgstr "Titre de la livraison"
 
 msgid "Delivery type"
 msgstr "Type de livraison"
+
+msgid "delivery_type"
+msgstr "Type de livraison:"
 
 msgid "Diagnostic tools"
 msgstr "Outils de diagnostic"
@@ -441,6 +276,15 @@ msgstr ""
 "exemple proposer une réduction pour cette fonction ou décompter des frais "
 "supplémentaires pour cette option de livraison."
 
+msgid "error_api_for_order_%s_no_shipments_created"
+msgstr "MyParcel API erreur au commande %s, aucun envoi n'a été créé."
+
+msgid "error_api_no_shipments_created"
+msgstr "MyParcel API erreur, aucun envoi n'a été créé."
+
+msgid "error_collo_weight_%1$s_but_max_%2$s"
+msgstr "Poids par paquet est de %1$s kg, maximum est %2$s kg."
+
 msgid "Evening delivery"
 msgstr "Livraison en soirée"
 
@@ -453,8 +297,17 @@ msgstr "Options d'exportation"
 msgid "Export to MyParcel"
 msgstr "Exporter vers MyParcel"
 
+msgid "export_hint_change_parcel"
+msgstr "Modifiez le type de paquet ou générez plusieurs étiquettes."
+
+msgid "export_orderid_%1$s_failed_because_%2$s"
+msgstr "Commande %1$s non pas exporté vers MyParcel. %2$s"
+
 msgid "Extra large size"
 msgstr "Très grande taille"
+
+msgid "extra_options"
+msgstr "Options supplémentaires:"
 
 msgid "Fee (optional)"
 msgstr "Frais (optionnel)"
@@ -549,11 +402,23 @@ msgstr "Assurer tous les colis jusqu'à la quantité sélectionnée."
 msgid "Insure from price"
 msgstr "Insure à partir des prix"
 
+msgid "insured"
+msgstr "Assuré"
+
 msgid "Insured for"
 msgstr "Montant assuré"
 
 msgid "Insured shipment"
 msgstr "Expédition assuré"
+
+msgid "insured_amount"
+msgstr "Montant d'assurance"
+
+msgid "insured_for"
+msgstr "Montant assuré"
+
+msgid "Invalid postal code"
+msgstr "Code postal incorrect"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -591,6 +456,12 @@ msgstr "Boites aux lettres"
 msgid "Max insured amount"
 msgstr "Max montant assuré"
 
+msgid "Missing country"
+msgstr "Pays manque"
+
+msgid "Missing number"
+msgstr "Numéro manque"
+
 msgid "Monday delivery"
 msgstr "Livraison lundi"
 
@@ -608,6 +479,9 @@ msgstr "Champs adresse MyParcel"
 
 msgid "MyParcel shipment:"
 msgstr "Envoi MyParcel:"
+
+msgid "myparcel_shipment_created"
+msgstr "Envoi MyParcel créé :"
 
 msgid "MyParcel: Export"
 msgstr "MyParcel: Exporter"
@@ -632,6 +506,9 @@ msgstr "Label pas encore créé."
 
 msgid "No."
 msgstr "Numéro"
+
+msgid "not_active"
+msgstr "Non actif"
 
 msgid "Number"
 msgstr "Numéro"
@@ -686,6 +563,9 @@ msgstr "Lieu de ramassage"
 
 msgid "Pickup title"
 msgstr "Titre du ramassage"
+
+msgid "pickup_location"
+msgstr "Lieu de ramassage"
 
 msgid "Place barcode inside note"
 msgstr "Conserver le code-barres dans une note"
@@ -744,6 +624,9 @@ msgstr "La quantité de produit"
 msgid "Product SKU"
 msgstr "SKU du produit"
 
+msgid "product_options_country_of_origin"
+msgstr "Pays d'origine"
+
 msgid "Retry"
 msgstr "Réessayez"
 
@@ -764,11 +647,151 @@ msgstr ""
 msgid "Send email"
 msgstr "Envoyer l'e-mail"
 
+msgid "setting_automatic_order_status"
+msgstr "Statut de commande automatique"
+
+msgid "setting_change_order_status_after"
+msgstr "Modification de l'état de la commande après"
+
+msgid "setting_change_status_after_export"
+msgstr "pour l'exportation"
+
+msgid "setting_change_status_after_help_text"
+msgstr ""
+"Modifier l'état de la commande après l'exportation ou après l'impression de "
+"l'étiquette d'expédition."
+
+msgid "setting_change_status_after_printing"
+msgstr "impression d'étiquettes"
+
+msgid "setting_country_of_origin"
+msgstr "Pays d'origine par défaut"
+
+msgid "setting_country_of_origin_help_text"
+msgstr ""
+"Pays d'origine est requis pour les envois du monde. Par défaut pour faire "
+"du shopping base."
+
+msgid "setting_export_automatic_status"
+msgstr "Export automatique suivant l'état de commande"
+
+msgid "setting_export_automatic_status_help_text"
+msgstr ""
+"Crea un envoi dans MyParcel quand l'état du commande change. Pour recevoir "
+"le barcode sélectionnez 'Traiter immédiatement les envois' aussi."
+
 msgid "Settings"
 msgstr "Paramètres"
 
+msgid "settings_checkout_display_for"
+msgstr "Afficher pour"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "Tous les modes d'expédition"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"Vous pouvez lier les options de livraison à des méthodes d'expédition "
+"spécifiques en les ajoutant aux types de colis sous \"Paramètres "
+"d'exportation standard\". Les options de livraison ne sont pas visibles aux "
+"adresses étrangères."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Mode d'expédition couplé au type de colis"
+
+msgid "settings_checkout_price_format"
+msgstr "Afficher les prix en"
+
+msgid "settings_checkout_surcharge"
+msgstr "Surtaxe"
+
+msgid "settings_checkout_total_price"
+msgstr "Prix ​​total"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Lieux de ramassage vue défaut"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Liste"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Carte"
+
 msgid "Shipment type"
 msgstr "Types d'expédition"
+
+msgid "shipment_options_age_check"
+msgstr "Vérification de l'âge"
+
+msgid "shipment_options_age_check_help_text"
+msgstr ""
+"Le contrôle d'âge est destiné aux envois de colis pour lesquels le "
+"destinataire doit montrer qu'ils ont plus de 18 ans au moyen d'une preuve "
+"d'identité. Avec ceci L'option 'signature pour réception' et 'livraison "
+"uniquement chez le destinataire' sont inclus. Cette option ne peut pas être "
+"combinée avec la livraison le matin ou le soir."
+
+msgid "shipment_options_insured"
+msgstr "Expédition assuré"
+
+msgid "shipment_options_insured_amount"
+msgstr "Max montant assuré"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Assurer tous les colis jusqu'à la quantité sélectionnée."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Insure à partir des prix"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Assurer toutes les commandes qui dépassent ce prix."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"Par défaut, il n'y a pas d'assurance sur les livraisons. Si vous voulez "
+"toujours assurer l'expédition, vous pouvez le faire. Nous assurons la "
+"valeur d'achat de l'expédition, avec une valeur assurée maximum de € 5.000. "
+"Les colis assurés contiennent toujours les options Adresse Accueil "
+"uniquement 'en « Signature pour la livraison »"
+
+msgid "shipment_options_large_format"
+msgstr "Très grande taille"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Activez cette option lorsque votre envoi est supérieure à 100 x 70 x 50 cm, "
+"mais plus petit que 175 x 78 x 58 cm. Des frais supplémentaires seront "
+"facturés. Noter! Si le colis est plus grand que 175 x 78 x 58 ou plus lourd "
+"que 30 kg, le taux palette sera facturé."
+
+msgid "shipment_options_only_recipient"
+msgstr "Seul destinataire"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"Si vous ne voulez pas que le colis soit livré aux voisins, choisissez cette "
+"option."
+
+msgid "shipment_options_return"
+msgstr "Retour si aucune réponse"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"Par défaut, une parcelle sera offert deux fois. Après deux tentatives "
+"infructueuses de livraison, le colis sera disponible au point le plus "
+"proche pick-up pendant deux semaines. Là, il peut être repris par le "
+"destinataire de la note qui a été laissé par le courrier. Si vous souhaitez "
+"recevoir le colis de retour directement et non en avant au point de "
+"ramassage, activez cette option."
+
+msgid "shipment_options_signature"
+msgstr "Signature pour réception"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"Le colis sera offert à l'adresse de livraison. Si le destinataire est pas à "
+"la maison, le colis sera livré aux voisins. Dans les deux cas, une "
+"signature sera nécessaire."
 
 msgid "Show after billing details"
 msgstr "Afficher après les données de facturation"
@@ -921,6 +944,9 @@ msgstr "lettre sans solde"
 msgid "View logs"
 msgstr "Afficher les logs"
 
+msgid "weight"
+msgstr "Poids"
+
 msgid ""
 "When enabled the checkout will use the MyParcel address fields. This means "
 "there will be three separate fields for street name, number and suffix. "
@@ -1031,21 +1057,3 @@ msgid "You have to export the orders to MyParcel before you can print the labels
 msgstr ""
 "Vous devez d'abord exporter vos commandes vers MyParcel avant de pouvoir "
 "imprimer vos étiquettes !"
-
-msgid "error_api_for_order_%s_no_shipments_created"
-msgstr ""
-
-msgid "error_api_no_shipments_created"
-msgstr ""
-
-msgid "export_orderid_%1$s_failed_because_%2$s"
-msgstr ""
-
-msgid "error_colli_weight_%1$s_but_max_%2$s"
-msgstr ""
-
-msgid "error_collo_weight_%1$s_but_max_%2$s"
-msgstr ""
-
-msgid "export_hint_change_parcel"
-msgstr ""

--- a/languages/woocommerce-myparcel-nl_BE.po
+++ b/languages/woocommerce-myparcel-nl_BE.po
@@ -11,180 +11,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language: nl_BE\n"
 
-msgid "setting_automatic_order_status"
-msgstr "Automatische orderstatus"
-
-msgid "setting_change_order_status_after"
-msgstr "Verander order status na"
-
-msgid "setting_change_status_after_printing"
-msgstr "Labels printen"
-
-msgid "setting_change_status_after_export"
-msgstr "Exporteren"
-
-msgid "setting_change_status_after_help_text"
-msgstr ""
-"Wijzig de bestelstatus na het exporteren of na het afdrukken van het "
-"verzendlabel."
-
-msgid "calculated_order_weight"
-msgstr "Berekend gewicht: %s"
-
-msgid "delivery_type"
-msgstr "Soort levering:"
-
-msgid "extra_options"
-msgstr "Extra opties:"
-
-msgid "insured"
-msgstr "Verzekerd"
-
-msgid "insured_amount"
-msgstr "Verzekerd bedrag"
-
-msgid "insured_for"
-msgstr "Verzekerd voor"
-
-msgid "myparcel_shipment_created"
-msgstr "MyParcel zending aangemaakt"
-
-msgid "pickup_location"
-msgstr "Afhaallocatie:"
-
-msgid "settings_checkout_display_for"
-msgstr "Toon bij"
-
-msgid "settings_checkout_display_for_all_methods"
-msgstr "Alle verzendmethoden"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
-"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
-"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
-
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Verzendmethoden gekoppeld aan pakkettype"
-
-msgid "settings_checkout_price_format"
-msgstr "Prijzen tonen als"
-
-msgid "settings_checkout_surcharge"
-msgstr "Meerprijs"
-
-msgid "settings_checkout_total_price"
-msgstr "Totaalprijs"
-
-msgid "shipment_options_age_check"
-msgstr "Leeftijdscheck 18+"
-
-msgid "shipment_options_age_check_help_text"
-msgstr ""
-"De leeftijdscheck is bedoeld voor pakketzendingen waarbij de ontvanger moet "
-"kunnen aantonen dat hij/zij 18+ is. Met deze optie worden \"Handtekening "
-"voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
-"worden gecombineerd met ochtend- of avondlevering."
-
-msgid "shipment_options_insured"
-msgstr "Verzekerde zending"
-
-msgid "shipment_options_insured_amount"
-msgstr "Verzekeren tot maximaal"
-
-msgid "shipment_options_insured_amount_help_text"
-msgstr "Verzeker alle orders tot het geselecteerde bedrag."
-
-msgid "shipment_options_insured_from_price"
-msgstr "Verzeker vanaf bedrag"
-
-msgid "shipment_options_insured_from_price_help_text"
-msgstr "Verzeker alle orders met een totaal prijs hoger dan het ingevulde bedrag."
-
-msgid "shipment_options_insured_help_text"
-msgstr ""
-"Standaard zit er geen verzekering op zendingen. Als je alsnog een zending "
-"wilt verzekeren kan dat. Wij verzekeren het aankoopbedrag van een zending "
-"met een maximum van €5000. Verzekerde zendingen worden altijd alleen "
-"afgeleverd op het thuisadres en een handtekening is vereist."
-
-msgid "shipment_options_large_format"
-msgstr "Extra grote verpakking"
-
-msgid "shipment_options_large_format_help_text"
-msgstr ""
-"Activeer deze instelling als je zending groter is dan 100 x 70 x 50 cm, "
-"maar kleiner dan 175 x 78 x 58 cm. Dit kost meer. Let op! Als het pakket "
-"groter dan 175 x 78 x 58 cm of zwaarder dan 30kg is, wordt het gerekend als "
-"pallet."
-
-msgid "shipment_options_only_recipient"
-msgstr "Alleen thuisadres"
-
-msgid "shipment_options_only_recipient_help_text"
-msgstr ""
-"Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
-"optie."
-
-msgid "shipment_options_return"
-msgstr "Retour bij mislukte leverpoging"
-
-msgid "shipment_options_return_help_text"
-msgstr ""
-"Standaard wordt een pakket 2x aangeboden. Bij 2 mislukte afleverpogingen, "
-"wordt het pakket bij het dichtstbijzijnde pickup point beschikbaar voor 2 "
-"weken. Daar kan het worden opgehaald met het bewijs dat is achtergelaten "
-"door de bezorger. Als je het pakket meteen retour wilt en NIET afgeleverd "
-"wil laten worden bij een pickup point, zet deze optie dan aan."
-
-msgid "shipment_options_signature"
-msgstr "Handtekening voor ontvangst"
-
-msgid "shipment_options_signature_help_text"
-msgstr ""
-"Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
-"thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
-"een handtekening vereist."
-
-msgid "weight"
-msgstr "Gewicht"
-
-msgid "error_api_for_order_%s_no_shipments_created"
-msgstr "MyParcel API error bij order %s, geen zendingen aangemaakt."
-
-msgid "error_api_no_shipments_created"
-msgstr "MyParcel API error, geen zendingen aangemaakt."
-
-msgid "export_orderid_%1$s_failed_because_%2$s"
-msgstr "Bestelling %1$s niet geëxporteerd naar MyParcel. %2$s"
-
-msgid "error_colli_weight_%1$s_but_max_%2$s"
-msgstr "Colli wegen %1$s kg, maximaal toegestaan is %2$s kg."
-
-msgid "error_collo_weight_%1$s_but_max_%2$s"
-msgstr "Zending weegt %1$s kg, maximum toegestaan is %2$s kg."
-
-msgid "export_hint_change_parcel"
-msgstr "Verander het pakkettype of maak meerdere labels aan."
-
-msgid "Invalid postal code"
-msgstr "Ongeldige postcode"
-
-msgid "Missing country"
-msgstr "Land ontbreekt"
-
-msgid "Missing number"
-msgstr "Nummer ontbreekt"
-
-msgid "settings_pickup_locations_default_view"
-msgstr "Pickup locaties standaard weergave"
-
-msgid "settings_pickup_locations_default_view_map"
-msgstr "Kaart"
-
-msgid "settings_pickup_locations_default_view_list"
-msgstr "Lijst"
-
 msgid "(Unknown)"
 msgstr "(Onbekend)"
 
@@ -270,6 +96,9 @@ msgstr ""
 msgid "Calculated weight: %s"
 msgstr "Berekend gewicht: %s"
 
+msgid "calculated_order_weight"
+msgstr "Berekend gewicht: %s"
+
 msgid "Carrier"
 msgstr "Vervoerder"
 
@@ -300,14 +129,6 @@ msgstr "Koppel e-mailadres klant"
 msgid "Connect customer phone"
 msgstr "Koppel telefoonnummer klant"
 
-msgid "product_options_country_of_origin"
-msgstr "Land van herkomst"
-
-msgid "setting_country_of_origin_help_text"
-msgstr ""
-"Land van herkomst is verplicht voor wereldzendingen. Standaard wordt de "
-"shoplocatie gebruikt."
-
 msgid "Custom ID (top left on label)"
 msgstr "Aangepast ID (linksboven op label)"
 
@@ -331,9 +152,6 @@ msgstr "Dagen van de week waarop je je pakket afgeeft bij PostNL"
 
 msgid "Default"
 msgstr "Standaard"
-
-msgid "setting_country_of_origin"
-msgstr "Standaard land van herkomst"
 
 msgid "Default export settings"
 msgstr "Standaard exportinstellingen"
@@ -369,10 +187,13 @@ msgid "Delivery options title"
 msgstr "Bezorgopties titel"
 
 msgid "Delivery title"
-msgstr "bezorg titel"
+msgstr "Bezorg titel"
 
 msgid "Delivery type"
 msgstr "Soort levering"
+
+msgid "delivery_type"
+msgstr "Soort levering:"
 
 msgid "Diagnostic tools"
 msgstr "Diagnostische hulpmiddelen"
@@ -451,6 +272,15 @@ msgstr ""
 "bijvoorbeeld korting geven voor het gebruiken van deze functie of wil je "
 "extra kosten rekenen voor deze bezorgoptie."
 
+msgid "error_api_for_order_%s_no_shipments_created"
+msgstr "MyParcel API error bij order %s, geen zendingen aangemaakt."
+
+msgid "error_api_no_shipments_created"
+msgstr "MyParcel API error, geen zendingen aangemaakt."
+
+msgid "error_collo_weight_%1$s_but_max_%2$s"
+msgstr "Gewicht per collo is %1$s kg, maximum toegestaan is %2$s kg."
+
 msgid "Evening delivery"
 msgstr "Avondlevering"
 
@@ -463,8 +293,17 @@ msgstr "Export opties"
 msgid "Export to MyParcel"
 msgstr "Exporteer naar MyParcel"
 
+msgid "export_hint_change_parcel"
+msgstr "Verander het pakkettype of maak meerdere labels aan."
+
+msgid "export_orderid_%1$s_failed_because_%2$s"
+msgstr "Bestelling %1$s niet geëxporteerd naar MyParcel. %2$s"
+
 msgid "Extra large size"
 msgstr "Extra grote verpakking"
+
+msgid "extra_options"
+msgstr "Extra opties:"
 
 msgid "Fee (optional)"
 msgstr "Kosten (optioneel)"
@@ -559,11 +398,23 @@ msgstr "Verzeker alle orders tot het geselecteerde bedrag."
 msgid "Insure from price"
 msgstr "Verzeker vanaf bedrag"
 
+msgid "insured"
+msgstr "Verzekerd"
+
 msgid "Insured for"
 msgstr "Verzekerd voor"
 
 msgid "Insured shipment"
 msgstr "Verzekerde zending"
+
+msgid "insured_amount"
+msgstr "Verzekerd bedrag"
+
+msgid "insured_for"
+msgstr "Verzekerd voor"
+
+msgid "Invalid postal code"
+msgstr "Ongeldige postcode"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -600,6 +451,12 @@ msgstr "Brievenbuspakje"
 msgid "Max insured amount"
 msgstr "Verzekeren tot maximaal"
 
+msgid "Missing country"
+msgstr "Land ontbreekt"
+
+msgid "Missing number"
+msgstr "Nummer ontbreekt"
+
 msgid "Monday delivery"
 msgstr "Maandag levering"
 
@@ -617,6 +474,9 @@ msgstr "MyParcel adresvelden"
 
 msgid "MyParcel shipment:"
 msgstr "MyParcel zending:"
+
+msgid "myparcel_shipment_created"
+msgstr "MyParcel zending aangemaakt"
 
 msgid "MyParcel: Export"
 msgstr "MyParcel: Exporteren"
@@ -641,6 +501,9 @@ msgstr "Er is nog geen label aangemaakt."
 
 msgid "No."
 msgstr "Nr."
+
+msgid "not_active"
+msgstr "Niet actief"
 
 msgid "Number"
 msgstr "Nummer"
@@ -695,6 +558,9 @@ msgstr "Afhaallocatie"
 
 msgid "Pickup title"
 msgstr "Afhalen titel"
+
+msgid "pickup_location"
+msgstr "Afhaallocatie:"
 
 msgid "Place barcode inside note"
 msgstr "Bewaar barcode in een notitie"
@@ -753,6 +619,9 @@ msgstr "Productaantal"
 msgid "Product SKU"
 msgstr "Product SKU"
 
+msgid "product_options_country_of_origin"
+msgstr "Land van herkomst"
+
 msgid "Retry"
 msgstr "Opnieuw"
 
@@ -771,11 +640,148 @@ msgstr "Selecteer een of meer verzendmethoden voor elk MyParcel pakkettype"
 msgid "Send email"
 msgstr "Verstuur e-mail"
 
+msgid "setting_automatic_order_status"
+msgstr "Automatische orderstatus"
+
+msgid "setting_change_order_status_after"
+msgstr "Verander order status na"
+
+msgid "setting_change_status_after_export"
+msgstr "Exporteren"
+
+msgid "setting_change_status_after_help_text"
+msgstr ""
+"Wijzig de bestelstatus na het exporteren of na het afdrukken van het "
+"verzendlabel."
+
+msgid "setting_change_status_after_printing"
+msgstr "Labels printen"
+
+msgid "setting_country_of_origin"
+msgstr "Standaard land van herkomst"
+
+msgid "setting_country_of_origin_help_text"
+msgstr ""
+"Land van herkomst is verplicht voor wereldzendingen. Standaard wordt de "
+"shoplocatie gebruikt."
+
+msgid "setting_export_automatic_status"
+msgstr "Automatische export bij besteling status"
+
+msgid "setting_export_automatic_status_help_text"
+msgstr ""
+"Maakt een zending aan in MyParcel wanneer de status van een bestelling "
+"wijzigt. Zorg dat je 'Verwerk zendingen direct' aan hebt staan om de "
+"barcode terug te krijgen."
+
 msgid "Settings"
 msgstr "Instellingen"
 
+msgid "settings_checkout_display_for"
+msgstr "Toon bij"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "Alle verzendmethoden"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
+"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
+"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Verzendmethoden gekoppeld aan pakkettype"
+
+msgid "settings_checkout_price_format"
+msgstr "Prijzen tonen als"
+
+msgid "settings_checkout_surcharge"
+msgstr "Meerprijs"
+
+msgid "settings_checkout_total_price"
+msgstr "Totaalprijs"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locaties standaard weergave"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Lijst"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Kaart"
+
 msgid "Shipment type"
 msgstr "Soort zending"
+
+msgid "shipment_options_age_check"
+msgstr "Leeftijdscheck 18+"
+
+msgid "shipment_options_age_check_help_text"
+msgstr ""
+"De leeftijdscheck is bedoeld voor pakketzendingen waarbij de ontvanger moet "
+"kunnen aantonen dat hij/zij 18+ is. Met deze optie worden \"Handtekening "
+"voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
+"worden gecombineerd met ochtend- of avondlevering."
+
+msgid "shipment_options_insured"
+msgstr "Verzekerde zending"
+
+msgid "shipment_options_insured_amount"
+msgstr "Verzekeren tot maximaal"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Verzeker alle orders tot het geselecteerde bedrag."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Verzeker vanaf bedrag"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Verzeker alle orders met een totaal prijs hoger dan het ingevulde bedrag."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"Standaard zit er geen verzekering op zendingen. Als je alsnog een zending "
+"wilt verzekeren kan dat. Wij verzekeren het aankoopbedrag van een zending "
+"met een maximum van €5000. Verzekerde zendingen worden altijd alleen "
+"afgeleverd op het thuisadres en een handtekening is vereist."
+
+msgid "shipment_options_large_format"
+msgstr "Extra grote verpakking"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Activeer deze instelling als je zending groter is dan 100 x 70 x 50 cm, "
+"maar kleiner dan 175 x 78 x 58 cm. Dit kost meer. Let op! Als het pakket "
+"groter dan 175 x 78 x 58 cm of zwaarder dan 30kg is, wordt het gerekend als "
+"pallet."
+
+msgid "shipment_options_only_recipient"
+msgstr "Alleen thuisadres"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
+"optie."
+
+msgid "shipment_options_return"
+msgstr "Retour bij mislukte leverpoging"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"Standaard wordt een pakket 2x aangeboden. Bij 2 mislukte afleverpogingen, "
+"wordt het pakket bij het dichtstbijzijnde pickup point beschikbaar voor 2 "
+"weken. Daar kan het worden opgehaald met het bewijs dat is achtergelaten "
+"door de bezorger. Als je het pakket meteen retour wilt en NIET afgeleverd "
+"wil laten worden bij een pickup point, zet deze optie dan aan."
+
+msgid "shipment_options_signature"
+msgstr "Handtekening voor ontvangst"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
+"thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
+"een handtekening vereist."
 
 msgid "Show after billing details"
 msgstr "Toon na factuurgegevens"
@@ -929,6 +935,9 @@ msgstr "Ongefrankeerd"
 
 msgid "View logs"
 msgstr "Logs weergeven"
+
+msgid "weight"
+msgstr "Gewicht"
 
 msgid ""
 "When enabled the checkout will use the MyParcel address fields. This means "

--- a/languages/woocommerce-myparcel-nl_NL.po
+++ b/languages/woocommerce-myparcel-nl_NL.po
@@ -11,180 +11,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language: nl_NL\n"
 
-msgid "setting_automatic_order_status"
-msgstr "Automatische orderstatus"
-
-msgid "setting_change_order_status_after"
-msgstr "Verander order status na"
-
-msgid "setting_change_status_after_printing"
-msgstr "Labels printen"
-
-msgid "setting_change_status_after_export"
-msgstr "Exporteren"
-
-msgid "setting_change_status_after_help_text"
-msgstr ""
-"Wijzig de bestelstatus na het exporteren of na het afdrukken van het "
-"verzendlabel."
-
-msgid "calculated_order_weight"
-msgstr "Berekend gewicht: %s"
-
-msgid "delivery_type"
-msgstr "Soort levering:"
-
-msgid "extra_options"
-msgstr "Extra opties:"
-
-msgid "insured"
-msgstr "Verzekerd"
-
-msgid "insured_amount"
-msgstr "Verzekerd bedrag"
-
-msgid "insured_for"
-msgstr "Verzekerd voor"
-
-msgid "myparcel_shipment_created"
-msgstr "MyParcel zending aangemaakt"
-
-msgid "pickup_location"
-msgstr "Afhaallocatie:"
-
-msgid "settings_checkout_display_for"
-msgstr "Toon bij"
-
-msgid "settings_checkout_display_for_all_methods"
-msgstr "Alle verzendmethoden"
-
-msgid "settings_checkout_display_for_help_text"
-msgstr ""
-"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
-"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
-"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
-
-msgid "settings_checkout_display_for_selected_methods"
-msgstr "Verzendmethoden gekoppeld aan pakkettype"
-
-msgid "settings_checkout_price_format"
-msgstr "Prijzen tonen als"
-
-msgid "settings_checkout_surcharge"
-msgstr "Meerprijs"
-
-msgid "settings_checkout_total_price"
-msgstr "Totaalprijs"
-
-msgid "shipment_options_age_check"
-msgstr "Leeftijdscheck 18+"
-
-msgid "shipment_options_age_check_help_text"
-msgstr ""
-"De leeftijdscheck is bedoeld voor pakketzendingen waarbij de ontvanger moet "
-"kunnen aantonen dat hij/zij 18+ is. Met deze optie worden \"Handtekening "
-"voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
-"worden gecombineerd met ochtend- of avondlevering."
-
-msgid "shipment_options_insured"
-msgstr "Verzekerde zending"
-
-msgid "shipment_options_insured_amount"
-msgstr "Verzekeren tot maximaal"
-
-msgid "shipment_options_insured_amount_help_text"
-msgstr "Verzeker alle orders tot het geselecteerde bedrag."
-
-msgid "shipment_options_insured_from_price"
-msgstr "Verzeker vanaf bedrag"
-
-msgid "shipment_options_insured_from_price_help_text"
-msgstr "Verzeker alle orders met een totaal prijs hoger dan het ingevulde bedrag."
-
-msgid "shipment_options_insured_help_text"
-msgstr ""
-"Standaard zit er geen verzekering op zendingen. Als je alsnog een zending "
-"wilt verzekeren kan dat. Wij verzekeren het aankoopbedrag van een zending "
-"met een maximum van €5000. Verzekerde zendingen worden altijd alleen "
-"afgeleverd op het thuisadres en een handtekening is vereist."
-
-msgid "shipment_options_large_format"
-msgstr "Extra grote verpakking"
-
-msgid "shipment_options_large_format_help_text"
-msgstr ""
-"Activeer deze instelling als je zending groter is dan 100 x 70 x 50 cm, "
-"maar kleiner dan 175 x 78 x 58 cm. Dit kost meer. Let op! Als het pakket "
-"groter dan 175 x 78 x 58 cm of zwaarder dan 30kg is, wordt het gerekend als "
-"pallet."
-
-msgid "shipment_options_only_recipient"
-msgstr "Alleen thuisadres"
-
-msgid "shipment_options_only_recipient_help_text"
-msgstr ""
-"Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
-"optie."
-
-msgid "shipment_options_return"
-msgstr "Retour bij mislukte leverpoging"
-
-msgid "shipment_options_return_help_text"
-msgstr ""
-"Standaard wordt een pakket 2x aangeboden. Bij 2 mislukte afleverpogingen, "
-"wordt het pakket bij het dichtstbijzijnde pickup point beschikbaar voor 2 "
-"weken. Daar kan het worden opgehaald met het bewijs dat is achtergelaten "
-"door de bezorger. Als je het pakket meteen retour wilt en NIET afgeleverd "
-"wil laten worden bij een pickup point, zet deze optie dan aan."
-
-msgid "shipment_options_signature"
-msgstr "Handtekening voor ontvangst"
-
-msgid "shipment_options_signature_help_text"
-msgstr ""
-"Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
-"thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
-"een handtekening vereist."
-
-msgid "weight"
-msgstr "Gewicht"
-
-msgid "error_api_for_order_%s_no_shipments_created"
-msgstr "MyParcel API error bij order %s, geen zendingen aangemaakt."
-
-msgid "error_api_no_shipments_created"
-msgstr "MyParcel API error, geen zendingen aangemaakt."
-
-msgid "export_orderid_%1$s_failed_because_%2$s"
-msgstr "Bestelling %1$s niet geëxporteerd naar MyParcel. %2$s"
-
-msgid "error_colli_weight_%1$s_but_max_%2$s"
-msgstr "Colli wegen %1$s kg, maximaal toegestaan is %2$s kg."
-
-msgid "error_collo_weight_%1$s_but_max_%2$s"
-msgstr "Zending weegt %1$s kg, maximum toegestaan is %2$s kg."
-
-msgid "export_hint_change_parcel"
-msgstr "Verander het pakkettype of maak meerdere labels aan."
-
-msgid "Invalid postal code"
-msgstr "Ongeldige postcode"
-
-msgid "Missing country"
-msgstr "Land ontbreekt"
-
-msgid "Missing number"
-msgstr "Nummer ontbreekt"
-
-msgid "settings_pickup_locations_default_view"
-msgstr "Pickup locaties standaard weergave"
-
-msgid "settings_pickup_locations_default_view_map"
-msgstr "Kaart"
-
-msgid "settings_pickup_locations_default_view_list"
-msgstr "Lijst"
-
 msgid "(Unknown)"
 msgstr "(Onbekend)"
 
@@ -270,6 +96,9 @@ msgstr ""
 msgid "Calculated weight: %s"
 msgstr "Berekend gewicht: %s"
 
+msgid "calculated_order_weight"
+msgstr "Berekend gewicht: %s"
+
 msgid "Carrier"
 msgstr "Vervoerder"
 
@@ -300,14 +129,6 @@ msgstr "Koppel e-mailadres klant"
 msgid "Connect customer phone"
 msgstr "Koppel telefoonnummer klant"
 
-msgid "product_options_country_of_origin"
-msgstr "Land van herkomst"
-
-msgid "setting_country_of_origin_help_text"
-msgstr ""
-"Land van herkomst is verplicht voor wereldzendingen. Standaard wordt de "
-"shoplocatie gebruikt."
-
 msgid "Custom ID (top left on label)"
 msgstr "Aangepast ID (linksboven op label)"
 
@@ -331,9 +152,6 @@ msgstr "Dagen van de week waarop je je pakket afgeeft bij PostNL"
 
 msgid "Default"
 msgstr "Standaard"
-
-msgid "setting_country_of_origin"
-msgstr "Standaard land van herkomst"
 
 msgid "Default export settings"
 msgstr "Standaard exportinstellingen"
@@ -369,10 +187,13 @@ msgid "Delivery options title"
 msgstr "Bezorgopties titel"
 
 msgid "Delivery title"
-msgstr "bezorg titel"
+msgstr "Bezorg titel"
 
 msgid "Delivery type"
 msgstr "Soort levering"
+
+msgid "delivery_type"
+msgstr "Soort levering:"
 
 msgid "Diagnostic tools"
 msgstr "Diagnostische hulpmiddelen"
@@ -451,6 +272,15 @@ msgstr ""
 "bijvoorbeeld korting geven voor het gebruiken van deze functie of wil je "
 "extra kosten rekenen voor deze bezorgoptie."
 
+msgid "error_api_for_order_%s_no_shipments_created"
+msgstr "MyParcel API error bij order %s, geen zendingen aangemaakt."
+
+msgid "error_api_no_shipments_created"
+msgstr "MyParcel API error, geen zendingen aangemaakt."
+
+msgid "error_collo_weight_%1$s_but_max_%2$s"
+msgstr "Gewicht per collo is %1$s kg, maximum toegestaan is %2$s kg."
+
 msgid "Evening delivery"
 msgstr "Avondlevering"
 
@@ -463,8 +293,17 @@ msgstr "Export opties"
 msgid "Export to MyParcel"
 msgstr "Exporteer naar MyParcel"
 
+msgid "export_hint_change_parcel"
+msgstr "Verander het pakkettype of maak meerdere labels aan."
+
+msgid "export_orderid_%1$s_failed_because_%2$s"
+msgstr "Bestelling %1$s niet geëxporteerd naar MyParcel. %2$s"
+
 msgid "Extra large size"
 msgstr "Extra grote verpakking"
+
+msgid "extra_options"
+msgstr "Extra opties:"
 
 msgid "Fee (optional)"
 msgstr "Kosten (optioneel)"
@@ -559,11 +398,23 @@ msgstr "Verzeker alle orders tot het geselecteerde bedrag."
 msgid "Insure from price"
 msgstr "Verzeker vanaf bedrag"
 
+msgid "insured"
+msgstr "Verzekerd"
+
 msgid "Insured for"
 msgstr "Verzekerd voor"
 
 msgid "Insured shipment"
 msgstr "Verzekerde zending"
+
+msgid "insured_amount"
+msgstr "Verzekerd bedrag"
+
+msgid "insured_for"
+msgstr "Verzekerd voor"
+
+msgid "Invalid postal code"
+msgstr "Ongeldige postcode"
 
 msgid ""
 "It looks like your shop is based in Netherlands. This plugin is for "
@@ -600,6 +451,12 @@ msgstr "Brievenbuspakje"
 msgid "Max insured amount"
 msgstr "Verzekeren tot maximaal"
 
+msgid "Missing country"
+msgstr "Land ontbreekt"
+
+msgid "Missing number"
+msgstr "Nummer ontbreekt"
+
 msgid "Monday delivery"
 msgstr "Maandag levering"
 
@@ -617,6 +474,9 @@ msgstr "MyParcel adresvelden"
 
 msgid "MyParcel shipment:"
 msgstr "MyParcel zending:"
+
+msgid "myparcel_shipment_created"
+msgstr "MyParcel zending aangemaakt"
 
 msgid "MyParcel: Export"
 msgstr "MyParcel: Exporteren"
@@ -641,6 +501,9 @@ msgstr "Er is nog geen label aangemaakt."
 
 msgid "No."
 msgstr "Nr."
+
+msgid "not_active"
+msgstr "Niet actief"
 
 msgid "Number"
 msgstr "Nummer"
@@ -695,6 +558,9 @@ msgstr "Afhaallocatie"
 
 msgid "Pickup title"
 msgstr "Afhalen titel"
+
+msgid "pickup_location"
+msgstr "Afhaallocatie:"
 
 msgid "Place barcode inside note"
 msgstr "Bewaar barcode in een notitie"
@@ -753,6 +619,9 @@ msgstr "Productaantal"
 msgid "Product SKU"
 msgstr "Product SKU"
 
+msgid "product_options_country_of_origin"
+msgstr "Land van herkomst"
+
 msgid "Retry"
 msgstr "Opnieuw"
 
@@ -771,11 +640,148 @@ msgstr "Selecteer een of meer verzendmethoden voor elk MyParcel pakkettype"
 msgid "Send email"
 msgstr "Verstuur e-mail"
 
+msgid "setting_automatic_order_status"
+msgstr "Automatische orderstatus"
+
+msgid "setting_change_order_status_after"
+msgstr "Verander order status na"
+
+msgid "setting_change_status_after_export"
+msgstr "Exporteren"
+
+msgid "setting_change_status_after_help_text"
+msgstr ""
+"Wijzig de bestelstatus na het exporteren of na het afdrukken van het "
+"verzendlabel."
+
+msgid "setting_change_status_after_printing"
+msgstr "Labels printen"
+
+msgid "setting_country_of_origin"
+msgstr "Standaard land van herkomst"
+
+msgid "setting_country_of_origin_help_text"
+msgstr ""
+"Land van herkomst is verplicht voor wereldzendingen. Standaard wordt de "
+"shoplocatie gebruikt."
+
+msgid "setting_export_automatic_status"
+msgstr "Automatische export bij besteling status"
+
+msgid "setting_export_automatic_status_help_text"
+msgstr ""
+"Maakt een zending aan in MyParcel wanneer de status van een bestelling "
+"wijzigt. Zorg dat je 'Verwerk zendingen direct' aan hebt staan om de "
+"barcode terug te krijgen."
+
 msgid "Settings"
 msgstr "Instellingen"
 
+msgid "settings_checkout_display_for"
+msgstr "Toon bij"
+
+msgid "settings_checkout_display_for_all_methods"
+msgstr "Alle verzendmethoden"
+
+msgid "settings_checkout_display_for_help_text"
+msgstr ""
+"Je kunt de bezorgopties koppelen aan specifieke verzendmethoden door ze toe "
+"te voegen aan de pakkettypen onder \"Standaard exportinstellingen\". De "
+"bezorgopties zijn niet zichtbaar op buitenlandse adressen."
+
+msgid "settings_checkout_display_for_selected_methods"
+msgstr "Verzendmethoden gekoppeld aan pakkettype"
+
+msgid "settings_checkout_price_format"
+msgstr "Prijzen tonen als"
+
+msgid "settings_checkout_surcharge"
+msgstr "Meerprijs"
+
+msgid "settings_checkout_total_price"
+msgstr "Totaalprijs"
+
+msgid "settings_pickup_locations_default_view"
+msgstr "Pickup locaties standaard weergave"
+
+msgid "settings_pickup_locations_default_view_list"
+msgstr "Lijst"
+
+msgid "settings_pickup_locations_default_view_map"
+msgstr "Kaart"
+
 msgid "Shipment type"
 msgstr "Soort zending"
+
+msgid "shipment_options_age_check"
+msgstr "Leeftijdscheck 18+"
+
+msgid "shipment_options_age_check_help_text"
+msgstr ""
+"De leeftijdscheck is bedoeld voor pakketzendingen waarbij de ontvanger moet "
+"kunnen aantonen dat hij/zij 18+ is. Met deze optie worden \"Handtekening "
+"voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
+"worden gecombineerd met ochtend- of avondlevering."
+
+msgid "shipment_options_insured"
+msgstr "Verzekerde zending"
+
+msgid "shipment_options_insured_amount"
+msgstr "Verzekeren tot maximaal"
+
+msgid "shipment_options_insured_amount_help_text"
+msgstr "Verzeker alle orders tot het geselecteerde bedrag."
+
+msgid "shipment_options_insured_from_price"
+msgstr "Verzeker vanaf bedrag"
+
+msgid "shipment_options_insured_from_price_help_text"
+msgstr "Verzeker alle orders met een totaal prijs hoger dan het ingevulde bedrag."
+
+msgid "shipment_options_insured_help_text"
+msgstr ""
+"Standaard zit er geen verzekering op zendingen. Als je alsnog een zending "
+"wilt verzekeren kan dat. Wij verzekeren het aankoopbedrag van een zending "
+"met een maximum van €5000. Verzekerde zendingen worden altijd alleen "
+"afgeleverd op het thuisadres en een handtekening is vereist."
+
+msgid "shipment_options_large_format"
+msgstr "Extra grote verpakking"
+
+msgid "shipment_options_large_format_help_text"
+msgstr ""
+"Activeer deze instelling als je zending groter is dan 100 x 70 x 50 cm, "
+"maar kleiner dan 175 x 78 x 58 cm. Dit kost meer. Let op! Als het pakket "
+"groter dan 175 x 78 x 58 cm of zwaarder dan 30kg is, wordt het gerekend als "
+"pallet."
+
+msgid "shipment_options_only_recipient"
+msgstr "Alleen thuisadres"
+
+msgid "shipment_options_only_recipient_help_text"
+msgstr ""
+"Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
+"optie."
+
+msgid "shipment_options_return"
+msgstr "Retour bij mislukte leverpoging"
+
+msgid "shipment_options_return_help_text"
+msgstr ""
+"Standaard wordt een pakket 2x aangeboden. Bij 2 mislukte afleverpogingen, "
+"wordt het pakket bij het dichtstbijzijnde pickup point beschikbaar voor 2 "
+"weken. Daar kan het worden opgehaald met het bewijs dat is achtergelaten "
+"door de bezorger. Als je het pakket meteen retour wilt en NIET afgeleverd "
+"wil laten worden bij een pickup point, zet deze optie dan aan."
+
+msgid "shipment_options_signature"
+msgstr "Handtekening voor ontvangst"
+
+msgid "shipment_options_signature_help_text"
+msgstr ""
+"Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
+"thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
+"een handtekening vereist."
 
 msgid "Show after billing details"
 msgstr "Toon na factuurgegevens"
@@ -929,6 +935,9 @@ msgstr "Ongefrankeerd"
 
 msgid "View logs"
 msgstr "Logs weergeven"
+
+msgid "weight"
+msgstr "Gewicht"
 
 msgid ""
 "When enabled the checkout will use the MyParcel address fields. This means "


### PR DESCRIPTION
…s) to MyParcel
Original functionality using the woocommerce_payment_complete hook is still in place, but the user can now choose an order status on which the shipments must be exported to MyParcel, in which case the payment_complete hook is canceled.