### PR TITLE
Feat: only show delivery options with non-virtual product in order

### DIFF
--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -88,9 +88,6 @@ class WCMP_Checkout
             $deps[] = "wcmp-checkout-fields";
         }
 
-        /*
-         * Show delivery options also for shipments on backorder
-         */
         if (! $this->shouldShowDeliveryOptions()) {
             return;
         }
@@ -529,27 +526,28 @@ class WCMP_Checkout
     }
 
     /**
-     * Show delivery options also for shipments on backorder
      * @return bool
      */
     private function shouldShowDeliveryOptions(): bool
     {
-        // $backorderDeliveryOptions causes the options to be displayed also when product is in backorder
-        $backorderDeliveryOptions = WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTINGS_SHOW_DELIVERY_OPTIONS_FOR_BACKORDERS);
-        $show                     = true;
-
-        if ($backorderDeliveryOptions) {
-            return $show;
-        }
+        $showForBackorders = WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTINGS_SHOW_DELIVERY_OPTIONS_FOR_BACKORDERS);
+        $show              = false;
 
         foreach (WC()->cart->get_cart() as $cartItem) {
             /**
              * @var WC_Product $product
              */
-            $product       = $cartItem['data'];
-            $isOnBackorder = $product->is_on_backorder($cartItem['quantity']);
+            $product = $cartItem['data'];
 
-            if ($isOnBackorder) {
+            if (! $show && ! $product->is_virtual()) {
+                $show = true;
+            }
+
+            if ($show && $showForBackorders) {
+                break;
+            }
+
+            if ($show && $product->is_on_backorder($cartItem['quantity'])) {
                 $show = false;
                 break;
             }

--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -526,6 +526,9 @@ class WCMP_Checkout
     }
 
     /**
+     * Returns true if any product in the loop is:
+     *  - physical
+     *  - not on backorder OR user allows products on backorder to have delivery options
      * @return bool
      */
     private function shouldShowDeliveryOptions(): bool
@@ -539,21 +542,15 @@ class WCMP_Checkout
              */
             $product = $cartItem['data'];
 
-            // check if any product in the loop is real (not virtual), only then we need to show the delivery options
-            if (! $showDeliveryOptions && ! $product->is_virtual()) {
+            if (! $product->is_virtual()) {
+
+                $isOnBackOrder = $product->is_on_backorder($cartItem['quantity']);
+                if (! $showForBackorders && $isOnBackOrder) {
+                    $showDeliveryOptions = false;
+                    break;
+                }
+
                 $showDeliveryOptions = true;
-            }
-
-            // if we show the delivery options regardless of whether a product is on backorder and we have a real
-            // product ($showDeliveryOptions is set to true), we are done with the loop
-            if ($showDeliveryOptions && $showForBackorders) {
-                break;
-            }
-
-            // check if any product in the loop is on backorder, if so return false
-            if ($showDeliveryOptions && $product->is_on_backorder($cartItem['quantity'])) {
-                $showDeliveryOptions = false;
-                break;
             }
         }
 

--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -530,8 +530,8 @@ class WCMP_Checkout
      */
     private function shouldShowDeliveryOptions(): bool
     {
-        $showForBackorders = WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTINGS_SHOW_DELIVERY_OPTIONS_FOR_BACKORDERS);
-        $show              = false;
+        $showForBackorders   = WCMYPA()->setting_collection->isEnabled(WCMYPA_Settings::SETTINGS_SHOW_DELIVERY_OPTIONS_FOR_BACKORDERS);
+        $showDeliveryOptions = false;
 
         foreach (WC()->cart->get_cart() as $cartItem) {
             /**
@@ -539,21 +539,25 @@ class WCMP_Checkout
              */
             $product = $cartItem['data'];
 
-            if (! $show && ! $product->is_virtual()) {
-                $show = true;
+            // check if any product in the loop is real (not virtual), only then we need to show the delivery options
+            if (! $showDeliveryOptions && ! $product->is_virtual()) {
+                $showDeliveryOptions = true;
             }
 
-            if ($show && $showForBackorders) {
+            // if we show the delivery options regardless of whether a product is on backorder and we have a real
+            // product ($showDeliveryOptions is set to true), we are done with the loop
+            if ($showDeliveryOptions && $showForBackorders) {
                 break;
             }
 
-            if ($show && $product->is_on_backorder($cartItem['quantity'])) {
-                $show = false;
+            // check if any product in the loop is on backorder, if so return false
+            if ($showDeliveryOptions && $product->is_on_backorder($cartItem['quantity'])) {
+                $showDeliveryOptions = false;
                 break;
             }
         }
 
-        return $show;
+        return $showDeliveryOptions;
     }
 }
 


### PR DESCRIPTION
Existing method expanded to also not show the options when only virtual products are in the cart