### PR TITLE
fix: additional fees not being added to totals if delivery options titles are empty

### DIFF
--- a/includes/admin/settings/class-wcmp-settings-data.php
+++ b/includes/admin/settings/class-wcmp-settings-data.php
@@ -541,7 +541,7 @@ class WCMP_Settings_Data
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DELIVERY_MORNING_ENABLED,
                 "condition" => WCMYPA_Settings::SETTING_CARRIER_DELIVERY_ENABLED,
-                "label"     => __("Morning delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_morning", "woocommerce-myparcel"),
                 "type"      => "toggle",
             ],
             self::getFeeField(
@@ -554,7 +554,7 @@ class WCMP_Settings_Data
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_DELIVERY_EVENING_ENABLED,
                 "condition" => WCMYPA_Settings::SETTING_CARRIER_DELIVERY_ENABLED,
-                "label"     => __("Evening delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_evening", "woocommerce-myparcel"),
                 "type"      => "toggle",
             ],
             self::getFeeField(
@@ -597,7 +597,7 @@ class WCMP_Settings_Data
             [
                 "name"      => WCMYPA_Settings::SETTING_CARRIER_MONDAY_DELIVERY_ENABLED,
                 "condition" => WCMYPA_Settings::SETTING_CARRIER_DELIVERY_ENABLED,
-                "label"     => __("Monday delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_monday", "woocommerce-myparcel"),
                 "type"      => "toggle",
             ],
             [
@@ -929,58 +929,53 @@ class WCMP_Settings_Data
             [
                 "name"      => WCMYPA_Settings::SETTING_HEADER_DELIVERY_OPTIONS_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Delivery options title", "woocommerce-myparcel"),
-                "title"     => "Delivery options title",
-                "help_text" => __(
-                    "You can place a delivery title above the MyParcel options. When there is no title, it will not be visible.",
-                    "woocommerce-myparcel"
-                ),
+                "label"     => __("shipment_options_delivery_options_title", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_delivery_options_title_description", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_DELIVERY_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Delivery title", "woocommerce-myparcel"),
-                "default"   => __("Delivered at home or at work", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_title", "woocommerce-myparcel"),
+                "default"   => __("shipment_options_delivery", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_MORNING_DELIVERY_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Morning delivery title", "woocommerce-myparcel"),
-                "default"   => __("Morning delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_morning_title", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_delivery_standard_description", "woocommerce-myparcel"),
+                "default"   => __("shipment_options_delivery_morning", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_STANDARD_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Standard delivery title", "woocommerce-myparcel"),
-                "help_text" => __(
-                    "When there is no title, the delivery time will automatically be visible.",
-                    "woocommerce-myparcel"
-                ),
-                "default"   => __("Standard delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_standard_title", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_delivery_standard_description", "woocommerce-myparcel"),
+                "default"   => __("shipment_options_delivery_standard", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_EVENING_DELIVERY_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Evening delivery title", "woocommerce-myparcel"),
-                "default"   => __("Evening delivery", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_evening_title", "woocommerce-myparcel"),
+                "help_text" => __("shipment_options_delivery_standard_description", "woocommerce-myparcel"),
+                "default"   => __("shipment_options_delivery_evening", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_ONLY_RECIPIENT_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Home address only title", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_only_recipient_title", "woocommerce-myparcel"),
                 "default"   => __("shipment_options_only_recipient", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_SIGNATURE_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Signature on delivery title", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_signature_title", "woocommerce-myparcel"),
                 "default"   => __("shipment_options_signature", "woocommerce-myparcel"),
             ],
             [
                 "name"      => WCMYPA_Settings::SETTING_PICKUP_TITLE,
                 "condition" => WCMYPA_Settings::SETTING_DELIVERY_OPTIONS_ENABLED,
-                "label"     => __("Pickup title", "woocommerce-myparcel"),
-                "default"   => __("Pickup", "woocommerce-myparcel"),
+                "label"     => __("shipment_options_delivery_pickup_title", "woocommerce-myparcel"),
+                "default"   => __("shipment_options_delivery_pickup", "woocommerce-myparcel"),
             ],
         ];
     }

--- a/includes/class-wcmp-data.php
+++ b/includes/class-wcmp-data.php
@@ -101,10 +101,10 @@ class WCMP_Data
         ];
 
         self::$deliveryTypesHuman = [
-            AbstractConsignment::DELIVERY_TYPE_MORNING_NAME  => __("Morning delivery", "woocommerce-myparcel"),
-            AbstractConsignment::DELIVERY_TYPE_STANDARD_NAME => __("Standard delivery", "woocommerce-myparcel"),
-            AbstractConsignment::DELIVERY_TYPE_EVENING_NAME  => __("Evening delivery", "woocommerce-myparcel"),
-            AbstractConsignment::DELIVERY_TYPE_PICKUP_NAME   => __("Pickup", "woocommerce-myparcel"),
+            AbstractConsignment::DELIVERY_TYPE_MORNING_NAME  => __("shipment_options_delivery_morning", "woocommerce-myparcel"),
+            AbstractConsignment::DELIVERY_TYPE_STANDARD_NAME => __("shipment_options_delivery_standard", "woocommerce-myparcel"),
+            AbstractConsignment::DELIVERY_TYPE_EVENING_NAME  => __("shipment_options_delivery_evening", "woocommerce-myparcel"),
+            AbstractConsignment::DELIVERY_TYPE_PICKUP_NAME   => __("shipment_options_delivery_pickup", "woocommerce-myparcel"),
         ];
     }
 

--- a/languages/woocommerce-myparcel-en_GB.po
+++ b/languages/woocommerce-myparcel-en_GB.po
@@ -172,7 +172,7 @@ msgstr "delivered - package picked up"
 msgid "delivered - ready for pickup"
 msgstr "delivered - ready for pickup"
 
-msgid "Delivered at home or at work"
+msgid "shipment_options_delivery"
 msgstr "Delivered at home or at work"
 
 msgid "Delivery date"
@@ -184,10 +184,10 @@ msgstr "Delivery days window"
 msgid "Delivery information:"
 msgstr "Delivery information:"
 
-msgid "Delivery options title"
+msgid "shipment_options_delivery_options_title"
 msgstr "Delivery options title"
 
-msgid "Delivery title"
+msgid "shipment_options_delivery_title"
 msgstr "Delivery title"
 
 msgid "Delivery type"
@@ -282,12 +282,6 @@ msgstr "MyParcel API error, no shipments created."
 msgid "error_collo_weight_%1$s_but_max_%2$s"
 msgstr "Weight per package is %1$s kg, maximum allowed is %2$s kg."
 
-msgid "Evening delivery"
-msgstr "Evening delivery"
-
-msgid "Evening delivery title"
-msgstr "Evening delivery title"
-
 msgid "Export options"
 msgstr "Export options"
 
@@ -320,12 +314,6 @@ msgstr "Gifts"
 
 msgid "Hide this message"
 msgstr "Hide this message"
-
-msgid "Home address only"
-msgstr "Home address only"
-
-msgid "Home address only title"
-msgstr "Home address only title"
 
 msgid "House number"
 msgstr "House number"
@@ -462,10 +450,10 @@ msgstr "Number is missing"
 msgid "Monday delivery"
 msgstr "Monday delivery"
 
-msgid "Morning delivery"
+msgid "shipment_options_delivery_morning"
 msgstr "Morning delivery"
 
-msgid "Morning delivery title"
+msgid "shipment_options_delivery_morning_title"
 msgstr "Morning delivery title"
 
 msgid "MyParcel"
@@ -552,13 +540,13 @@ msgstr "Pick up at"
 msgid "Pick up from"
 msgstr "Pick up from"
 
-msgid "Pickup"
+msgid "shipment_options_delivery_pickup"
 msgstr "Pickup"
 
 msgid "Pickup location"
 msgstr "Pickup location"
 
-msgid "Pickup title"
+msgid "shipment_options_delivery_pickup_title"
 msgstr "Pickup title"
 
 msgid "pickup_location"
@@ -720,6 +708,18 @@ msgstr ""
 "receipt\" and \"Delivery only at recipient\" are included with this option. "
 "This option can't be combined with morning or evening delivery."
 
+msgid "shipment_options_delivery_evening"
+msgstr "Evening delivery"
+
+msgid "shipment_options_delivery_evening_title"
+msgstr "Evening delivery title"
+
+msgid "shipment_options_delivery_standard_description"
+msgstr "When there is no title, the delivery time will automatically be visible."
+
+msgid "shipment_options_delivery_standard_title"
+msgstr "Standard delivery title"
+
 msgid "shipment_options_insured"
 msgstr "Insured shipment"
 
@@ -760,6 +760,9 @@ msgstr ""
 "If you don't want the parcel to be delivered at the neighbours, choose this "
 "option."
 
+msgid "shipment_options_only_recipient_title"
+msgstr "Home address only title"
+
 msgid "shipment_options_return"
 msgstr "Return if no answer"
 
@@ -779,6 +782,9 @@ msgstr ""
 "The parcel will be offered at the delivery address. If the recipient is not "
 "at home, the parcel will be delivered to the neighbours. In both cases, a "
 "signature will be required."
+
+msgid "shipment_options_signature_title"
+msgstr "Signature on delivery title"
 
 msgid "Show after billing details"
 msgstr "Show after billing details"
@@ -808,17 +814,8 @@ msgstr ""
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Show Track & Trace code and link in My Account."
 
-msgid "Signature on delivery"
-msgstr "Signature on delivery"
-
-msgid "Signature on delivery title"
-msgstr "Signature on delivery title"
-
 msgid "Standard delivery"
 msgstr "Standard delivery"
-
-msgid "Standard delivery title"
-msgstr "Standard delivery title"
 
 msgid "Standard printer (A4)"
 msgstr "Standard printer (A4)"
@@ -939,9 +936,6 @@ msgstr ""
 "there will be three separate fields for street name, number and suffix. "
 "Want to use the WooCommerce default fields? Leave this option unchecked."
 
-msgid "When there is no title, the delivery time will automatically be visible."
-msgstr "When there is no title, the delivery time will automatically be visible."
-
 msgid ""
 "When this option is enabled, delivery options and delivery day will be also "
 "shown for backorders."
@@ -1013,9 +1007,7 @@ msgstr ""
 msgid "You can change the text before the barcode inside an note"
 msgstr "You can change the text before the barcode inside an note"
 
-msgid ""
-"You can place a delivery title above the MyParcel options. When there is no "
-"title, it will not be visible."
+msgid "shipment_options_delivery_options_title_description"
 msgstr ""
 "You can place a delivery title above the MyParcel options. When there is no "
 "title, it will not be visible."

--- a/languages/woocommerce-myparcel-en_US.po
+++ b/languages/woocommerce-myparcel-en_US.po
@@ -173,7 +173,7 @@ msgstr "delivered - package picked up"
 msgid "delivered - ready for pickup"
 msgstr "delivered - ready for pickup"
 
-msgid "Delivered at home or at work"
+msgid "shipment_options_delivery"
 msgstr "Delivered at home or at work"
 
 msgid "Delivery date"
@@ -185,10 +185,10 @@ msgstr "Delivery days window"
 msgid "Delivery information:"
 msgstr "Delivery information:"
 
-msgid "Delivery options title"
+msgid "shipment_options_delivery_options_title"
 msgstr "Delivery options title"
 
-msgid "Delivery title"
+msgid "shipment_options_delivery_title"
 msgstr "Delivery title"
 
 msgid "Delivery type"
@@ -283,12 +283,6 @@ msgstr "MyParcel API error, no shipments created."
 msgid "error_collo_weight_%1$s_but_max_%2$s"
 msgstr "Weight per package is %1$s kg, maximum allowed is %2$s kg."
 
-msgid "Evening delivery"
-msgstr "Evening delivery"
-
-msgid "Evening delivery title"
-msgstr "Evening delivery title"
-
 msgid "Export options"
 msgstr "Export options"
 
@@ -321,12 +315,6 @@ msgstr "Gifts"
 
 msgid "Hide this message"
 msgstr "Hide this message"
-
-msgid "Home address only"
-msgstr "Home address only"
-
-msgid "Home address only title"
-msgstr "Home address only title"
 
 msgid "House number"
 msgstr "House number"
@@ -463,10 +451,10 @@ msgstr "Number is missing"
 msgid "Monday delivery"
 msgstr "Monday delivery"
 
-msgid "Morning delivery"
+msgid "shipment_options_delivery_morning"
 msgstr "Morning delivery"
 
-msgid "Morning delivery title"
+msgid "shipment_options_delivery_morning_title"
 msgstr "Morning delivery title"
 
 msgid "MyParcel"
@@ -553,13 +541,13 @@ msgstr "Pick up at"
 msgid "Pick up from"
 msgstr "Pick up from"
 
-msgid "Pickup"
+msgid "shipment_options_delivery_pickup"
 msgstr "Pickup"
 
 msgid "Pickup location"
 msgstr "Pickup location"
 
-msgid "Pickup title"
+msgid "shipment_options_delivery_pickup_title"
 msgstr "Pickup title"
 
 msgid "pickup_location"
@@ -721,6 +709,18 @@ msgstr ""
 "receipt\" and \"Delivery only at recipient\" are included with this option. "
 "This option can't be combined with morning or evening delivery."
 
+msgid "shipment_options_delivery_evening"
+msgstr "Evening delivery"
+
+msgid "shipment_options_delivery_evening_title"
+msgstr "Evening delivery title"
+
+msgid "shipment_options_delivery_standard_description"
+msgstr "When there is no title, the delivery time will automatically be visible."
+
+msgid "shipment_options_delivery_standard_title"
+msgstr "Standard delivery title"
+
 msgid "shipment_options_insured"
 msgstr "Insured shipment"
 
@@ -761,6 +761,9 @@ msgstr ""
 "If you don't want the parcel to be delivered at the neighbours, choose this "
 "option."
 
+msgid "shipment_options_only_recipient_title"
+msgstr "Home address only title"
+
 msgid "shipment_options_return"
 msgstr "Return if no answer"
 
@@ -780,6 +783,9 @@ msgstr ""
 "The parcel will be offered at the delivery address. If the recipient is not "
 "at home, the parcel will be delivered to the neighbours. In both cases, a "
 "signature will be required."
+
+msgid "shipment_options_signature_title"
+msgstr "Signature on delivery title"
 
 msgid "Show after billing details"
 msgstr "Show after billing details"
@@ -809,17 +815,8 @@ msgstr ""
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Show Track & Trace code and link in My Account."
 
-msgid "Signature on delivery"
-msgstr "Signature on delivery"
-
-msgid "Signature on delivery title"
-msgstr "Signature on delivery title"
-
 msgid "Standard delivery"
 msgstr "Standard delivery"
-
-msgid "Standard delivery title"
-msgstr "Standard delivery title"
 
 msgid "Standard printer (A4)"
 msgstr "Standard printer (A4)"
@@ -940,9 +937,6 @@ msgstr ""
 "there will be three separate fields for street name, number and suffix. "
 "Want to use the WooCommerce default fields? Leave this option unchecked."
 
-msgid "When there is no title, the delivery time will automatically be visible."
-msgstr "When there is no title, the delivery time will automatically be visible."
-
 msgid ""
 "When this option is enabled, delivery options and delivery day will be also "
 "shown for backorders."
@@ -1014,9 +1008,7 @@ msgstr ""
 msgid "You can change the text before the barcode inside an note"
 msgstr "You can change the text before the barcode inside an note"
 
-msgid ""
-"You can place a delivery title above the MyParcel options. When there is no "
-"title, it will not be visible."
+msgid "shipment_options_delivery_options_title_description"
 msgstr ""
 "You can place a delivery title above the MyParcel options. When there is no "
 "title, it will not be visible."

--- a/languages/woocommerce-myparcel-fr_BE.po
+++ b/languages/woocommerce-myparcel-fr_BE.po
@@ -134,7 +134,7 @@ msgid "Connect customer phone"
 msgstr "Associer le numéro de téléphone du client"
 
 msgid "Custom ID (top left on label)"
-msgstr "ID personnalisés (angle supérieur gauche sur l 'étiquette)"
+msgstr "ID personnalisés (en haut à gauche sur l'étiquette)"
 
 msgid "Custom styles"
 msgstr "Styles personnalisés (CSS)"
@@ -175,7 +175,7 @@ msgstr "livré - collecté"
 msgid "delivered - ready for pickup"
 msgstr "livré - prêt à être collecté"
 
-msgid "Delivered at home or at work"
+msgid "shipment_options_delivery"
 msgstr "Livré à la maison ou au travail"
 
 msgid "Delivery date"
@@ -187,10 +187,10 @@ msgstr "Fenêtre jours de livraison"
 msgid "Delivery information:"
 msgstr "Informations de livraison:"
 
-msgid "Delivery options title"
+msgid "shipment_options_delivery_options_title"
 msgstr "Options de livraison - titre"
 
-msgid "Delivery title"
+msgid "shipment_options_delivery_title"
 msgstr "Titre de la livraison"
 
 msgid "Delivery type"
@@ -285,12 +285,6 @@ msgstr "MyParcel API erreur, aucun envoi n'a été créé."
 msgid "error_collo_weight_%1$s_but_max_%2$s"
 msgstr "Poids par paquet est de %1$s kg, maximum est %2$s kg."
 
-msgid "Evening delivery"
-msgstr "Livraison en soirée"
-
-msgid "Evening delivery title"
-msgstr "Titre de la livraison du soir"
-
 msgid "Export options"
 msgstr "Options d'exportation"
 
@@ -323,12 +317,6 @@ msgstr "Cadeaux"
 
 msgid "Hide this message"
 msgstr "Masquez ce message"
-
-msgid "Home address only"
-msgstr "Qu'adresse du domicile"
-
-msgid "Home address only title"
-msgstr "Adresse du domicile seul titre"
 
 msgid "House number"
 msgstr "Numéro de rue"
@@ -465,10 +453,10 @@ msgstr "Numéro manque"
 msgid "Monday delivery"
 msgstr "Livraison lundi"
 
-msgid "Morning delivery"
+msgid "shipment_options_delivery_morning"
 msgstr "Livraison le matin"
 
-msgid "Morning delivery title"
+msgid "shipment_options_delivery_morning_title"
 msgstr "Titre de la livraison du matin"
 
 msgid "MyParcel"
@@ -555,13 +543,13 @@ msgstr "Ramasser à"
 msgid "Pick up from"
 msgstr "Collecte à partir de"
 
-msgid "Pickup"
+msgid "shipment_options_delivery_pickup"
 msgstr "Ramasser"
 
 msgid "Pickup location"
 msgstr "Lieu de ramassage"
 
-msgid "Pickup title"
+msgid "shipment_options_delivery_pickup_title"
 msgstr "Titre du ramassage"
 
 msgid "pickup_location"
@@ -731,6 +719,20 @@ msgstr ""
 "uniquement chez le destinataire' sont inclus. Cette option ne peut pas être "
 "combinée avec la livraison le matin ou le soir."
 
+msgid "shipment_options_delivery_evening"
+msgstr "Livraison en soirée"
+
+msgid "shipment_options_delivery_evening_title"
+msgstr "Titre de la livraison du soir"
+
+msgid "shipment_options_delivery_standard_description"
+msgstr ""
+"Lorsqu'aucun titre n'est complété, les heures de livraison sont affichées "
+"automatiquement."
+
+msgid "shipment_options_delivery_standard_title"
+msgstr "Livraison standard - titre"
+
 msgid "shipment_options_insured"
 msgstr "Expédition assuré"
 
@@ -772,6 +774,9 @@ msgstr ""
 "Si vous ne voulez pas que le colis soit livré aux voisins, choisissez cette "
 "option."
 
+msgid "shipment_options_only_recipient_title"
+msgstr "Adresse du domicile seul titre"
+
 msgid "shipment_options_return"
 msgstr "Retour si aucune réponse"
 
@@ -792,6 +797,9 @@ msgstr ""
 "Le colis sera offert à l'adresse de livraison. Si le destinataire est pas à "
 "la maison, le colis sera livré aux voisins. Dans les deux cas, une "
 "signature sera nécessaire."
+
+msgid "shipment_options_signature_title"
+msgstr "Signature sur le titre de livraison"
 
 msgid "Show after billing details"
 msgstr "Afficher après les données de facturation"
@@ -821,17 +829,8 @@ msgstr ""
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Montrer le code et le lien Track & Trace dans Mon Compte."
 
-msgid "Signature on delivery"
-msgstr "Signature pour réception"
-
-msgid "Signature on delivery title"
-msgstr "Signature sur le titre de livraison"
-
 msgid "Standard delivery"
 msgstr "Livraison standard"
-
-msgid "Standard delivery title"
-msgstr "Livraison standard - titre"
 
 msgid "Standard printer (A4)"
 msgstr "Imprimante standard (A4)"
@@ -957,11 +956,6 @@ msgstr ""
 "l'extension. Si vous souhaitez utiliser les champs adresse standards de "
 "WooCommerce, ne cochez pas cette option."
 
-msgid "When there is no title, the delivery time will automatically be visible."
-msgstr ""
-"Lorsqu'aucun titre n'est complété, les heures de livraison sont affichées "
-"automatiquement."
-
 msgid ""
 "When this option is enabled, delivery options and delivery day will be also "
 "shown for backorders."
@@ -1037,9 +1031,7 @@ msgstr ""
 msgid "You can change the text before the barcode inside an note"
 msgstr "Vous pouvez modifier le texte du code-barres dans une note"
 
-msgid ""
-"You can place a delivery title above the MyParcel options. When there is no "
-"title, it will not be visible."
+msgid "shipment_options_delivery_options_title_description"
 msgstr ""
 "Vous pouvez indiquer un titre pour la livraison au-dessus des options "
 "MyParcel. S'il n'y a pas de titre, cet élément ne sera pas visible."

--- a/languages/woocommerce-myparcel-fr_FR.po
+++ b/languages/woocommerce-myparcel-fr_FR.po
@@ -134,7 +134,7 @@ msgid "Connect customer phone"
 msgstr "Associer le numéro de tél��phone du client"
 
 msgid "Custom ID (top left on label)"
-msgstr "ID personnalisés (angle supérieur gauche sur l 'étiquette)"
+msgstr "ID personnalisés (en haut à gauche sur l'étiquette)"
 
 msgid "Custom styles"
 msgstr "Styles personnalisés (CSS)"
@@ -175,7 +175,7 @@ msgstr "livré - collecté"
 msgid "delivered - ready for pickup"
 msgstr "livré - prêt à être collecté"
 
-msgid "Delivered at home or at work"
+msgid "shipment_options_delivery"
 msgstr "Livré à la maison ou au travail"
 
 msgid "Delivery date"
@@ -187,10 +187,10 @@ msgstr "Fenêtre jours de livraison"
 msgid "Delivery information:"
 msgstr "Informations de livraison:"
 
-msgid "Delivery options title"
+msgid "shipment_options_delivery_options_title"
 msgstr "Options de livraison - titre"
 
-msgid "Delivery title"
+msgid "shipment_options_delivery_title"
 msgstr "Titre de la livraison"
 
 msgid "Delivery type"
@@ -285,12 +285,6 @@ msgstr "MyParcel API erreur, aucun envoi n'a été créé."
 msgid "error_collo_weight_%1$s_but_max_%2$s"
 msgstr "Poids par paquet est de %1$s kg, maximum est %2$s kg."
 
-msgid "Evening delivery"
-msgstr "Livraison en soirée"
-
-msgid "Evening delivery title"
-msgstr "Titre de la livraison du soir"
-
 msgid "Export options"
 msgstr "Options d'exportation"
 
@@ -324,12 +318,6 @@ msgstr "Cadeaux"
 msgid "Hide this message"
 msgstr "Masquez ce message"
 
-msgid "Home address only"
-msgstr "Qu'adresse du domicile"
-
-msgid "Home address only title"
-msgstr "Adresse du domicile seul titre"
-
 msgid "House number"
 msgstr "Numéro de rue"
 
@@ -344,7 +332,7 @@ msgid ""
 "appropriate code on the %ssite of the Dutch Customs%s"
 msgstr ""
 "Les codes SH sont utilisés pour les envois dans le monde MyParcel, vous "
-"pouvez trouver le code approprié sur le %ssite de la douane néerlandaise%s"
+"pouvez trouver le code approprié sur le %ssite de la douane n��erlandaise%s"
 
 msgid ""
 "HS Codes are used for MyParcel world shipments, you can find the "
@@ -465,10 +453,10 @@ msgstr "Numéro manque"
 msgid "Monday delivery"
 msgstr "Livraison lundi"
 
-msgid "Morning delivery"
+msgid "shipment_options_delivery_morning"
 msgstr "Livraison le matin"
 
-msgid "Morning delivery title"
+msgid "shipment_options_delivery_morning_title"
 msgstr "Titre de la livraison du matin"
 
 msgid "MyParcel"
@@ -555,13 +543,13 @@ msgstr "Ramasser à"
 msgid "Pick up from"
 msgstr "Collecte à partir de"
 
-msgid "Pickup"
+msgid "shipment_options_delivery_pickup"
 msgstr "Ramasser"
 
 msgid "Pickup location"
 msgstr "Lieu de ramassage"
 
-msgid "Pickup title"
+msgid "shipment_options_delivery_pickup_title"
 msgstr "Titre du ramassage"
 
 msgid "pickup_location"
@@ -731,6 +719,20 @@ msgstr ""
 "uniquement chez le destinataire' sont inclus. Cette option ne peut pas être "
 "combinée avec la livraison le matin ou le soir."
 
+msgid "shipment_options_delivery_evening"
+msgstr "Livraison en soirée"
+
+msgid "shipment_options_delivery_evening_title"
+msgstr "Titre de la livraison du soir"
+
+msgid "shipment_options_delivery_standard_description"
+msgstr ""
+"Lorsqu'aucun titre n'est complété, les heures de livraison sont affichées "
+"automatiquement."
+
+msgid "shipment_options_delivery_standard_title"
+msgstr "Livraison standard - titre"
+
 msgid "shipment_options_insured"
 msgstr "Expédition assuré"
 
@@ -772,6 +774,9 @@ msgstr ""
 "Si vous ne voulez pas que le colis soit livré aux voisins, choisissez cette "
 "option."
 
+msgid "shipment_options_only_recipient_title"
+msgstr "Adresse du domicile seul titre"
+
 msgid "shipment_options_return"
 msgstr "Retour si aucune réponse"
 
@@ -792,6 +797,9 @@ msgstr ""
 "Le colis sera offert à l'adresse de livraison. Si le destinataire est pas à "
 "la maison, le colis sera livré aux voisins. Dans les deux cas, une "
 "signature sera nécessaire."
+
+msgid "shipment_options_signature_title"
+msgstr "Signature sur le titre de livraison"
 
 msgid "Show after billing details"
 msgstr "Afficher après les données de facturation"
@@ -821,17 +829,8 @@ msgstr ""
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Montrer le code et le lien Track & Trace dans Mon Compte."
 
-msgid "Signature on delivery"
-msgstr "Signature pour réception"
-
-msgid "Signature on delivery title"
-msgstr "Signature sur le titre de livraison"
-
 msgid "Standard delivery"
 msgstr "Livraison standard"
-
-msgid "Standard delivery title"
-msgstr "Livraison standard - titre"
 
 msgid "Standard printer (A4)"
 msgstr "Imprimante standard (A4)"
@@ -957,11 +956,6 @@ msgstr ""
 "l'extension. Si vous souhaitez utiliser les champs adresse standards de "
 "WooCommerce, ne cochez pas cette option."
 
-msgid "When there is no title, the delivery time will automatically be visible."
-msgstr ""
-"Lorsqu'aucun titre n'est complété, les heures de livraison sont affichées "
-"automatiquement."
-
 msgid ""
 "When this option is enabled, delivery options and delivery day will be also "
 "shown for backorders."
@@ -1037,9 +1031,7 @@ msgstr ""
 msgid "You can change the text before the barcode inside an note"
 msgstr "Vous pouvez modifier le texte du code-barres dans une note"
 
-msgid ""
-"You can place a delivery title above the MyParcel options. When there is no "
-"title, it will not be visible."
+msgid "shipment_options_delivery_options_title_description"
 msgstr ""
 "Vous pouvez indiquer un titre pour la livraison au-dessus des options "
 "MyParcel. S'il n'y a pas de titre, cet élément ne sera pas visible."

--- a/languages/woocommerce-myparcel-nl_BE.po
+++ b/languages/woocommerce-myparcel-nl_BE.po
@@ -171,7 +171,7 @@ msgstr "afgeleverd - opgehaald"
 msgid "delivered - ready for pickup"
 msgstr "afgeleverd - klaar om opgehaald te worden"
 
-msgid "Delivered at home or at work"
+msgid "shipment_options_delivery"
 msgstr "Thuis of op het werk bezorgd"
 
 msgid "Delivery date"
@@ -183,10 +183,10 @@ msgstr "Leverdagen venster"
 msgid "Delivery information:"
 msgstr "Bezorginformatie:"
 
-msgid "Delivery options title"
+msgid "shipment_options_delivery_options_title"
 msgstr "Bezorgopties titel"
 
-msgid "Delivery title"
+msgid "shipment_options_delivery_title"
 msgstr "Bezorg titel"
 
 msgid "Delivery type"
@@ -281,12 +281,6 @@ msgstr "MyParcel API error, geen zendingen aangemaakt."
 msgid "error_collo_weight_%1$s_but_max_%2$s"
 msgstr "Gewicht per collo is %1$s kg, maximum toegestaan is %2$s kg."
 
-msgid "Evening delivery"
-msgstr "Avondlevering"
-
-msgid "Evening delivery title"
-msgstr "Avondlevering titel"
-
 msgid "Export options"
 msgstr "Export opties"
 
@@ -319,12 +313,6 @@ msgstr "Geschenken"
 
 msgid "Hide this message"
 msgstr "Verberg dit bericht"
-
-msgid "Home address only"
-msgstr "Alleen thuisadres"
-
-msgid "Home address only title"
-msgstr "Alleen thuisadres titel"
 
 msgid "House number"
 msgstr "Huisnummer"
@@ -460,10 +448,10 @@ msgstr "Nummer ontbreekt"
 msgid "Monday delivery"
 msgstr "Maandag levering"
 
-msgid "Morning delivery"
+msgid "shipment_options_delivery_morning"
 msgstr "Ochtendlevering"
 
-msgid "Morning delivery title"
+msgid "shipment_options_delivery_morning_title"
 msgstr "Ochtendlevering titel"
 
 msgid "MyParcel"
@@ -550,13 +538,13 @@ msgstr "Afhalen bij"
 msgid "Pick up from"
 msgstr "Ophalen vanaf"
 
-msgid "Pickup"
+msgid "shipment_options_delivery_pickup"
 msgstr "Afhalen"
 
 msgid "Pickup location"
 msgstr "Afhaallocatie"
 
-msgid "Pickup title"
+msgid "shipment_options_delivery_pickup_title"
 msgstr "Afhalen titel"
 
 msgid "pickup_location"
@@ -723,6 +711,20 @@ msgstr ""
 "voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
 "worden gecombineerd met ochtend- of avondlevering."
 
+msgid "shipment_options_delivery_evening"
+msgstr "Avondlevering"
+
+msgid "shipment_options_delivery_evening_title"
+msgstr "Avondlevering titel"
+
+msgid "shipment_options_delivery_standard_description"
+msgstr ""
+"Wanneer er geen titel is ingevuld, worden de bezorgtijden automatisch "
+"zichtbaar."
+
+msgid "shipment_options_delivery_standard_title"
+msgstr "Standaard bezorgtitel"
+
 msgid "shipment_options_insured"
 msgstr "Verzekerde zending"
 
@@ -763,6 +765,9 @@ msgstr ""
 "Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
 "optie."
 
+msgid "shipment_options_only_recipient_title"
+msgstr "Alleen thuisadres titel"
+
 msgid "shipment_options_return"
 msgstr "Retour bij mislukte leverpoging"
 
@@ -782,6 +787,9 @@ msgstr ""
 "Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
 "thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
 "een handtekening vereist."
+
+msgid "shipment_options_signature_title"
+msgstr "Handtekening bij levering titel"
 
 msgid "Show after billing details"
 msgstr "Toon na factuurgegevens"
@@ -811,17 +819,8 @@ msgstr ""
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Toon Track & Trace code en link in Mijn Account."
 
-msgid "Signature on delivery"
-msgstr "Handtekening voor ontvangst"
-
-msgid "Signature on delivery title"
-msgstr "Handtekening bij levering titel"
-
 msgid "Standard delivery"
 msgstr "Standaardlevering"
-
-msgid "Standard delivery title"
-msgstr "Standaard bezorgtitel"
 
 msgid "Standard printer (A4)"
 msgstr "Standaard printer (A4)"
@@ -949,11 +948,6 @@ msgstr ""
 "je de standaard WooCommerce adresvelden gebruiken? Laat deze optie "
 "uitgevinkt staan."
 
-msgid "When there is no title, the delivery time will automatically be visible."
-msgstr ""
-"Wanneer er geen titel is ingevuld, worden de bezorgtijden automatisch "
-"zichtbaar."
-
 msgid ""
 "When this option is enabled, delivery options and delivery day will be also "
 "shown for backorders."
@@ -1025,9 +1019,7 @@ msgstr ""
 msgid "You can change the text before the barcode inside an note"
 msgstr "Je kunt de tekst veranderen voor de barcode in een notitie"
 
-msgid ""
-"You can place a delivery title above the MyParcel options. When there is no "
-"title, it will not be visible."
+msgid "shipment_options_delivery_options_title_description"
 msgstr ""
 "Je kunt een bezorgtitel boven de MyParcel opties plaatsen. Als er geen "
 "titel is, is deze niet zichtbaar."

--- a/languages/woocommerce-myparcel-nl_NL.po
+++ b/languages/woocommerce-myparcel-nl_NL.po
@@ -171,7 +171,7 @@ msgstr "afgeleverd - opgehaald"
 msgid "delivered - ready for pickup"
 msgstr "afgeleverd - klaar om opgehaald te worden"
 
-msgid "Delivered at home or at work"
+msgid "shipment_options_delivery"
 msgstr "Thuis of op het werk bezorgd"
 
 msgid "Delivery date"
@@ -183,10 +183,10 @@ msgstr "Leverdagen venster"
 msgid "Delivery information:"
 msgstr "Bezorginformatie:"
 
-msgid "Delivery options title"
+msgid "shipment_options_delivery_options_title"
 msgstr "Bezorgopties titel"
 
-msgid "Delivery title"
+msgid "shipment_options_delivery_title"
 msgstr "Bezorg titel"
 
 msgid "Delivery type"
@@ -281,12 +281,6 @@ msgstr "MyParcel API error, geen zendingen aangemaakt."
 msgid "error_collo_weight_%1$s_but_max_%2$s"
 msgstr "Gewicht per collo is %1$s kg, maximum toegestaan is %2$s kg."
 
-msgid "Evening delivery"
-msgstr "Avondlevering"
-
-msgid "Evening delivery title"
-msgstr "Avondlevering titel"
-
 msgid "Export options"
 msgstr "Export opties"
 
@@ -319,12 +313,6 @@ msgstr "Geschenken"
 
 msgid "Hide this message"
 msgstr "Verberg dit bericht"
-
-msgid "Home address only"
-msgstr "Alleen thuisadres"
-
-msgid "Home address only title"
-msgstr "Alleen thuisadres titel"
 
 msgid "House number"
 msgstr "Huisnummer"
@@ -460,10 +448,10 @@ msgstr "Nummer ontbreekt"
 msgid "Monday delivery"
 msgstr "Maandag levering"
 
-msgid "Morning delivery"
+msgid "shipment_options_delivery_morning"
 msgstr "Ochtendlevering"
 
-msgid "Morning delivery title"
+msgid "shipment_options_delivery_morning_title"
 msgstr "Ochtendlevering titel"
 
 msgid "MyParcel"
@@ -550,13 +538,13 @@ msgstr "Afhalen bij"
 msgid "Pick up from"
 msgstr "Ophalen vanaf"
 
-msgid "Pickup"
+msgid "shipment_options_delivery_pickup"
 msgstr "Afhalen"
 
 msgid "Pickup location"
 msgstr "Afhaallocatie"
 
-msgid "Pickup title"
+msgid "shipment_options_delivery_pickup_title"
 msgstr "Afhalen titel"
 
 msgid "pickup_location"
@@ -723,6 +711,20 @@ msgstr ""
 "voor ontvangst\" en \"Alleen ontvanger\" geactiveerd. Deze optie kan niet "
 "worden gecombineerd met ochtend- of avondlevering."
 
+msgid "shipment_options_delivery_evening"
+msgstr "Avondlevering"
+
+msgid "shipment_options_delivery_evening_title"
+msgstr "Avondlevering titel"
+
+msgid "shipment_options_delivery_standard_description"
+msgstr ""
+"Wanneer er geen titel is ingevuld, worden de bezorgtijden automatisch "
+"zichtbaar."
+
+msgid "shipment_options_delivery_standard_title"
+msgstr "Standaard bezorgtitel"
+
 msgid "shipment_options_insured"
 msgstr "Verzekerde zending"
 
@@ -763,6 +765,9 @@ msgstr ""
 "Als je je pakket niet bij de buren bezorgd wil hebben, kies dan voor deze "
 "optie."
 
+msgid "shipment_options_only_recipient_title"
+msgstr "Alleen thuisadres titel"
+
 msgid "shipment_options_return"
 msgstr "Retour bij mislukte leverpoging"
 
@@ -782,6 +787,9 @@ msgstr ""
 "Het pakket wordt aangeboden op het leveringsadres. Als de ontvangende niet "
 "thuis is, wordt het pakket bij de buren afgeleverd. In beide gevallen is "
 "een handtekening vereist."
+
+msgid "shipment_options_signature_title"
+msgstr "Handtekening bij levering titel"
 
 msgid "Show after billing details"
 msgstr "Toon na factuurgegevens"
@@ -811,17 +819,8 @@ msgstr ""
 msgid "Show Track & Trace trace code and link in My Account."
 msgstr "Toon Track & Trace code en link in Mijn Account."
 
-msgid "Signature on delivery"
-msgstr "Handtekening voor ontvangst"
-
-msgid "Signature on delivery title"
-msgstr "Handtekening bij levering titel"
-
 msgid "Standard delivery"
 msgstr "Standaardlevering"
-
-msgid "Standard delivery title"
-msgstr "Standaard bezorgtitel"
 
 msgid "Standard printer (A4)"
 msgstr "Standaard printer (A4)"
@@ -949,11 +948,6 @@ msgstr ""
 "je de standaard WooCommerce adresvelden gebruiken? Laat deze optie "
 "uitgevinkt staan."
 
-msgid "When there is no title, the delivery time will automatically be visible."
-msgstr ""
-"Wanneer er geen titel is ingevuld, worden de bezorgtijden automatisch "
-"zichtbaar."
-
 msgid ""
 "When this option is enabled, delivery options and delivery day will be also "
 "shown for backorders."
@@ -1025,9 +1019,7 @@ msgstr ""
 msgid "You can change the text before the barcode inside an note"
 msgstr "Je kunt de tekst veranderen voor de barcode in een notitie"
 
-msgid ""
-"You can place a delivery title above the MyParcel options. When there is no "
-"title, it will not be visible."
+msgid "shipment_options_delivery_options_title_description"
 msgstr ""
 "Je kunt een bezorgtitel boven de MyParcel opties plaatsen. Als er geen "
 "titel is, is deze niet zichtbaar."


### PR DESCRIPTION
De change in `WCMP_Cart_Fees::getFeeTitles` is de echte fix, ik kon het gewoon niet laten om meteen de vertalingen strings mee te nemen :)

Resolves #648 