### PR TITLE
fix: check if package type is set in _myparcel_shipment_options meta

### DIFF
--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -934,10 +934,10 @@ class WCMP_Export
             $shipmentOptions = WCX_Order::get_meta($order, WCMYPA_Admin::META_SHIPMENT_OPTIONS_LT_4_0_0);
 
             if (isset($shipmentOptions['package_type'])) {
-                $packageType = (string) WCMP_Data::getPackageTypeId($shipmentOptions['package_type']);
+                $packageType = WCMP_Data::getPackageTypeId($shipmentOptions['package_type']);
             }
 
-            return $packageType ?? (string) AbstractConsignment::DEFAULT_PACKAGE_TYPE;
+            return (string) ($packageType ?? AbstractConsignment::DEFAULT_PACKAGE_TYPE);
         }
 
         $packageType = AbstractConsignment::DEFAULT_PACKAGE_TYPE_NAME;

--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -932,7 +932,12 @@ class WCMP_Export
         // Get pre 4.0.0 package type if it exists.
         if (WCX_Order::has_meta($order, WCMYPA_Admin::META_SHIPMENT_OPTIONS_LT_4_0_0)) {
             $shipmentOptions = WCX_Order::get_meta($order, WCMYPA_Admin::META_SHIPMENT_OPTIONS_LT_4_0_0);
-            return (string) WCMP_Data::getPackageTypeId($shipmentOptions['package_type']);
+
+            if (isset($shipmentOptions['package_type'])) {
+                $packageType = (string) WCMP_Data::getPackageTypeId($shipmentOptions['package_type']);
+            }
+
+            return $packageType ?? (string) AbstractConsignment::DEFAULT_PACKAGE_TYPE;
         }
 
         $packageType = AbstractConsignment::DEFAULT_PACKAGE_TYPE_NAME;


### PR DESCRIPTION
Issue: https://wordpress.org/support/topic/meta-field-returns-1-ipv-array/