### PR TITLE
Fix bug where getShipmentData would return all orders

### DIFF
--- a/includes/admin/class-wcmp-export.php
+++ b/includes/admin/class-wcmp-export.php
@@ -1145,6 +1145,10 @@ class WCMP_Export
      */
     public function getShipmentData(array $ids, WC_Order $order): array
     {
+        if (empty($ids)) {
+            return [];
+        }
+        
         $data     = [];
         $api      = $this->init_api();
         $response = $api->get_shipments($ids);


### PR DESCRIPTION
# Problem
When calling `getShipmentData` with an empty list of IDs, all order would be retrieved, instead of not returning any orders. This has in some cases led to multiple shipments being assigned to an order that does not belong to this order.

# Solution
By checking if the IDs list is empty before getting the orders from the API, and immediately returning an empty array in this case, the problem is solved.