### PR TITLE
fix: age check with different scenarios

### DIFF
--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -294,9 +294,7 @@ class OrderSettings
 
             if (empty($productAgeCheck)) {
                 $hasAgeCheck = WCMYPA_Admin::PRODUCT_OPTIONS_DEFAULT;
-            }
-
-            if ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_ENABLED) {
+            } elseif ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_ENABLED) {
                 return true;
             }
         }

--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -276,11 +276,12 @@ class OrderSettings
     /**
      * Gets product age check value based on if it was explicitly set to either true or false. It defaults to inheriting from the default export settings.
      *
-     * @return ?bool
+     * @return bool|null
+     * @throws JsonException
      */
     private function getAgeCheckOfProduct(): ?bool
     {
-        $hasAgeCheck = null;
+        $hasAgeCheck = [];
 
         foreach ($this->order->get_items() as $item) {
             $product = $item->get_product();
@@ -296,11 +297,19 @@ class OrderSettings
             }
 
             if ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_DISABLED) {
-                $hasAgeCheck = false;
+                $hasAgeCheck[] = false;
+            }
+
+            if (empty($productAgeCheck)) {
+                $hasAgeCheck[] = null;
             }
         }
+        // Check if there is a product that is set to "default" and has the value null
+        if (in_array(null, $hasAgeCheck, true)) {
+            return null;
+        }
 
-        return $hasAgeCheck;
+        return false;
     }
 
     /**

--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -281,6 +281,8 @@ class OrderSettings
      */
     private function getAgeCheckOfProduct(): ?bool
     {
+        $hasAgeCheck = false;
+
         foreach ($this->order->get_items() as $item) {
             $product = $item->get_product();
 
@@ -291,7 +293,7 @@ class OrderSettings
             $productAgeCheck = WCX_Product::get_meta($product, WCMYPA_Admin::META_AGE_CHECK, true);
 
             if (empty($productAgeCheck)) {
-                return null;
+                $hasAgeCheck = WCMYPA_Admin::PRODUCT_OPTIONS_DEFAULT;
             }
 
             if ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_ENABLED) {
@@ -299,7 +301,7 @@ class OrderSettings
             }
         }
 
-        return false;
+        return $hasAgeCheck;
     }
 
     /**

--- a/includes/admin/OrderSettings.php
+++ b/includes/admin/OrderSettings.php
@@ -281,8 +281,6 @@ class OrderSettings
      */
     private function getAgeCheckOfProduct(): ?bool
     {
-        $hasAgeCheck = [];
-
         foreach ($this->order->get_items() as $item) {
             $product = $item->get_product();
 
@@ -292,21 +290,13 @@ class OrderSettings
 
             $productAgeCheck = WCX_Product::get_meta($product, WCMYPA_Admin::META_AGE_CHECK, true);
 
+            if (empty($productAgeCheck)) {
+                return null;
+            }
+
             if ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_ENABLED) {
                 return true;
             }
-
-            if ($productAgeCheck === WCMYPA_Admin::PRODUCT_OPTIONS_DISABLED) {
-                $hasAgeCheck[] = false;
-            }
-
-            if (empty($productAgeCheck)) {
-                $hasAgeCheck[] = null;
-            }
-        }
-        // Check if there is a product that is set to "default" and has the value null
-        if (in_array(null, $hasAgeCheck, true)) {
-            return null;
         }
 
         return false;

--- a/includes/admin/class-wcmypa-admin.php
+++ b/includes/admin/class-wcmypa-admin.php
@@ -64,6 +64,7 @@ class WCMYPA_Admin
 
     public const PRODUCT_OPTIONS_ENABLED  = "yes";
     public const PRODUCT_OPTIONS_DISABLED = "no";
+    public const PRODUCT_OPTIONS_DEFAULT  = null;
 
     public function __construct()
     {


### PR DESCRIPTION
There are several scenarios that don't work because the last value is always selected, when you use multiple products.

That is why an array is used.