### PR TITLE
fix(migration): allow shipping method without colon

### DIFF
--- a/src/Migration/Pdk/SettingsMigration.php
+++ b/src/Migration/Pdk/SettingsMigration.php
@@ -354,7 +354,7 @@ final class SettingsMigration extends AbstractPdkMigration
                         $method = sprintf('%s:%s', $parts[0], $parts[1]);
                     }
 
-                    if ($parts[1] > 10 && Str::startsWith($item, self::PREFIX_FLAT_RATE)) {
+                    if (($parts[1] ?? 0) > 10 && Str::startsWith($item, self::PREFIX_FLAT_RATE)) {
                         $carry[] = $method;
                         $method  = sprintf('%s%s', self::PREFIX_FLAT_RATE, $parts[1][0]);
                     }


### PR DESCRIPTION
Note: this would most likely not fail on production, but it will fail when the php error level is to show E_NOTICES