### PR TITLE
fix(compatibility): restore compatibility with wooc table rate

### DIFF
--- a/includes/admin/settings/class-wcmp-shipping-methods.php
+++ b/includes/admin/settings/class-wcmp-shipping-methods.php
@@ -205,12 +205,12 @@ class WCMP_Shipping_Methods
         ShippingZone $zone,
         WC_Shipping_Method $zoneShippingMethod
     ): void {
-        foreach ($zoneShippingMethod->get_shipping_rates() as $zoneShippingRate) {
-            $label = $zoneShippingRate->rate_label ?? "{$zoneShippingMethod->title} ({$zoneShippingRate->rate_id})";
+        foreach ($zoneShippingMethod->get_normalized_shipping_rates() as $zoneShippingRate) {
+            $label = $zoneShippingRate['rate_label'] ?? "{$zoneShippingMethod['title']} ({$zoneShippingRate['rate_id']})";
 
             $this->addShippingMethod(
-                self::TABLE_RATES_WOOCOMMERCE . ":{$zoneShippingMethod->instance_id}:{$zoneShippingRate->rate_id}",
-                "{$zone->get_zone_name()} - {$label}"
+                self::TABLE_RATES_WOOCOMMERCE . ":{$zoneShippingMethod['instance_id']}:{$zoneShippingRate['rate_id']}",
+                "{$zone->get_zone_name()} - $label"
             );
         }
     }

--- a/includes/admin/settings/class-wcmp-shipping-methods.php
+++ b/includes/admin/settings/class-wcmp-shipping-methods.php
@@ -206,10 +206,10 @@ class WCMP_Shipping_Methods
         WC_Shipping_Method $zoneShippingMethod
     ): void {
         foreach ($zoneShippingMethod->get_normalized_shipping_rates() as $zoneShippingRate) {
-            $label = $zoneShippingRate['rate_label'] ?? "{$zoneShippingMethod['title']} ({$zoneShippingRate['rate_id']})";
+            $label = $zoneShippingRate['rate_label'] ?? "$zoneShippingMethod->title ({$zoneShippingRate['rate_id']})";
 
             $this->addShippingMethod(
-                self::TABLE_RATES_WOOCOMMERCE . ":{$zoneShippingMethod['instance_id']}:{$zoneShippingRate['rate_id']}",
+                self::TABLE_RATES_WOOCOMMERCE . ":$zoneShippingMethod->instance_id:{$zoneShippingRate['rate_id']}",
                 "{$zone->get_zone_name()} - $label"
             );
         }


### PR DESCRIPTION
Resolves https://wordpress.org/support/topic/fatal-error-if-woocommerce-table-rate-shipping-is-updated/

INT-453
