### PR TITLE
fix: Make VAT and EORI fields optional for non-EU checkout

### DIFF
--- a/src/Hooks/TaxFieldsHooks.php
+++ b/src/Hooks/TaxFieldsHooks.php
@@ -56,11 +56,11 @@ class TaxFieldsHooks extends AbstractFieldsHooks
         return array_merge($fields, [
             Pdk::get('fieldEoriNumber') => [
                 'hidden'   => false,
-                'required' => true,
+                'required' => false,
             ],
             Pdk::get('fieldVatNumber')  => [
                 'hidden'   => false,
-                'required' => true,
+                'required' => false,
             ],
         ]);
     }


### PR DESCRIPTION
INT-778
Make VAT and EORI fields optional for non-EU checkout