### PR TITLE
fix(migrations): fix an issue where db migrations would not automatically run for already active plugin installations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,14 @@ docker compose run php composer test
 
 These will also be run automatically on GitHub when you create a pull request and must pass before your changes can be merged.
 
+Update snapshots:
+
+To run the PHP tests:
+
+```shell
+docker compose run php composer test:snapshots
+```
+
 #### Manual testing
 
 ##### Using a local WordPress instance

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "analyze": "composer run analyse",
     "analyze:generate": "composer run analyse:generate",
     "test": "vendor/bin/pest",
+    "test:snapshots": "vendor/bin/pest -d --update-snapshots",
     "test:coverage": "php -dpcov.enabled=1 vendor/bin/pest --coverage-clover=coverage.xml"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "myparcelnl/woocommerce",
   "version": "5.3.1",
   "require": {
-    "myparcelnl/pdk": "^2.0.0",
+    "myparcelnl/pdk": "^2.52.1",
     "guzzlehttp/guzzle": "^7.5.0",
     "psr/log": "*",
     "php": ">= 7.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7c5ea9d82b116c40b10dbd562287031",
+    "content-hash": "b5a2583ab1185755f586e851d294b84d",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -459,16 +459,16 @@
         },
         {
             "name": "myparcelnl/pdk",
-            "version": "2.51.2",
+            "version": "2.52.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/pdk.git",
-                "reference": "97cc3579392b5d33bd510eebb42dffc1632e7bca"
+                "reference": "54d20a21631a3969a1d7ad81decc822ad43f476d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/97cc3579392b5d33bd510eebb42dffc1632e7bca",
-                "reference": "97cc3579392b5d33bd510eebb42dffc1632e7bca",
+                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/54d20a21631a3969a1d7ad81decc822ad43f476d",
+                "reference": "54d20a21631a3969a1d7ad81decc822ad43f476d",
                 "shasum": ""
             },
             "require": {
@@ -513,9 +513,9 @@
             "homepage": "https://myparcel.nl",
             "support": {
                 "issues": "https://github.com/myparcelnl/pdk/issues",
-                "source": "https://github.com/myparcelnl/pdk/tree/v2.51.2"
+                "source": "https://github.com/myparcelnl/pdk/tree/v2.52.1"
             },
-            "time": "2025-02-27T13:08:42+00:00"
+            "time": "2025-03-05T15:27:53+00:00"
         },
         {
             "name": "myparcelnl/sdk",

--- a/src/Migration/Migration5_3_2.php
+++ b/src/Migration/Migration5_3_2.php
@@ -7,9 +7,8 @@ namespace MyParcelNL\WooCommerce\Migration;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
 use MyParcelNL\Pdk\Audit\Service\AuditService;
 use MyParcelNL\WooCommerce\Database\Contract\WpDatabaseServiceInterface;
-use MyParcelNL\WooCommerce\Migration\Pdk\AbstractPdkMigration;
 
-final class Migration5_2_1 extends AbstractPdkMigration
+final class Migration5_3_2 extends AbstractMigration
 {
     /**
      * @var \MyParcelNL\Pdk\Audit\Service\AuditService
@@ -38,7 +37,7 @@ final class Migration5_2_1 extends AbstractPdkMigration
 
     public function getVersion(): string
     {
-        return '5.2.1';
+        return '5.3.2';
     }
 
     /**

--- a/src/Pdk/Audit/Repository/WcPdkAuditRepository.php
+++ b/src/Pdk/Audit/Repository/WcPdkAuditRepository.php
@@ -20,13 +20,42 @@ use MyParcelNL\WooCommerce\Database\Contract\WpDatabaseServiceInterface;
 class WcPdkAuditRepository extends Repository implements PdkAuditRepositoryInterface
 {
     /**
+     * @var \MyParcelNL\WooCommerce\Database\Contract\WpDatabaseServiceInterface
+     */
+    private $wpDatabaseService;
+
+    /**
+     * @param  \MyParcelNL\Pdk\Storage\Contract\StorageInterface                    $storage
+     * @param  \MyParcelNL\WooCommerce\Database\Contract\WpDatabaseServiceInterface $wpDatabaseService
+     */
+    public function __construct(StorageInterface $storage, WpDatabaseServiceInterface $wpDatabaseService)
+    {
+        parent::__construct($storage);
+        $this->wpDatabaseService = $wpDatabaseService;
+    }
+
+    /**
      * @return \MyParcelNL\Pdk\Audit\Collection\AuditCollection
      * @throws \Exception
-     * @deprecated This method is a no-op, retained for compatibility only.
+     * @deprecated This method is retained for compatibility only.
      */
     public function all(): AuditCollection
     {
-        return new AuditCollection([]);
+        return $this->retrieve('audits', function () {
+            $audits = $this->wpDatabaseService->getAll(Pdk::get('tableNameAudits'));
+
+            return new AuditCollection($audits->map(static function (array $audit): Audit {
+                return new Audit([
+                    'id'              => $audit['auditId'],
+                    'arguments'       => json_decode($audit['arguments'], true),
+                    'action'          => $audit['action'],
+                    'model'           => $audit['model'],
+                    'modelIdentifier' => $audit['modelIdentifier'],
+                    'created'         => new DateTime($audit['created']),
+                    'type'            => $audit['type'],
+                ]);
+            }));
+        });
     }
 
     /**

--- a/src/Pdk/Plugin/Installer/WcMigrationService.php
+++ b/src/Pdk/Plugin/Installer/WcMigrationService.php
@@ -13,8 +13,7 @@ use MyParcelNL\WooCommerce\Migration\Migration4_1_0;
 use MyParcelNL\WooCommerce\Migration\Migration4_2_1;
 use MyParcelNL\WooCommerce\Migration\Migration4_4_1;
 use MyParcelNL\WooCommerce\Migration\Migration5_0_0;
-use MyParcelNL\WooCommerce\Migration\Migration5_2_1;
-use MyParcelNL\WooCommerce\Migration\Pdk\AuditsMigration;
+use MyParcelNL\WooCommerce\Migration\Migration5_3_2;
 
 final class WcMigrationService implements MigrationServiceInterface
 {
@@ -41,7 +40,7 @@ final class WcMigrationService implements MigrationServiceInterface
             Migration4_2_1::class,
             Migration4_4_1::class,
             Migration5_0_0::class,
-            Migration5_2_1::class,
+            Migration5_3_2::class,
         ];
     }
 }

--- a/tests/__snapshots__/EntryTest__it_adds_all_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/EntryTest__it_adds_all_hooks_on_plugin_init__1.json
@@ -1,127 +1,136 @@
 {
-  "activate_woocommerce-myparcel": ["MyParcelNLWooCommerce::install"],
-  "deactivate_woocommerce-myparcel": ["MyParcelNLWooCommerce::uninstall"],
-  "init": [],
-  "woocommerce_blocks_checkout_block_registration": [
-    "MyParcelNLWooCommerce::registerCheckoutBlocks"
-  ],
-  "admin_init": [{}],
-  "woocommerce_order_status_changed": [
-    "MyParcelNL\\WooCommerce\\Hooks\\AutomaticOrderExportHooks::automaticExportOrder"
-  ],
-  "before_woocommerce_init": [
-    "MyParcelNL\\WooCommerce\\Hooks\\BlocksIntegrationHooks::declareCheckoutBlocksCompatibility"
-  ],
-  "woocommerce_cart_calculate_fees": [
-    "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::calculateDeliveryOptionsFees"
-  ],
-  "wp": [
-    "MyParcelNL\\WooCommerce\\Hooks\\CheckoutScriptHooks::enqueueFrontendScripts"
-  ],
-  "woocommerce_order_note_added": [
-    "MyParcelNL\\WooCommerce\\Hooks\\OrderNotesHooks::addOrderNotes"
-  ],
-  "rest_api_init": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkAdminEndpointHooks::registerPdkRoutes",
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkFrontendEndpointHooks::registerPdkRoutes",
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkWebhookHooks::registerWebhookRoutes"
-  ],
-  "woocommerce_checkout_order_processed": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveDeliveryOptions"
-  ],
-  "woocommerce_blocks_checkout_order_processed": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveBlocksDeliveryOptions"
-  ],
-  "admin_enqueue_scripts": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::registerPdkScripts"
-  ],
-  "admin_footer": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::renderPdkInitScripts"
-  ],
-  "all_admin_notices": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::renderPdkNotifications"
-  ],
-  "script_loader_tag": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::changeScriptTag"
-  ],
-  "add_meta_boxes": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderHooks::registerSingleOrderPageMetaBox"
-  ],
-  "bulk_actions-edit-shop_order": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderListHooks::registerBulkActions"
-  ],
-  "manage_edit-shop_order_columns": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderListHooks::registerMyParcelOrderListItem"
-  ],
-  "manage_shop_order_posts_custom_column": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderListHooks::renderPdkOrderListItem"
-  ],
-  "admin_menu": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::registerMenuItem"
-  ],
-  "body_class": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::setWooCommerceBodyClasses"
-  ],
-  "woocommerce_screen_ids": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::registerSettingsScreenInWooCommerce"
-  ],
-  "woocommerce_navigation_is_connected_page": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::connectPageToWooCommerce"
-  ],
-  "woocommerce_product_data_tabs": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::registerProductSettingsTab"
-  ],
-  "woocommerce_product_data_panels": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::renderPdkProductSettings"
-  ],
-  "woocommerce_product_after_variable_attributes": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::renderPdkProductSettingsForVariant"
-  ],
-  "woocommerce_process_product_meta": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::handleSaveProduct"
-  ],
-  "woocommerce_save_product_variation": [
-    "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::handleSaveProduct"
-  ],
-  "plugin_action_links_..": [
-    "MyParcelNL\\WooCommerce\\Hooks\\PluginInfoHooks::setPluginActionLinks"
-  ],
-  "plugin_row_meta": [
-    "MyParcelNL\\WooCommerce\\Hooks\\PluginInfoHooks::setPluginMeta"
-  ],
-  "myparcelnl_migrate_5_0_0_orders": [
-    "MyParcelNL\\WooCommerce\\Migration\\Pdk\\OrdersMigration::migrateOrder"
-  ],
-  "myparcelnl_migrate_5_0_0_product_settings": [
-    "MyParcelNL\\WooCommerce\\Migration\\Pdk\\ProductSettingsMigration::migrateProductSettings"
-  ],
-  "woocommerce_get_country_locale": [
-    "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendLocaleWithSeparateAddressFields",
-    "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendLocaleWithTaxFields"
-  ],
-  "woocommerce_country_locale_field_selectors": [
-    "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendSelectorsWithSeparateAddressFields",
-    "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendSelectorsWithTaxFields"
-  ],
-  "woocommerce_default_address_fields": [
-    "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendDefaultsWithSeparateAddressFields",
-    "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendDefaultsWithTaxFields"
-  ],
-  "woocommerce_billing_fields": [
-    "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendBillingFields",
-    "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendBillingFields"
-  ],
-  "woocommerce_shipping_fields": [
-    "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendShippingFields",
-    "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendShippingFields"
-  ],
-  "woocommerce_email_before_order_table": [
-    "MyParcelNL\\WooCommerce\\Hooks\\TrackTraceHooks::renderTrackTraceInEmail"
-  ],
-  "woocommerce_after_order_details": [
-    "MyParcelNL\\WooCommerce\\Hooks\\TrackTraceHooks::renderTrackTraceInAccountOrderDetails"
-  ],
-  "woocommerce_my_account_my_orders_actions": [
-    "MyParcelNL\\WooCommerce\\Hooks\\TrackTraceHooks::registerTrackTraceActions"
-  ]
+    "activate_woocommerce-myparcel": [
+        "MyParcelNLWooCommerce::install"
+    ],
+    "wp_loaded": [
+        "MyParcelNLWooCommerce::upgrade"
+    ],
+    "deactivate_woocommerce-myparcel": [
+        "MyParcelNLWooCommerce::uninstall"
+    ],
+    "init": [],
+    "woocommerce_blocks_checkout_block_registration": [
+        "MyParcelNLWooCommerce::registerCheckoutBlocks"
+    ],
+    "admin_init": [
+        {}
+    ],
+    "woocommerce_order_status_changed": [
+        "MyParcelNL\\WooCommerce\\Hooks\\AutomaticOrderExportHooks::automaticExportOrder"
+    ],
+    "before_woocommerce_init": [
+        "MyParcelNL\\WooCommerce\\Hooks\\BlocksIntegrationHooks::declareCheckoutBlocksCompatibility"
+    ],
+    "woocommerce_cart_calculate_fees": [
+        "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::calculateDeliveryOptionsFees"
+    ],
+    "wp": [
+        "MyParcelNL\\WooCommerce\\Hooks\\CheckoutScriptHooks::enqueueFrontendScripts"
+    ],
+    "woocommerce_order_note_added": [
+        "MyParcelNL\\WooCommerce\\Hooks\\OrderNotesHooks::addOrderNotes"
+    ],
+    "rest_api_init": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkAdminEndpointHooks::registerPdkRoutes",
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkFrontendEndpointHooks::registerPdkRoutes",
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkWebhookHooks::registerWebhookRoutes"
+    ],
+    "woocommerce_checkout_order_processed": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveDeliveryOptions"
+    ],
+    "woocommerce_blocks_checkout_order_processed": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveBlocksDeliveryOptions"
+    ],
+    "admin_enqueue_scripts": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::registerPdkScripts"
+    ],
+    "admin_footer": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::renderPdkInitScripts"
+    ],
+    "all_admin_notices": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::renderPdkNotifications"
+    ],
+    "script_loader_tag": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::changeScriptTag"
+    ],
+    "add_meta_boxes": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderHooks::registerSingleOrderPageMetaBox"
+    ],
+    "bulk_actions-edit-shop_order": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderListHooks::registerBulkActions"
+    ],
+    "manage_edit-shop_order_columns": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderListHooks::registerMyParcelOrderListItem"
+    ],
+    "manage_shop_order_posts_custom_column": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkOrderListHooks::renderPdkOrderListItem"
+    ],
+    "admin_menu": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::registerMenuItem"
+    ],
+    "body_class": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::setWooCommerceBodyClasses"
+    ],
+    "woocommerce_screen_ids": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::registerSettingsScreenInWooCommerce"
+    ],
+    "woocommerce_navigation_is_connected_page": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkPluginSettingsHooks::connectPageToWooCommerce"
+    ],
+    "woocommerce_product_data_tabs": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::registerProductSettingsTab"
+    ],
+    "woocommerce_product_data_panels": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::renderPdkProductSettings"
+    ],
+    "woocommerce_product_after_variable_attributes": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::renderPdkProductSettingsForVariant"
+    ],
+    "woocommerce_process_product_meta": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::handleSaveProduct"
+    ],
+    "woocommerce_save_product_variation": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkProductSettingsHooks::handleSaveProduct"
+    ],
+    "plugin_action_links_..": [
+        "MyParcelNL\\WooCommerce\\Hooks\\PluginInfoHooks::setPluginActionLinks"
+    ],
+    "plugin_row_meta": [
+        "MyParcelNL\\WooCommerce\\Hooks\\PluginInfoHooks::setPluginMeta"
+    ],
+    "myparcelnl_migrate_5_0_0_orders": [
+        "MyParcelNL\\WooCommerce\\Migration\\Pdk\\OrdersMigration::migrateOrder"
+    ],
+    "myparcelnl_migrate_5_0_0_product_settings": [
+        "MyParcelNL\\WooCommerce\\Migration\\Pdk\\ProductSettingsMigration::migrateProductSettings"
+    ],
+    "woocommerce_get_country_locale": [
+        "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendLocaleWithSeparateAddressFields",
+        "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendLocaleWithTaxFields"
+    ],
+    "woocommerce_country_locale_field_selectors": [
+        "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendSelectorsWithSeparateAddressFields",
+        "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendSelectorsWithTaxFields"
+    ],
+    "woocommerce_default_address_fields": [
+        "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendDefaultsWithSeparateAddressFields",
+        "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendDefaultsWithTaxFields"
+    ],
+    "woocommerce_billing_fields": [
+        "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendBillingFields",
+        "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendBillingFields"
+    ],
+    "woocommerce_shipping_fields": [
+        "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendShippingFields",
+        "MyParcelNL\\WooCommerce\\Hooks\\TaxFieldsHooks::extendShippingFields"
+    ],
+    "woocommerce_email_before_order_table": [
+        "MyParcelNL\\WooCommerce\\Hooks\\TrackTraceHooks::renderTrackTraceInEmail"
+    ],
+    "woocommerce_after_order_details": [
+        "MyParcelNL\\WooCommerce\\Hooks\\TrackTraceHooks::renderTrackTraceInAccountOrderDetails"
+    ],
+    "woocommerce_my_account_my_orders_actions": [
+        "MyParcelNL\\WooCommerce\\Hooks\\TrackTraceHooks::registerTrackTraceActions"
+    ]
 }

--- a/tests/__snapshots__/EntryTest__it_instantiates_the_plugin__1.json
+++ b/tests/__snapshots__/EntryTest__it_instantiates_the_plugin__1.json
@@ -1,8 +1,17 @@
 {
-  "activate_woocommerce-myparcel": ["MyParcelNLWooCommerce::install"],
-  "deactivate_woocommerce-myparcel": ["MyParcelNLWooCommerce::uninstall"],
-  "init": ["MyParcelNLWooCommerce::initialize"],
-  "woocommerce_blocks_checkout_block_registration": [
-    "MyParcelNLWooCommerce::registerCheckoutBlocks"
-  ]
+    "activate_woocommerce-myparcel": [
+        "MyParcelNLWooCommerce::install"
+    ],
+    "wp_loaded": [
+        "MyParcelNLWooCommerce::upgrade"
+    ],
+    "deactivate_woocommerce-myparcel": [
+        "MyParcelNLWooCommerce::uninstall"
+    ],
+    "init": [
+        "MyParcelNLWooCommerce::initialize"
+    ],
+    "woocommerce_blocks_checkout_block_registration": [
+        "MyParcelNLWooCommerce::registerCheckoutBlocks"
+    ]
 }

--- a/tests/__snapshots__/SettingsMigrationTest__it_migrates_pre_v5.0.0_settings_with_data_set_empty__1.json
+++ b/tests/__snapshots__/SettingsMigrationTest__it_migrates_pre_v5.0.0_settings_with_data_set_empty__1.json
@@ -36,6 +36,8 @@
             3,
             4
         ],
+        "directPrint": false,
+        "printerGroupId": "",
         "prompt": false
     },
     "customs": {

--- a/tests/__snapshots__/SettingsMigrationTest__it_migrates_pre_v5.0.0_settings_with_data_set_filled__1.json
+++ b/tests/__snapshots__/SettingsMigrationTest__it_migrates_pre_v5.0.0_settings_with_data_set_filled__1.json
@@ -36,6 +36,8 @@
             3,
             4
         ],
+        "directPrint": false,
+        "printerGroupId": "",
         "prompt": true
     },
     "customs": {

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection AutoloadingIssuesInspection */
 
 /*
@@ -22,6 +23,7 @@ use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\WooCommerce\Facade\WooCommerce;
 use MyParcelNL\WooCommerce\Integration\WcBlocksLoader;
 use MyParcelNL\WooCommerce\Service\WordPressHookService;
+
 use function MyParcelNL\WooCommerce\bootPdk;
 
 require plugin_dir_path(__FILE__) . 'vendor/autoload.php';
@@ -34,6 +36,9 @@ final class MyParcelNLWooCommerce
     public function __construct()
     {
         register_activation_hook(__FILE__, [$this, 'install']);
+        // Since wordpress 3.1 register_activation_hook is not called when a plugin is updated
+        add_action('wp_loaded', [$this, 'upgrade']);
+
         register_deactivation_hook(__FILE__, [$this, 'uninstall']);
         add_action('init', [$this, 'initialize'], 9999);
         add_action('woocommerce_blocks_checkout_block_registration', [$this, 'registerCheckoutBlocks']);
@@ -61,6 +66,7 @@ final class MyParcelNLWooCommerce
     {
         $this->boot();
 
+        // Prerequisites check also runs in boot() but here we want to stop on error rather than just show a notice.
         $errors = $this->checkPrerequisites();
 
         if (! empty($errors)) {
@@ -68,6 +74,17 @@ final class MyParcelNLWooCommerce
             wp_die(implode('<br>', $errors), '', ['back_link' => true]);
         }
 
+        Installer::install();
+    }
+
+    /**
+     * Run upgrade migrations
+     * @return void
+     * @throws Exception
+     */
+    public function upgrade(): void
+    {
+        // The install function will check whether we are installing a new plugin or upgrading an existing one and run the appropiate migrations.
         Installer::install();
     }
 

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -16,6 +16,7 @@
 
 declare(strict_types=1);
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 use MyParcelNL\Pdk\Base\Pdk as PdkInstance;
 use MyParcelNL\Pdk\Facade\Installer;


### PR DESCRIPTION
database migrations only ran when activating the plugin, this commit makes sure they are automatically checked when wordpress is loaded

fixes INT-876