### PR TITLE
fix(language): fix myparcel settings not rendering in some languages

### DIFF
--- a/src/Pdk/Service/LanguageService.php
+++ b/src/Pdk/Service/LanguageService.php
@@ -24,7 +24,7 @@ class LanguageService extends AbstractLanguageService
      */
     public function getLanguage(): string
     {
-        return str_replace('_', '-', get_locale());
+        return str_replace('_', '-', get_user_locale());
     }
 
     /**

--- a/tests/mock_wp_functions.php
+++ b/tests/mock_wp_functions.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpMissingReturnTypeInspection,PhpUnhandledExceptionInspection,PhpMissingParamTypeInspection,PhpUnusedParameterInspection,PhpUnused */
 
 declare(strict_types=1);
@@ -39,6 +40,12 @@ function get_bloginfo(string $name): string
 function get_locale(): string
 {
     return 'nl_NL';
+}
+
+/** @see \get_user_locale() */
+function get_user_locale(): string
+{
+    return 'en_US';
 }
 
 /** @see \wp_die() */


### PR DESCRIPTION
fixes the myparcel settings screen in the admin always showing in the site default language, rather than any user-specific language override, and failing to show at all in any unsupported language

fixes INT-875