### PR TITLE
fix(checkout): fix validation error when using split address

### DIFF
--- a/views/frontend/common/src/types.ts
+++ b/views/frontend/common/src/types.ts
@@ -1,8 +1,7 @@
-import {type PdkCheckoutConfigInput} from '@myparcel-pdk/checkout-common';
-import {type AddressField} from '@myparcel-pdk/checkout';
+import {type PdkCheckoutConfigInput, type PdkCheckoutForm} from '@myparcel-pdk/checkout-common';
 
 export interface CheckoutConfig<Config extends Partial<PdkCheckoutConfigInput> = Partial<PdkCheckoutConfigInput>> {
-  addressFields: Record<AddressField, string>;
+  addressFields: PdkCheckoutForm['billing'] & PdkCheckoutForm['shipping'];
   config: Config;
   fieldShippingMethod: string;
   prefixBilling: string;

--- a/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
+++ b/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
@@ -1,5 +1,5 @@
 import {AddressType, useConfig} from '@myparcel-pdk/checkout-common';
-import {useUtil, AddressField, PdkUtil} from '@myparcel-pdk/checkout';
+import {useUtil, AddressField, PdkUtil, SeparateAddressField} from '@myparcel-pdk/checkout';
 import {type CheckoutConfig} from '../../types';
 
 // eslint-disable-next-line max-lines-per-function
@@ -11,6 +11,9 @@ export const getClassicCheckoutConfig = (): CheckoutConfig => {
       [AddressField.City]: `city`,
       [AddressField.Country]: `country`,
       [AddressField.PostalCode]: `postcode`,
+      [SeparateAddressField.Street]: `street_name`,
+      [SeparateAddressField.Number]: `house_number`,
+      [SeparateAddressField.NumberSuffix]: `house_number_suffix`,
     },
 
     prefixBilling: 'billing_',


### PR DESCRIPTION
fixes validation errors during checkout for street not being filled when the "split address" feature was enabled

fixes INT-716