### PR TITLE
docs: add troubleshooting tip for random plugin loading errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ This will build the plugin and output a version for each platform to the `dist` 
 
 ### Troubleshooting Plugin Loading Issues
 
-If you encounter a random error when loading the plugin, try running the following command:
+If you run into issues where the plugin settings or other screens do not render, you may resolve these by running the following command:
 
 ```shell
 yarn pdk-builder translations


### PR DESCRIPTION
I lost some sanity/time trying to figure out why the MyParcel plugin wasn't rendering/loading, and it turned out it had to do with missing translations. There is no error message or what so ever, so I added it to the setup steps, to make sure this error is avoided