### PR TITLE
fix(address-widget): fix address widget with only one allowed country

### DIFF
--- a/views/frontend/checkout-address-widget/src/utils/syncData.ts
+++ b/views/frontend/checkout-address-widget/src/utils/syncData.ts
@@ -178,7 +178,7 @@ export const getAddressFromPdkStore = (appIdentifier: string): ConfigObject['add
  */
 export const getSelectedCountry = (): Alpha2CountryCode => {
   const element = document.querySelector('select.country_to_state, input.country_to_state');
-  return (element as HTMLSelectElement)?.value as Alpha2CountryCode;
+  return (element as HTMLSelectElement | HTMLInputElement)?.value as Alpha2CountryCode;
 };
 
 export const wrapperToAppIdentifier = (wrapper?: unknown[]): string => {


### PR DESCRIPTION
fixes an issue where if there is no country dropdown on the checkout, because there is no country selection possible, the address widget would not initialize

fixes INT-1130