### PR TITLE
fix: prevent using stale data for orders

### DIFF
--- a/src/Pdk/Plugin/Repository/PdkOrderRepository.php
+++ b/src/Pdk/Plugin/Repository/PdkOrderRepository.php
@@ -75,7 +75,7 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
         $order = $this->wcOrderRepository->get($input);
 
         try {
-             return $this->getDataFromOrder($order);
+            return $this->getDataFromOrder($order);
         } catch (Throwable $exception) {
             Logger::error(
                 'Could not retrieve order data from WooCommerce order',
@@ -249,13 +249,6 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
      */
     private function getShipments(WC_Order $order): ShipmentCollection
     {
-        return $this->retrieve(
-            "wc_order_shipments_{$order->get_id()}",
-            function () use ($order): ShipmentCollection {
-                $shipments = $order->get_meta(Pdk::get('metaKeyOrderShipments')) ?: null;
-
-                return new ShipmentCollection($shipments);
-            }
-        );
+        return new ShipmentCollection($order->get_meta(Pdk::get('metaKeyOrderShipments')) ?: null);
     }
 }

--- a/tests/Mock/MockWcClass.php
+++ b/tests/Mock/MockWcClass.php
@@ -55,7 +55,7 @@ abstract class MockWcClass extends WC_Data
      */
     public function get_meta($key = '', $single = true, $context = 'view')
     {
-        return get_post_meta($this->get_id(), $key);
+        return MockWpMeta::get($this->get_id(), $key);
     }
 
     /**


### PR DESCRIPTION
INT-1343

By not using internal caching (the `retrieve`) mechanism, we prevent using stale data (meta data might be modified elsewhere).