### PR TITLE
feat: handle shipment status by order mode

### DIFF
--- a/config/pdk.php
+++ b/config/pdk.php
@@ -18,6 +18,7 @@ use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
 use MyParcelNL\Pdk\App\Order\Contract\PdkProductRepositoryInterface;
 use MyParcelNL\Pdk\App\ShippingMethod\Contract\PdkShippingMethodRepositoryInterface;
 use MyParcelNL\Pdk\App\Tax\Contract\TaxServiceInterface;
+use MyParcelNL\Pdk\App\Webhook\Hook\ShipmentStatusChangeWebhook;
 use MyParcelNL\Pdk\App\Webhook\Contract\PdkWebhookServiceInterface;
 use MyParcelNL\Pdk\App\Webhook\Contract\PdkWebhooksRepositoryInterface;
 use MyParcelNL\Pdk\Audit\Contract\PdkAuditRepositoryInterface;
@@ -67,6 +68,7 @@ use MyParcelNL\WooCommerce\Pdk\Service\WcTaxService;
 use MyParcelNL\WooCommerce\Pdk\Service\WcViewService;
 use MyParcelNL\WooCommerce\Pdk\Service\WcWeightService;
 use MyParcelNL\WooCommerce\Pdk\Settings\Repository\PdkSettingsRepository;
+use MyParcelNL\WooCommerce\Pdk\Webhook\WcShipmentStatusChangeWebhook;
 use MyParcelNL\WooCommerce\Pdk\Webhook\WcWebhooksRepository;
 use MyParcelNL\WooCommerce\Service\WooCommerceService;
 use MyParcelNL\WooCommerce\Service\WordPressService;
@@ -88,6 +90,8 @@ use function DI\value;
  * @see \MyParcelNL\WooCommerce\Pdk\WcPdkBootstrapper for configuration based on the plugin itself.
  */
 return [
+    ShipmentStatusChangeWebhook::class => get(WcShipmentStatusChangeWebhook::class),
+
     'wordPressVersion' => factory(function (): string {
         return get_bloginfo('version');
     }),

--- a/src/Pdk/Plugin/Service/WcShipmentStatusWebhookService.php
+++ b/src/Pdk/Plugin/Service/WcShipmentStatusWebhookService.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Pdk\Plugin\Service;
+
+use MyParcelNL\Pdk\App\Api\Backend\PdkBackendActions;
+use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Facade\Actions;
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Settings\Model\OrderSettings;
+use MyParcelNL\Pdk\Shipment\Model\Shipment;
+
+final class WcShipmentStatusWebhookService
+{
+    public const ORDER_MODE_SHIPMENTS = 0;
+    public const ORDER_MODE_V1        = 1;
+    public const ORDER_MODE_V2        = 2;
+
+    private const ACCOUNT_FEATURES_SERVICE = 'MyParcelNL\Pdk\Account\Contract\AccountFeaturesServiceInterface';
+
+    /**
+     * @var \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface
+     */
+    private $pdkOrderRepository;
+
+    /**
+     * @param  \MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface $pdkOrderRepository
+     */
+    public function __construct(PdkOrderRepositoryInterface $pdkOrderRepository)
+    {
+        $this->pdkOrderRepository = $pdkOrderRepository;
+    }
+
+    /**
+     * @param  array $content
+     *
+     * @return void
+     */
+    public function handle(array $content): void
+    {
+        $orderModeVersion = $this->getOrderModeVersion();
+
+        if (self::ORDER_MODE_V2 === $orderModeVersion) {
+            $this->handleOrderV2($content);
+
+            return;
+        }
+
+        $orderIds = self::ORDER_MODE_V1 === $orderModeVersion
+            ? $this->getOrderIdsForOrderV1($content)
+            : $this->getOrderIdsFromShipmentReference($content);
+
+        if (empty($orderIds)) {
+            $this->logSkippedWebhook('Skipping shipment status change webhook without a valid order identifier', $content);
+
+            return;
+        }
+
+        $this->updateShipmentsFromApi($orderIds, $content);
+    }
+
+    /**
+     * @return int
+     */
+    private function getOrderModeVersion(): int
+    {
+        $featuresService = Pdk::get(self::ACCOUNT_FEATURES_SERVICE);
+
+        return (int) $featuresService->getOrderModeVersion();
+    }
+
+    /**
+     * @param  array $content
+     *
+     * @return string[]
+     */
+    private function getOrderIdsForOrderV1(array $content): array
+    {
+        $apiIdentifier = $this->getTrimmedValue($content, 'order_id');
+
+        if ('' === $apiIdentifier || ! method_exists($this->pdkOrderRepository, 'getByApiIdentifier')) {
+            return [];
+        }
+
+        /** @var null|\MyParcelNL\Pdk\App\Order\Model\PdkOrder $order */
+        $order = call_user_func([$this->pdkOrderRepository, 'getByApiIdentifier'], $apiIdentifier);
+
+        if (! $order) {
+            return [];
+        }
+
+        $externalIdentifier = $order->externalIdentifier;
+
+        return $externalIdentifier ? [$externalIdentifier] : [];
+    }
+
+    /**
+     * @param  array $content
+     *
+     * @return string[]
+     */
+    private function getOrderIdsFromShipmentReference(array $content): array
+    {
+        $orderId = $this->getTrimmedValue($content, 'shipment_reference_identifier');
+
+        return '' === $orderId ? [] : [$orderId];
+    }
+
+    /**
+     * @param  array $content
+     *
+     * @return void
+     */
+    private function handleOrderV2(array $content): void
+    {
+        $orderId = $this->getTrimmedValue($content, 'shipment_reference_identifier');
+
+        if ('' === $orderId) {
+            $this->logSkippedWebhook('Skipping order v2 shipment status webhook without a shipment reference identifier', $content);
+
+            return;
+        }
+
+        $shipmentId = $this->getShipmentId($content);
+
+        if (null === $shipmentId) {
+            $this->logSkippedWebhook('Skipping order v2 shipment status webhook without a shipment id', $content);
+
+            return;
+        }
+
+        $order = $this->pdkOrderRepository->find($orderId);
+
+        if (! $order) {
+            $this->logSkippedWebhook('Skipping order v2 shipment status webhook for unknown WooCommerce order', $content);
+
+            return;
+        }
+
+        $shipment = $this->getShipmentFromOrder($order, $shipmentId);
+
+        if (! $shipment) {
+            $this->logSkippedWebhook('Skipping order v2 shipment status webhook for unknown shipment', $content);
+
+            return;
+        }
+
+        $externalIdentifier = $order->externalIdentifier;
+
+        if (! $externalIdentifier) {
+            $this->logSkippedWebhook('Skipping order v2 shipment status webhook for an order without external identifier', $content);
+
+            return;
+        }
+
+        $this->updateShipmentFromWebhook($shipment, $externalIdentifier, $content);
+        $this->pdkOrderRepository->update($order);
+
+        $this->updateOrderStatus([$externalIdentifier], $content);
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\App\Order\Model\PdkOrder $order
+     * @param  int                                      $shipmentId
+     *
+     * @return null|\MyParcelNL\Pdk\Shipment\Model\Shipment
+     */
+    private function getShipmentFromOrder(PdkOrder $order, int $shipmentId): ?Shipment
+    {
+        return $order->shipments->first(function (Shipment $shipment) use ($shipmentId) {
+            return (int) $shipment->id === $shipmentId;
+        });
+    }
+
+    /**
+     * @param  array $content
+     * @param  string $key
+     *
+     * @return string
+     */
+    private function getTrimmedValue(array $content, string $key): string
+    {
+        return isset($content[$key]) ? trim((string) $content[$key]) : '';
+    }
+
+    /**
+     * @param  array $content
+     *
+     * @return null|int
+     */
+    private function getShipmentId(array $content): ?int
+    {
+        if (! isset($content['shipment_id']) || '' === trim((string) $content['shipment_id'])) {
+            return null;
+        }
+
+        return (int) $content['shipment_id'];
+    }
+
+    /**
+     * @param  string[] $orderIds
+     * @param  array    $content
+     *
+     * @return void
+     */
+    private function updateShipmentsFromApi(array $orderIds, array $content): void
+    {
+        Actions::execute(PdkBackendActions::UPDATE_SHIPMENTS, [
+            'orderIds'                      => $orderIds,
+            'shipmentIds'                   => [$content['shipment_id']],
+            'orderStatus'                   => OrderSettings::getStatus((int) ($content['status'] ?? null)),
+            'linkFirstShipmentToFirstOrder' => true,
+        ]);
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\Shipment\Model\Shipment   $shipment
+     * @param  string                                    $orderId
+     * @param  array                                     $content
+     *
+     * @return void
+     */
+    private function updateShipmentFromWebhook(Shipment $shipment, string $orderId, array $content): void
+    {
+        $shipment->orderId = $orderId;
+
+        if (array_key_exists('status', $content)) {
+            $shipment->status = (int) $content['status'];
+        }
+
+        $barcode = $this->getTrimmedValue($content, 'barcode');
+
+        if ('' !== $barcode) {
+            $shipment->barcode = $barcode;
+        }
+    }
+
+    /**
+     * @param  string[] $orderIds
+     * @param  array    $content
+     *
+     * @return void
+     */
+    private function updateOrderStatus(array $orderIds, array $content): void
+    {
+        Actions::execute(PdkBackendActions::UPDATE_ORDER_STATUS, [
+            'orderIds' => $orderIds,
+            'setting'  => OrderSettings::getStatus((int) ($content['status'] ?? null)),
+        ]);
+    }
+
+    /**
+     * @param  string $message
+     * @param  array  $content
+     *
+     * @return void
+     */
+    private function logSkippedWebhook(string $message, array $content): void
+    {
+        Logger::debug($message, [
+            'shipment_id'                   => $content['shipment_id'] ?? null,
+            'order_id'                      => $content['order_id'] ?? null,
+            'shipment_reference_identifier' => $content['shipment_reference_identifier'] ?? null,
+        ]);
+    }
+}

--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -129,10 +129,14 @@ class WcPdkBootstrapper extends PdkBootstrapper
             ]),
 
             'bulkActions' => factory(static function (): array {
-                $orderMode =
-                    ['Shipments', 'OrderV1', 'OrderV2'][Pdk::get(AccountFeaturesServiceInterface::class)
-                        ->getOrderModeVersion()];
+                $orderModeVersion = (int) Pdk::get(AccountFeaturesServiceInterface::class)
+                    ->getOrderModeVersion();
 
+                $orderMode = [
+                    0 => 'Shipments',
+                    1 => 'OrderV1',
+                    2 => 'OrderV2',
+                ][$orderModeVersion] ?? 'Shipments';
                 // Note: Export actions are not filtered here - filtering happens in the frontend
                 // by not rendering export buttons for local pickup orders
                 return Arr::get(Pdk::get('allBulkActions'), $orderMode, []);

--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\WooCommerce\Pdk;
 
+use MyParcelNL\Pdk\Account\Contract\AccountFeaturesServiceInterface;
 use MyParcelNL\Pdk\Base\PdkBootstrapper;
 use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Facade\Pdk;
@@ -112,29 +113,29 @@ class WcPdkBootstrapper extends PdkBootstrapper
              */
 
             'allBulkActions' => value([
-                'default'   => [
+                'Shipments'   => [
                     'action_print',
                     'action_export_print',
                     'action_export',
                     'action_edit',
                 ],
-                'orderMode' => [
+                'OrderV1' => [
                     'action_edit',
                     'action_export',
+                ],
+                'OrderV2' => [
+                    'action_edit',
                 ],
             ]),
 
             'bulkActions' => factory(static function (): array {
-                $orderModeEnabled = Settings::get(OrderSettings::ORDER_MODE, OrderSettings::ID);
-                $all              = Pdk::get('allBulkActions');
-
-                $actions = $orderModeEnabled
-                    ? Arr::get($all, 'orderMode', [])
-                    : Arr::get($all, 'default', []);
+                $orderMode =
+                    ['Shipments', 'OrderV1', 'OrderV2'][Pdk::get(AccountFeaturesServiceInterface::class)
+                        ->getOrderModeVersion()];
 
                 // Note: Export actions are not filtered here - filtering happens in the frontend
                 // by not rendering export buttons for local pickup orders
-                return $actions;
+                return Arr::get(Pdk::get('allBulkActions'), $orderMode, []);
             }),
 
             ###

--- a/src/Pdk/Webhook/WcShipmentStatusChangeWebhook.php
+++ b/src/Pdk/Webhook/WcShipmentStatusChangeWebhook.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Pdk\Webhook;
+
+use MyParcelNL\Pdk\App\Webhook\Hook\AbstractHook;
+use MyParcelNL\Pdk\Webhook\Model\WebhookSubscription;
+use MyParcelNL\WooCommerce\Pdk\Plugin\Service\WcShipmentStatusWebhookService;
+use Symfony\Component\HttpFoundation\Request;
+
+final class WcShipmentStatusChangeWebhook extends AbstractHook
+{
+    /**
+     * @var \MyParcelNL\WooCommerce\Pdk\Plugin\Service\WcShipmentStatusWebhookService
+     */
+    private $shipmentStatusWebhookService;
+
+    /**
+     * @param  \MyParcelNL\WooCommerce\Pdk\Plugin\Service\WcShipmentStatusWebhookService $shipmentStatusWebhookService
+     */
+    public function __construct(WcShipmentStatusWebhookService $shipmentStatusWebhookService)
+    {
+        $this->shipmentStatusWebhookService = $shipmentStatusWebhookService;
+    }
+
+    /**
+     * @param  \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return void
+     */
+    public function handle(Request $request): void
+    {
+        $this->shipmentStatusWebhookService->handle($this->getHookBody($request));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getHookEvent(): string
+    {
+        return WebhookSubscription::SHIPMENT_STATUS_CHANGE;
+    }
+}

--- a/tests/Unit/Pdk/Webhook/WcShipmentStatusChangeWebhookTest.php
+++ b/tests/Unit/Pdk/Webhook/WcShipmentStatusChangeWebhookTest.php
@@ -1,0 +1,455 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Pdk\Webhook;
+
+use MyParcelNL\Pdk\Account\Contract\AccountSettingsServiceInterface;
+use MyParcelNL\Pdk\Account\Model\Account;
+use MyParcelNL\Pdk\Account\Model\Shop;
+use MyParcelNL\Pdk\App\Api\Backend\PdkBackendActions;
+use MyParcelNL\Pdk\App\Api\Contract\PdkActionsServiceInterface;
+use MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection;
+use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\App\Webhook\Hook\ShipmentStatusChangeWebhook;
+use MyParcelNL\Pdk\Base\Contract\ModelInterface;
+use MyParcelNL\Pdk\Base\Support\Collection;
+use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Settings\Model\OrderSettings;
+use MyParcelNL\WooCommerce\Pdk\Plugin\Service\WcShipmentStatusWebhookService;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use function DI\get;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+final class TestAccountFeaturesService
+{
+    /**
+     * @var int
+     */
+    public static $orderModeVersion = WcShipmentStatusWebhookService::ORDER_MODE_SHIPMENTS;
+
+    /**
+     * @return int
+     */
+    public function getOrderModeVersion(): int
+    {
+        return self::$orderModeVersion;
+    }
+}
+
+final class TestAccountSettingsService implements AccountSettingsServiceInterface
+{
+    /**
+     * @return null|\MyParcelNL\Pdk\Account\Model\Account
+     */
+    public function getAccount(): ?Account
+    {
+        return null;
+    }
+
+    /**
+     * @return \MyParcelNL\Pdk\Carrier\Collection\CarrierCollection
+     */
+    public function getCarrierOptions(): CarrierCollection
+    {
+        return new CarrierCollection();
+    }
+
+    /**
+     * @return \MyParcelNL\Pdk\Carrier\Collection\CarrierCollection
+     */
+    public function getCarriers(): CarrierCollection
+    {
+        return new CarrierCollection();
+    }
+
+    /**
+     * @return null|\MyParcelNL\Pdk\Account\Model\Shop
+     */
+    public function getShop(): ?Shop
+    {
+        return null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAccount(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasCarrierSmallPackageContract(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTaxFields(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function usesOrderMode(): bool
+    {
+        return TestAccountFeaturesService::$orderModeVersion > WcShipmentStatusWebhookService::ORDER_MODE_SHIPMENTS;
+    }
+}
+
+final class TestPdkActionsService implements PdkActionsServiceInterface
+{
+    /**
+     * @var array
+     */
+    public static $calls = [];
+
+    /**
+     * @param  string|\Symfony\Component\HttpFoundation\Request $action
+     * @param  array                                            $parameters
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function execute($action, array $parameters = []): Response
+    {
+        self::$calls[] = compact('action', 'parameters');
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @param  string|\Symfony\Component\HttpFoundation\Request $action
+     * @param  array                                            $parameters
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function executeAutomatic($action, array $parameters = []): Response
+    {
+        return $this->execute($action, $parameters);
+    }
+
+    /**
+     * @param  string $context
+     *
+     * @return $this
+     */
+    public function setContext(string $context): PdkActionsServiceInterface
+    {
+        return $this;
+    }
+}
+
+final class TestPdkOrderRepository implements PdkOrderRepositoryInterface
+{
+    /**
+     * @var array<string, \MyParcelNL\Pdk\App\Order\Model\PdkOrder>
+     */
+    public static $orders = [];
+
+    /**
+     * @var array<string, \MyParcelNL\Pdk\App\Order\Model\PdkOrder>
+     */
+    public static $ordersByApiIdentifier = [];
+
+    /**
+     * @var \MyParcelNL\Pdk\App\Order\Model\PdkOrder[]
+     */
+    public static $updatedOrders = [];
+
+    /**
+     * @param  mixed $input
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    public function get($input): PdkOrder
+    {
+        $id = is_array($input) ? $input['externalIdentifier'] : $input;
+
+        return $this->find($id) ?? new PdkOrder(['externalIdentifier' => $id]);
+    }
+
+    /**
+     * @param  int|string $id
+     *
+     * @return null|\MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    public function find($id): ?PdkOrder
+    {
+        return self::$orders[(string) $id] ?? null;
+    }
+
+    /**
+     * @param  array $ids
+     *
+     * @return \MyParcelNL\Pdk\Base\Support\Collection
+     */
+    public function findAll(array $ids): Collection
+    {
+        return new Collection(array_filter(array_map([$this, 'find'], $ids)));
+    }
+
+    /**
+     * @param  int|string $id
+     *
+     * @return \MyParcelNL\Pdk\Base\Contract\ModelInterface
+     */
+    public function findOrFail($id): ModelInterface
+    {
+        $order = $this->find($id);
+
+        if (! $order) {
+            throw new RuntimeException(sprintf('Order "%s" not found.', $id));
+        }
+
+        return $order;
+    }
+
+    /**
+     * @return \MyParcelNL\Pdk\Base\Support\Collection
+     */
+    public function all(): Collection
+    {
+        return new Collection(self::$orders);
+    }
+
+    /**
+     * @param  int|string $id
+     *
+     * @return bool
+     */
+    public function exists($id): bool
+    {
+        return null !== $this->find($id);
+    }
+
+    /**
+     * @param  string|string[] $orderIds
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection
+     */
+    public function getMany($orderIds): PdkOrderCollection
+    {
+        return new PdkOrderCollection(array_map([$this, 'get'], (array) $orderIds));
+    }
+
+    /**
+     * @param  string $uuid
+     *
+     * @return null|\MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    public function getByApiIdentifier(string $uuid): ?PdkOrder
+    {
+        return self::$ordersByApiIdentifier[$uuid] ?? null;
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\App\Order\Model\PdkOrder $order
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    public function update(PdkOrder $order): PdkOrder
+    {
+        self::$orders[$order->externalIdentifier] = $order;
+        self::$updatedOrders[]                    = $order;
+
+        return $order;
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection $collection
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Collection\PdkOrderCollection
+     */
+    public function updateMany(PdkOrderCollection $collection): PdkOrderCollection
+    {
+        return $collection->map([$this, 'update']);
+    }
+
+    /**
+     * @param  string        $key
+     * @param  null|callable $callback
+     * @param  bool          $force
+     *
+     * @return mixed
+     */
+    public function retrieve(string $key, ?callable $callback = null, bool $force = false)
+    {
+        return self::$orders[$key] ?? ($callback ? $callback() : null);
+    }
+
+    /**
+     * @param  string $key
+     * @param  mixed  $data
+     *
+     * @return mixed
+     */
+    public function save(string $key, $data)
+    {
+        self::$orders[$key] = $data;
+
+        return $data;
+    }
+}
+
+usesShared(new UsesMockWcPdkInstance([
+    'MyParcelNL\Pdk\Account\Contract\AccountFeaturesServiceInterface' => get(TestAccountFeaturesService::class),
+    AccountSettingsServiceInterface::class                            => get(TestAccountSettingsService::class),
+    PdkActionsServiceInterface::class                                 => get(TestPdkActionsService::class),
+    PdkOrderRepositoryInterface::class                                => get(TestPdkOrderRepository::class),
+]));
+
+beforeEach(function () {
+    TestAccountFeaturesService::$orderModeVersion  = WcShipmentStatusWebhookService::ORDER_MODE_SHIPMENTS;
+    TestPdkActionsService::$calls                  = [];
+    TestPdkOrderRepository::$orders                = [];
+    TestPdkOrderRepository::$ordersByApiIdentifier = [];
+    TestPdkOrderRepository::$updatedOrders         = [];
+});
+
+function handleShipmentStatusWebhook(array $payload): void
+{
+    /** @var \MyParcelNL\WooCommerce\Pdk\Webhook\WcShipmentStatusChangeWebhook $webhook */
+    $webhook = Pdk::get(WcShipmentStatusChangeWebhook::class);
+
+    $webhook->handle(new Request([], [], [], [], [], [], json_encode([
+        'data' => [
+            'hooks' => [$payload],
+        ],
+    ])));
+}
+
+it('overrides the pdk shipment status change webhook', function () {
+    expect(Pdk::get(ShipmentStatusChangeWebhook::class))
+        ->toBeInstanceOf(WcShipmentStatusChangeWebhook::class);
+});
+
+it('updates an existing order v2 shipment locally without fetching shipments from the api', function () {
+    TestAccountFeaturesService::$orderModeVersion = WcShipmentStatusWebhookService::ORDER_MODE_V2;
+
+    TestPdkOrderRepository::$orders['46'] = new PdkOrder([
+        'externalIdentifier' => '46',
+        'shipments'          => [
+            [
+                'id'      => 231032886,
+                'barcode' => 'old-barcode',
+                'status'  => 2,
+            ],
+        ],
+    ]);
+
+    handleShipmentStatusWebhook([
+        'shipment_id'                   => 231032886,
+        'status'                        => 4,
+        'barcode'                       => '3SMYPA428613388',
+        'shipment_reference_identifier' => '46',
+        'order_id'                      => 'legacy-order-id',
+    ]);
+
+    $updatedOrder    = TestPdkOrderRepository::$updatedOrders[0];
+    $updatedShipment = $updatedOrder->shipments->first();
+
+    expect(TestPdkOrderRepository::$updatedOrders)
+        ->toHaveLength(1)
+        ->and($updatedShipment->status)
+        ->toBe(4)
+        ->and($updatedShipment->barcode)
+        ->toBe('3SMYPA428613388')
+        ->and($updatedShipment->orderId)
+        ->toBe('46')
+        ->and(TestPdkActionsService::$calls)
+        ->toHaveLength(1)
+        ->and(TestPdkActionsService::$calls[0]['action'])
+        ->toBe(PdkBackendActions::UPDATE_ORDER_STATUS)
+        ->and(TestPdkActionsService::$calls[0]['parameters']['orderIds'])
+        ->toBe(['46'])
+        ->and(TestPdkActionsService::$calls[0]['parameters']['setting'])
+        ->toBe(OrderSettings::STATUS_WHEN_LABEL_SCANNED);
+});
+
+it('keeps using the legacy order id lookup for order v1', function () {
+    TestAccountFeaturesService::$orderModeVersion = WcShipmentStatusWebhookService::ORDER_MODE_V1;
+
+    TestPdkOrderRepository::$ordersByApiIdentifier['order-api-uuid'] = new PdkOrder([
+        'externalIdentifier' => '197',
+    ]);
+
+    handleShipmentStatusWebhook([
+        'shipment_id'                   => 231032886,
+        'status'                        => 4,
+        'shipment_reference_identifier' => '46',
+        'order_id'                      => 'order-api-uuid',
+    ]);
+
+    expect(TestPdkOrderRepository::$updatedOrders)
+        ->toHaveLength(0)
+        ->and(TestPdkActionsService::$calls)
+        ->toHaveLength(1)
+        ->and(TestPdkActionsService::$calls[0]['action'])
+        ->toBe(PdkBackendActions::UPDATE_SHIPMENTS)
+        ->and(TestPdkActionsService::$calls[0]['parameters']['orderIds'])
+        ->toBe(['197'])
+        ->and(TestPdkActionsService::$calls[0]['parameters']['orderStatus'])
+        ->toBe(OrderSettings::STATUS_WHEN_LABEL_SCANNED);
+});
+
+it('keeps using the shipment reference identifier for shipments mode', function () {
+    TestAccountFeaturesService::$orderModeVersion = WcShipmentStatusWebhookService::ORDER_MODE_SHIPMENTS;
+
+    handleShipmentStatusWebhook([
+        'shipment_id'                   => 231032886,
+        'status'                        => 4,
+        'shipment_reference_identifier' => '46',
+        'order_id'                      => 'order-api-uuid',
+    ]);
+
+    expect(TestPdkOrderRepository::$updatedOrders)
+        ->toHaveLength(0)
+        ->and(TestPdkActionsService::$calls)
+        ->toHaveLength(1)
+        ->and(TestPdkActionsService::$calls[0]['action'])
+        ->toBe(PdkBackendActions::UPDATE_SHIPMENTS)
+        ->and(TestPdkActionsService::$calls[0]['parameters']['orderIds'])
+        ->toBe(['46'])
+        ->and(TestPdkActionsService::$calls[0]['parameters']['orderStatus'])
+        ->toBe(OrderSettings::STATUS_WHEN_LABEL_SCANNED);
+});
+
+it('skips order v2 updates when the shipment is not already stored on the referenced order', function () {
+    TestAccountFeaturesService::$orderModeVersion = WcShipmentStatusWebhookService::ORDER_MODE_V2;
+
+    TestPdkOrderRepository::$orders['46'] = new PdkOrder([
+        'externalIdentifier' => '46',
+        'shipments'          => [
+            [
+                'id'     => 123,
+                'status' => 2,
+            ],
+        ],
+    ]);
+
+    handleShipmentStatusWebhook([
+        'shipment_id'                   => 231032886,
+        'status'                        => 4,
+        'shipment_reference_identifier' => '46',
+    ]);
+
+    expect(TestPdkOrderRepository::$updatedOrders)
+        ->toHaveLength(0)
+        ->and(TestPdkActionsService::$calls)
+        ->toHaveLength(0);
+});


### PR DESCRIPTION
This updates the shipment_status_change webhook handling for the new order mode setup.

Changes:
- Uses shipment_reference_identifier as the WooCommerce order ID for Order v2
- Updates existing local WooCommerce shipment status from the webhook payload for Order v2
- Updates WooCommerce order status through the existing shipment status mapping
- Avoids fetching shipment data through the Shipments API for Order v2
- Keeps existing Order v1 behavior using order_id / apiIdentifier lookup
- Keeps existing Shipments-only behavior using shipment_reference_identifier

Tests:
- Added unit coverage for Order v2, Order v1, Shipments-only and mismatch handling
- Targeted webhook test passes: 5 passed

Notes:
- [Depends on the PDK WhoAmI/order mode capabilities work. ](https://github.com/myparcelnl/pdk/pull/432)

INT-1329 and INT-1331