### PR TITLE
feat: re-enable shipment export when WooCommerce uses Order v2

### DIFF
--- a/config/pdk.php
+++ b/config/pdk.php
@@ -24,20 +24,17 @@ use MyParcelNL\Pdk\Audit\Contract\PdkAuditRepositoryInterface;
 use MyParcelNL\Pdk\Base\Contract\CronServiceInterface;
 use MyParcelNL\Pdk\Base\Contract\WeightServiceInterface;
 use MyParcelNL\Pdk\Base\PdkBootstrapper;
-use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Context\Contract\ContextServiceInterface;
 use MyParcelNL\Pdk\Facade\Language;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Facade\Pdk as PdkFacade;
 use MyParcelNL\Pdk\Facade\Platform;
-use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Frontend\Contract\FrontendRenderServiceInterface;
 use MyParcelNL\Pdk\Frontend\Contract\ScriptServiceInterface;
 use MyParcelNL\Pdk\Frontend\Contract\ViewServiceInterface;
 use MyParcelNL\Pdk\Language\Contract\LanguageServiceInterface;
 use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
-use MyParcelNL\Pdk\Settings\Model\OrderSettings;
 use MyParcelNL\WooCommerce\Contract\WooCommerceServiceInterface;
 use MyParcelNL\WooCommerce\Contract\WordPressServiceInterface;
 use MyParcelNL\WooCommerce\Contract\WpFilterServiceInterface;
@@ -164,14 +161,8 @@ return [
         ];
     }),
 
-    'bulkActions' => factory(static function (): array {
-        $orderModeEnabled = Settings::get(OrderSettings::ORDER_MODE, OrderSettings::ID);
-        $all              = PdkFacade::get('allBulkActions');
-
-        return $orderModeEnabled
-            ? Arr::get($all, 'orderMode', [])
-            : Arr::get($all, 'default', []);
-    }),
+    // `bulkActions` is now provided by PDK's pdk-default.php (effective-mode-driven factory).
+    // The WooCommerce plugin no longer overrides it.
 
     'orderListPageId' => factory(static function (): string {
         if (! WooCommerce::isUsingHpos()) {

--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\WooCommerce\Pdk;
 
-use MyParcelNL\Pdk\Account\Contract\AccountFeaturesServiceInterface;
 use MyParcelNL\Pdk\Base\PdkBootstrapper;
-use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
@@ -106,41 +104,9 @@ class WcPdkBootstrapper extends PdkBootstrapper
             'orderListColumnTitle'    => value($title),
             'orderListPreviousColumn' => value('shipping_address'),
 
-            /**
-             * Bulk order actions.
-             *
-             * @example Pdk::get('bulkActions') // gets the bulk actions for the current order mode.
-             */
-
-            'allBulkActions' => value([
-                'Shipments'   => [
-                    'action_print',
-                    'action_export_print',
-                    'action_export',
-                    'action_edit',
-                ],
-                'OrderV1' => [
-                    'action_edit',
-                    'action_export',
-                ],
-                'OrderV2' => [
-                    'action_edit',
-                ],
-            ]),
-
-            'bulkActions' => factory(static function (): array {
-                $orderModeVersion = (int) Pdk::get(AccountFeaturesServiceInterface::class)
-                    ->getOrderModeVersion();
-
-                $orderMode = [
-                    0 => 'Shipments',
-                    1 => 'OrderV1',
-                    2 => 'OrderV2',
-                ][$orderModeVersion] ?? 'Shipments';
-                // Note: Export actions are not filtered here - filtering happens in the frontend
-                // by not rendering export buttons for local pickup orders
-                return Arr::get(Pdk::get('allBulkActions'), $orderMode, []);
-            }),
+            // Bulk order actions: PDK now ships the same Shipments/OrderV1/OrderV2 sets and
+            // an effective-mode-driven factory, so the WooCommerce plugin no longer needs to
+            // override either `allBulkActions` or `bulkActions` here. See pdk-default.php.
 
             ###
             # Single order page


### PR DESCRIPTION
The WooCommerce plugin used to keep its own copies of `allBulkActions` and `bulkActions` in both `WcPdkBootstrapper` and `config/pdk.php`, dating from when PDK only exposed a 2-way order-mode toggle and the plugin needed finer `Shipments`/`OrderV1`/`OrderV2` granularity. PDK now ships the same three-way action set and an effective-mode-driven factory, so both copies are redundant.

Deleting them lets WooCommerce inherit PDK's defaults end-to-end, which includes the new hybrid Order v2 behaviour: shipment export, print and export+print are now exposed in V2 too, so merchants without an active sales channel can still manage labels through the plugin.

The older `config/pdk.php` override was already dead code — it referenced the removed `OrderSettings::ORDER_MODE` constant and would have crashed if evaluated. It only avoided a fatal because the bootstrapper shadowed it at boot.

Depends on https://github.com/myparcelnl/pdk/pull/473 (the PDK three-way `allBulkActions` + effective-mode factory).

Resolves INT-1594