### PR TITLE
fix(checkout): fix infinite loading or "blocks not supported" notices when using blocks checkout

### DIFF
--- a/src/Hooks/BlocksIntegrationHooks.php
+++ b/src/Hooks/BlocksIntegrationHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelNL\WooCommerce\Hooks;
 
-use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\WooCommerce\Hooks\Contract\WordPressHooksInterface;
 
@@ -22,22 +21,6 @@ class BlocksIntegrationHooks implements WordPressHooksInterface
     public function apply(): void
     {
         $this->loadBlocks();
-    }
-
-    /**
-     * @return void
-     */
-    public function declareCheckoutBlocksCompatibility(): void
-    {
-        // @codeCoverageIgnoreStart
-        if (! class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
-            return;
-        }
-
-        $appInfo = Pdk::getAppInfo();
-
-        FeaturesUtil::declare_compatibility('cart_checkout_blocks', $appInfo->path);
-        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/src/Hooks/BlocksIntegrationHooks.php
+++ b/src/Hooks/BlocksIntegrationHooks.php
@@ -21,8 +21,6 @@ class BlocksIntegrationHooks implements WordPressHooksInterface
      */
     public function apply(): void
     {
-        add_action('before_woocommerce_init', [$this, 'declareCheckoutBlocksCompatibility']);
-
         $this->loadBlocks();
     }
 

--- a/src/Integration/AbstractBlocksIntegration.php
+++ b/src/Integration/AbstractBlocksIntegration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MyParcelNL\WooCommerce\Integration;
 
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
-use MyParcelNL\Pdk\Facade\Pdk;
 
 abstract class AbstractBlocksIntegration implements IntegrationInterface
 {
@@ -19,9 +18,7 @@ abstract class AbstractBlocksIntegration implements IntegrationInterface
      */
     public function __construct(string $blockName)
     {
-        $appInfo = Pdk::getAppInfo();
-
-        $this->name = "$appInfo->name-$blockName";
+        $this->name = $blockName;
     }
 
     /**

--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -167,7 +167,7 @@ class WcPdkBootstrapper extends PdkBootstrapper
             ###
 
             'wooCommerceBlocksCheckout' => value([
-                'delivery-options' => DeliveryOptionsBlocksIntegration::class,
+                'myparcelnl-delivery-options' => DeliveryOptionsBlocksIntegration::class,
             ]),
 
             ###

--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -167,7 +167,7 @@ class WcPdkBootstrapper extends PdkBootstrapper
             ###
 
             'wooCommerceBlocksCheckout' => value([
-                'myparcelnl-delivery-options' => DeliveryOptionsBlocksIntegration::class,
+                'myparcelcom-delivery-options' => DeliveryOptionsBlocksIntegration::class,
             ]),
 
             ###

--- a/tests/Mock/MockWcBlocksUtils.php
+++ b/tests/Mock/MockWcBlocksUtils.php
@@ -18,8 +18,7 @@ class MockWcBlocksUtils extends MockWcClass
      */
     public static function has_block_in_page($page, $block_name)
     {
-        $data = MockWpCache::get($page, 'pages');
-
-        return is_array($data) && ! empty($data['hasBlocks']);
+        //todo: extend this function when we want to check for specific blocks in tests
+        return MockWpCache::get($page, 'pages')['hasBlocks'];
     }
 }

--- a/tests/Mock/MockWcBlocksUtils.php
+++ b/tests/Mock/MockWcBlocksUtils.php
@@ -18,7 +18,8 @@ class MockWcBlocksUtils extends MockWcClass
      */
     public static function has_block_in_page($page, $block_name)
     {
-        //todo: extend this function when we want to check for specific blocks in tests
-        return MockWpCache::get($page, 'pages')['hasBlocks'];
+        $data = MockWpCache::get($page, 'pages');
+
+        return is_array($data) && ! empty($data['hasBlocks']);
     }
 }

--- a/tests/Unit/Integration/DeliveryOptionsBlocksIntegrationTest.php
+++ b/tests/Unit/Integration/DeliveryOptionsBlocksIntegrationTest.php
@@ -12,15 +12,15 @@ use function MyParcelNL\Pdk\Tests\usesShared;
 usesShared(new UsesMockWcPdkInstance());
 
 it('integrates with WooCommerce Blocks', function () {
-    $class      = new DeliveryOptionsBlocksIntegration('delivery-options');
+    $class      = new DeliveryOptionsBlocksIntegration('myparcelnl-delivery-options');
     $scriptData = $class->get_script_data();
 
     expect($class->get_name())
-        ->toBe('pest-delivery-options')
+        ->toBe('myparcelnl-delivery-options')
         ->and($class->get_script_handles())
-        ->toBe(['pest-delivery-options-block-view-script', 'pest-delivery-options-block-editor-script'])
+        ->toBe(['myparcelnl-delivery-options-block-view-script', 'myparcelnl-delivery-options-block-editor-script'])
         ->and($class->get_editor_script_handles())
-        ->toBe(['pest-delivery-options-block-view-script'])
+        ->toBe(['myparcelnl-delivery-options-block-view-script'])
         ->and($scriptData)
         ->toHaveKeys(['context', 'style'])
         ->and($scriptData['context'])

--- a/tests/Unit/Integration/DeliveryOptionsBlocksIntegrationTest.php
+++ b/tests/Unit/Integration/DeliveryOptionsBlocksIntegrationTest.php
@@ -12,15 +12,15 @@ use function MyParcelNL\Pdk\Tests\usesShared;
 usesShared(new UsesMockWcPdkInstance());
 
 it('integrates with WooCommerce Blocks', function () {
-    $class      = new DeliveryOptionsBlocksIntegration('myparcelnl-delivery-options');
+    $class      = new DeliveryOptionsBlocksIntegration('myparcelcom-delivery-options');
     $scriptData = $class->get_script_data();
 
     expect($class->get_name())
-        ->toBe('myparcelnl-delivery-options')
+        ->toBe('myparcelcom-delivery-options')
         ->and($class->get_script_handles())
-        ->toBe(['myparcelnl-delivery-options-block-view-script', 'myparcelnl-delivery-options-block-editor-script'])
+        ->toBe(['myparcelcom-delivery-options-block-view-script', 'myparcelcom-delivery-options-block-editor-script'])
         ->and($class->get_editor_script_handles())
-        ->toBe(['myparcelnl-delivery-options-block-view-script'])
+        ->toBe(['myparcelcom-delivery-options-block-view-script'])
         ->and($scriptData)
         ->toHaveKeys(['context', 'style'])
         ->and($scriptData['context'])

--- a/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
@@ -1,4 +1,7 @@
 {
+    "before_woocommerce_init": [
+        "MyParcelNLWooCommerce::declareBlocksCompatibility"
+    ],
     "activate_woocommerce-myparcel": [
         "MyParcelNLWooCommerce::install"
     ],
@@ -15,9 +18,6 @@
     ],
     "woocommerce_order_status_changed": [
         "MyParcelNL\\WooCommerce\\Hooks\\AutomaticOrderExportHooks::automaticExportOrder"
-    ],
-    "before_woocommerce_init": [
-        "MyParcelNL\\WooCommerce\\Hooks\\BlocksIntegrationHooks::declareCheckoutBlocksCompatibility"
     ],
     "woocommerce_cart_calculate_fees": [
         "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::calculateDeliveryOptionsFees"

--- a/tests/__snapshots__/EntryTest__it_adds_necessary_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/EntryTest__it_adds_necessary_hooks_on_plugin_init__1.json
@@ -1,4 +1,7 @@
 {
+    "before_woocommerce_init": [
+        "MyParcelNLWooCommerce::declareBlocksCompatibility"
+    ],
     "activate_woocommerce-myparcel": [
         "MyParcelNLWooCommerce::install"
     ],

--- a/tests/__snapshots__/EntryTest__it_instantiates_the_plugin__1.json
+++ b/tests/__snapshots__/EntryTest__it_instantiates_the_plugin__1.json
@@ -1,4 +1,7 @@
 {
+    "before_woocommerce_init": [
+        "MyParcelNLWooCommerce::declareBlocksCompatibility"
+    ],
     "activate_woocommerce-myparcel": [
         "MyParcelNLWooCommerce::install"
     ],

--- a/tests/mock_wc_functions.php
+++ b/tests/mock_wc_functions.php
@@ -104,7 +104,7 @@ function wc_get_page_id(string $page)
         $page = 'myaccount';
     }
 
-    $allPages = MockWpCache::$cache['pages'];
+    $allPages = MockWpCache::$cache['pages'] ?? [];
 
     foreach ($allPages as $pageId => $singlePage) {
         if ($singlePage['data']['pageName'] === $page) {

--- a/views/blocks/delivery-options/block.json
+++ b/views/blocks/delivery-options/block.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
-  "name": "myparcelnl/delivery-options-block",
+  "name": "myparcelcom/delivery-options-block",
   "title": "MyParcel Delivery Options",
   "category": "woocommerce",
   "description": "If used, the customer can choose delivery options during checkout.",

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -5,7 +5,7 @@ import {getSetting} from '@woocommerce/settings';
 import {ExperimentalOrderShippingPackages} from '@woocommerce/blocks-checkout';
 import {CHECKOUT_STORE_KEY} from '@woocommerce/block-data';
 
-const NAME = 'myparcelnl-delivery-options';
+const NAME = 'myparcelcom-delivery-options';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const DeliveryOptionsWrapper = () => {

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -17,6 +17,7 @@
 declare(strict_types=1);
 
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use MyParcelNL\Pdk\Base\Pdk as PdkInstance;
 use MyParcelNL\Pdk\Base\PdkBootstrapper;
 use MyParcelNL\Pdk\Facade\Installer;
@@ -41,6 +42,8 @@ final class MyParcelNLWooCommerce
     public function __construct()
     {
         $this->boot();
+
+        add_action('before_woocommerce_init', [$this, 'declareBlocksCompatibility']);
 
         register_activation_hook(__FILE__, [$this, 'install']);
         register_deactivation_hook(__FILE__, [$this, 'uninstall']);
@@ -125,6 +128,16 @@ final class MyParcelNLWooCommerce
         $loader = Pdk::get(WcBlocksLoader::class);
         $loader->setRegistry($integrationRegistry);
         $loader->registerBlocks(Pdk::get('wooCommerceBlocksCheckout'));
+    }
+
+    /**
+     * @return void
+     */
+    public function declareBlocksCompatibility(): void
+    {
+        if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+            FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__);
+        }
     }
 
     /**


### PR DESCRIPTION
Replaces #1628 and #1629 (rebased cleanly on main, no conflicts).

Resolves INT-1454
Fixes #1623 

## Commit 1 — fix(blocks): fix WooCommerce blocks checkout regression introduced in V6

Three bugs caused the blocks checkout to infinite-load and show "blocks not supported" in the editor when the plugin was active:

**Root cause — namespace mismatch:** `AppInfo->name` changed to `myparcelcom` in V6, but `AbstractBlocksIntegration` derived its integration name from it, producing `myparcelcom-delivery-options`. `block.json` still uses `myparcelnl/delivery-options-block`, so WordPress registered the handle as `myparcelnl-delivery-options-block-view-script`. WooCommerce's `IntegrationRegistry` looked for `myparcelcom-delivery-options-block-view-script` (which doesn't exist) and the checkout hung indefinitely waiting for it. Also, `get_script_data()` was injected under key `myparcelcom-delivery-options_data` but `frontend.js` reads from `myparcelnl-delivery-options_data`.

**`declare_compatibility()` timing:** `BlocksIntegrationHooks::apply()` registered the `before_woocommerce_init` callback at `init` priority 9999, but `FeaturesUtil::declare_compatibility()` checks `doing_action('before_woocommerce_init')` internally and rejects calls made outside that hook. Fixed by registering the listener in the plugin constructor (at `plugins_loaded`, before `init` fires).

**Defensive test-infrastructure:** null-safe guards in `MockWcBlocksUtils` and `mock_wc_functions`.

## Commit 2 — feat(blocks): rename delivery-options block namespace from myparcelnl to myparcelcom

Aligns `block.json`, integration name, and settings key with the plugin's V6 namespace. The `myparcelnl__delivery-options` CSS class is preserved for backwards compatibility with existing custom stylesheets.

**Note:** Existing installations with `myparcelnl/delivery-options-block` explicitly inserted in checkout page content will need to re-insert the block. Risk is low — blocks checkout was broken in V6 before this fix, so no V6 installs would have the block in active use.

## Test plan

- [ ] Activate plugin on a WordPress instance with WooCommerce blocks checkout active
- [ ] Blocks checkout page loads without hanging
- [ ] Delivery options render correctly in blocks checkout (if enabled + shippable products in cart)
- [ ] Gutenberg editor: "blocks not supported" warning no longer mentions this plugin
- [ ] Classic checkout continues to work normally
- [ ] `./vendor/bin/pest tests/Unit/BootTest.php tests/Unit/Hooks/ tests/Unit/Integration/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)