### PR TITLE
fix: fix fatal errors when upgrading to v6.5.0 from > v6.1.0

### DIFF
--- a/src/Hooks/ScheduledMigrationHooks.php
+++ b/src/Hooks/ScheduledMigrationHooks.php
@@ -6,7 +6,7 @@ namespace MyParcelNL\WooCommerce\Hooks;
 
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\WooCommerce\Hooks\Contract\WordPressHooksInterface;
-use MyParcelNL\WooCommerce\Migration\Migration6_1_0;
+use MyParcelNL\WooCommerce\Migration\Migration6_5_1;
 use MyParcelNL\WooCommerce\Migration\Pdk\OrdersMigration;
 use MyParcelNL\WooCommerce\Migration\Pdk\ProductSettingsMigration;
 
@@ -18,26 +18,26 @@ final class ScheduledMigrationHooks implements WordPressHooksInterface
     public function apply(): void
     {
         $this->addPdkMigrations();
-        $this->addMigration610();
+        $this->addMigration651();
     }
 
     /**
-     * Migrations for version 6.1.0
+     * Migrations for version 6.5.1
      *
      * @return void
      */
-    private function addMigration610(): void
+    private function addMigration651(): void
     {
-        /** @var \MyParcelNL\WooCommerce\Migration\Migration6_1_0 $migration */
-        $migration = Pdk::get(Migration6_1_0::class);
+        /** @var \MyParcelNL\WooCommerce\Migration\Migration6_5_1 $migration */
+        $migration = Pdk::get(Migration6_5_1::class);
 
         add_action(
-            Pdk::get('migrateAction_6_1_0_Orders'),
+            Pdk::get('migrateAction_6_5_1_Orders'),
             [$migration, 'migrateOrderChunk']
         );
 
         add_action(
-            Pdk::get('migrateAction_6_1_0_Shipments'),
+            Pdk::get('migrateAction_6_5_1_Shipments'),
             [$migration, 'migrateShipmentChunk']
         );
     }

--- a/src/Migration/Migration6_5_1.php
+++ b/src/Migration/Migration6_5_1.php
@@ -12,7 +12,7 @@ use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 use WC_Order;
 
-final class Migration6_1_0 extends AbstractMigration
+final class Migration6_5_1 extends AbstractMigration
 {
     protected CarrierCapabilitiesRepository $carrierCapabilitiesRepository;
     protected PdkAccountRepositoryInterface $accountRepository;
@@ -33,7 +33,7 @@ final class Migration6_1_0 extends AbstractMigration
 
     public function getVersion(): string
     {
-        return '6.1.0';
+        return '6.5.1';
     }
 
     public function down(): void {}
@@ -115,7 +115,7 @@ final class Migration6_1_0 extends AbstractMigration
     {
         $this->schedulePagedMigration(
             Pdk::get('metaKeyOrderData'),
-            Pdk::get('migrateAction_6_1_0_Orders')
+            Pdk::get('migrateAction_6_5_1_Orders')
         );
     }
 
@@ -183,7 +183,7 @@ final class Migration6_1_0 extends AbstractMigration
     {
         $this->schedulePagedMigration(
             Pdk::get('metaKeyOrderShipments'),
-            Pdk::get('migrateAction_6_1_0_Shipments')
+            Pdk::get('migrateAction_6_5_1_Shipments')
         );
     }
 

--- a/src/Pdk/Plugin/Installer/WcMigrationService.php
+++ b/src/Pdk/Plugin/Installer/WcMigrationService.php
@@ -15,7 +15,7 @@ use MyParcelNL\WooCommerce\Migration\Migration4_4_1;
 use MyParcelNL\WooCommerce\Migration\Migration5_0_0;
 use MyParcelNL\WooCommerce\Migration\Migration5_3_2;
 use MyParcelNL\WooCommerce\Migration\Migration6_0_0;
-use MyParcelNL\WooCommerce\Migration\Migration6_1_0;
+use MyParcelNL\WooCommerce\Migration\Migration6_5_1;
 
 final class WcMigrationService implements MigrationServiceInterface
 {
@@ -44,7 +44,7 @@ final class WcMigrationService implements MigrationServiceInterface
             Migration5_0_0::class,
             Migration5_3_2::class,
             Migration6_0_0::class,
-            Migration6_1_0::class,
+            Migration6_5_1::class,
         ];
     }
 }

--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -136,7 +136,8 @@ class WcPdkBootstrapper extends PdkBootstrapper
             'disabledSettings'         => factory(function () {
                 $disabledSettings = [];
                 if (Pdk::get(WooCommerceService::class)
-                    ->isUsingBlocksCheckout()) {
+                    ->isUsingBlocksCheckout()
+                ) {
                     $disabledSettings[CheckoutSettings::ID][] = CheckoutSettings::DELIVERY_OPTIONS_POSITION;
                 }
 
@@ -253,8 +254,8 @@ class WcPdkBootstrapper extends PdkBootstrapper
 
             'migrateAction_5_0_0_Orders'          => value("{$name}_migrate_5_0_0_orders"),
             'migrateAction_5_0_0_ProductSettings' => value("{$name}_migrate_5_0_0_product_settings"),
-            'migrateAction_6_1_0_Orders'          => value("{$name}_migrate_6_1_0_orders"),
-            'migrateAction_6_1_0_Shipments'       => value("{$name}_migrate_6_1_0_shipments"),
+            'migrateAction_6_5_1_Orders'          => value("{$name}_migrate_6_5_1_orders"),
+            'migrateAction_6_5_1_Shipments'       => value("{$name}_migrate_6_5_1_shipments"),
 
             # WP Cron actions
 

--- a/tests/Unit/Migration/Pdk/Migration6_5_1Test.php
+++ b/tests/Unit/Migration/Pdk/Migration6_5_1Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection StaticClosureCanBeUsedInspection */
 
 declare(strict_types=1);
@@ -13,7 +14,7 @@ use MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
-use MyParcelNL\WooCommerce\Migration\Migration6_1_0;
+use MyParcelNL\WooCommerce\Migration\Migration6_5_1;
 use MyParcelNL\WooCommerce\Tests\Mock\MockWpMeta;
 use MyParcelNL\WooCommerce\Tests\Mock\WordPressScheduledTasks;
 use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
@@ -30,8 +31,8 @@ it('does not fail account data migration when no account or shop is available', 
     /** @var PdkAccountRepositoryInterface $accountRepo */
     $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
 
     // No account configured (and a forced refresh has no valid API key), so getAccount()
     // returns null. The migration must skip gracefully instead of fataling.
@@ -55,10 +56,10 @@ it('rethrows when fetching carrier definitions fails so the migration retries', 
 
     mockPdkProperties([CarrierCapabilitiesRepository::class => $throwingRepo]);
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
 
-    expect(fn () => $migration->migrateAccountData())->toThrow(RuntimeException::class);
+    expect(fn() => $migration->migrateAccountData())->toThrow(RuntimeException::class);
 });
 
 // --- migrateCarrierSettings ---
@@ -74,8 +75,8 @@ it('remaps legacy carrier setting keys to new format', function () {
         'dhlparcelconnect' => ['delivery_enabled' => '0'],
     ]);
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->migrateCarrierSettings();
 
     $result = $settingsRepo->get($settingsKey);
@@ -91,8 +92,8 @@ it('remaps legacy carrier setting keys to new format', function () {
 });
 
 it('does not fail when carrier settings are empty', function () {
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->migrateCarrierSettings();
 
     /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockSettingsRepository $settingsRepo */
@@ -112,8 +113,8 @@ it('preserves carrier settings that already use new key format', function () {
         'BPOST'  => ['delivery_enabled' => '1'],
     ]);
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->migrateCarrierSettings();
 
     $result = $settingsRepo->get($settingsKey);
@@ -133,14 +134,14 @@ it('schedules order data migration', function () {
         createWcOrder(['id' => $i]);
     }
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->updateOrderData();
 
     $allTasks = $tasks->all();
 
     expect($allTasks->count())->toBeGreaterThanOrEqual(1)
-        ->and($allTasks->pluck('callback'))->each->toBe(Pdk::get('migrateAction_6_1_0_Orders'))
+        ->and($allTasks->pluck('callback'))->each->toBe(Pdk::get('migrateAction_6_5_1_Orders'))
         ->and($allTasks->first()['args'][0]['orderIds'])->not->toBeEmpty()
         ->and($allTasks->first()['args'][0]['chunk'])->toBe(1);
 });
@@ -153,14 +154,14 @@ it('schedules shipment data migration', function () {
         createWcOrder(['id' => $i]);
     }
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->updateShipmentData();
 
     $allTasks = $tasks->all();
 
     expect($allTasks->count())->toBeGreaterThanOrEqual(1)
-        ->and($allTasks->pluck('callback'))->each->toBe(Pdk::get('migrateAction_6_1_0_Shipments'));
+        ->and($allTasks->pluck('callback'))->each->toBe(Pdk::get('migrateAction_6_5_1_Shipments'));
 });
 
 // --- migrateOrderChunk (carrier normalization) ---
@@ -189,8 +190,8 @@ it('normalises the carrier field in order data', function (array $orderData, str
 
     createWcOrder(['id' => 1, 'meta' => [$metaKey => $orderData]]);
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->migrateOrderChunk([
         'orderIds' => [1],
         'chunk'    => 1,
@@ -204,8 +205,8 @@ it('normalises the carrier field in order data', function (array $orderData, str
 it('skips orders without order data meta', function () {
     createWcOrder(['id' => 1]);
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->migrateOrderChunk([
         'orderIds' => [1],
         'chunk'    => 1,
@@ -240,8 +241,8 @@ it('normalises the carrier field in shipment data', function (array $shipments, 
 
     createWcOrder(['id' => 1, 'meta' => [$metaKey => $shipments]]);
 
-    /** @var Migration6_1_0 $migration */
-    $migration = Pdk::get(Migration6_1_0::class);
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
     $migration->migrateShipmentChunk([
         'orderIds' => [1],
         'chunk'    => 1,

--- a/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
@@ -106,11 +106,11 @@
     "myparcelcom_migrate_5_0_0_product_settings": [
         "MyParcelNL\\WooCommerce\\Migration\\Pdk\\ProductSettingsMigration::migrateProductSettings"
     ],
-    "myparcelcom_migrate_6_1_0_orders": [
-        "MyParcelNL\\WooCommerce\\Migration\\Migration6_1_0::migrateOrderChunk"
+    "myparcelcom_migrate_6_5_1_orders": [
+        "MyParcelNL\\WooCommerce\\Migration\\Migration6_5_1::migrateOrderChunk"
     ],
-    "myparcelcom_migrate_6_1_0_shipments": [
-        "MyParcelNL\\WooCommerce\\Migration\\Migration6_1_0::migrateShipmentChunk"
+    "myparcelcom_migrate_6_5_1_shipments": [
+        "MyParcelNL\\WooCommerce\\Migration\\Migration6_5_1::migrateShipmentChunk"
     ],
     "woocommerce_get_country_locale": [
         "MyParcelNL\\WooCommerce\\Hooks\\SeparateAddressFieldsHooks::extendLocaleWithSeparateAddressFields",


### PR DESCRIPTION
fixes a fatal error due to a migration not running when upgrading from a version later than 6.1.0 to 6.5.0. Upgrading from any version older than 6.1.0 to 6.5.0 did not run into this issue.