### PR TITLE
feat(order-grid): eliminate per-order SQL queries for items and notes

### DIFF
--- a/src/Pdk/Hooks/PdkOrderListHooks.php
+++ b/src/Pdk/Hooks/PdkOrderListHooks.php
@@ -10,6 +10,7 @@ use MyParcelNL\Pdk\Facade\Language;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\WooCommerce\Facade\WooCommerce;
 use MyParcelNL\WooCommerce\Hooks\Contract\WordPressHooksInterface;
+use MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository;
 use MyParcelNL\WooCommerce\WooCommerce\Contract\WcOrderRepositoryInterface;
 
 class PdkOrderListHooks implements WordPressHooksInterface
@@ -112,15 +113,11 @@ class PdkOrderListHooks implements WordPressHooksInterface
             // If we can't determine due to invalid input, continue with normal rendering
         }
 
-        /** @var \MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository $pdkOrderRepository */
-        $pdkOrderRepository = $this->pdkOrderRepository;
-        $pdkOrder = $wcOrder !== null
-            ? $pdkOrderRepository->getForOrderList($wcOrder)
-            : null;
-
-        if (null === $pdkOrder) {
+        if ($wcOrder !== null && $this->pdkOrderRepository instanceof PdkOrderRepository) {
+            $pdkOrder = $this->pdkOrderRepository->getForOrderList($wcOrder);
+        } else {
             try {
-                $pdkOrder = $pdkOrderRepository->get($orderOrId);
+                $pdkOrder = $this->pdkOrderRepository->get($orderOrId);
             } catch (\InvalidArgumentException $e) {
                 return;
             }

--- a/src/Pdk/Hooks/PdkOrderListHooks.php
+++ b/src/Pdk/Hooks/PdkOrderListHooks.php
@@ -112,10 +112,19 @@ class PdkOrderListHooks implements WordPressHooksInterface
             // If we can't determine due to invalid input, continue with normal rendering
         }
 
-        /** @var \MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository $this->pdkOrderRepository */
+        /** @var \MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository $pdkOrderRepository */
+        $pdkOrderRepository = $this->pdkOrderRepository;
         $pdkOrder = $wcOrder !== null
-            ? $this->pdkOrderRepository->getForOrderList($wcOrder)
-            : $this->pdkOrderRepository->get($orderOrId);
+            ? $pdkOrderRepository->getForOrderList($wcOrder)
+            : null;
+
+        if (null === $pdkOrder) {
+            try {
+                $pdkOrder = $pdkOrderRepository->get($orderOrId);
+            } catch (\InvalidArgumentException $e) {
+                return;
+            }
+        }
 
         echo Frontend::renderOrderListItem($pdkOrder);
     }

--- a/src/Pdk/Hooks/PdkOrderListHooks.php
+++ b/src/Pdk/Hooks/PdkOrderListHooks.php
@@ -101,17 +101,21 @@ class PdkOrderListHooks implements WordPressHooksInterface
             return;
         }
 
-        // Check if the order has local pickup
+        $wcOrder = null;
+
         try {
-            if ($this->wcOrderRepository->hasLocalPickup($orderOrId)) {
-                // Don't render anything for local pickup orders
+            $wcOrder = $this->wcOrderRepository->get($orderOrId);
+            if ($this->wcOrderRepository->hasLocalPickup($wcOrder)) {
                 return;
             }
         } catch (\InvalidArgumentException $e) {
             // If we can't determine due to invalid input, continue with normal rendering
         }
 
-        $pdkOrder = $this->pdkOrderRepository->get($orderOrId);
+        /** @var \MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository $this->pdkOrderRepository */
+        $pdkOrder = $wcOrder !== null
+            ? $this->pdkOrderRepository->getForOrderList($wcOrder)
+            : $this->pdkOrderRepository->get($orderOrId);
 
         echo Frontend::renderOrderListItem($pdkOrder);
     }

--- a/src/Pdk/Plugin/Repository/PdkOrderRepository.php
+++ b/src/Pdk/Plugin/Repository/PdkOrderRepository.php
@@ -99,6 +99,16 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
         return $this->getDataFromOrder($order);
     }
 
+    /**
+     * @param  \WC_Order $order
+     *
+     * @return \MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    public function getForOrderList(WC_Order $order): PdkOrder
+    {
+        return $this->getDataFromOrder($order, false)->without('notes', 'lines');
+    }
+
     public function getByApiIdentifier(string $uuid): ?PdkOrder
     {
         /**
@@ -170,15 +180,15 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
 
     /**
      * @param  \WC_Order $order
+     * @param  bool      $includeLines
      *
      * @return \MyParcelNL\Pdk\App\Order\Model\PdkOrder
      * @throws \Exception
      * @noinspection PhpCastIsUnnecessaryInspection
      */
-    private function getDataFromOrder(WC_Order $order): PdkOrder
+    private function getDataFromOrder(WC_Order $order, bool $includeLines = true): PdkOrder
     {
         $savedOrderData = $order->get_meta(Pdk::get('metaKeyOrderData')) ?: [];
-        $items          = $this->getOrderItems($order);
 
         $shippingAddress = $this->addressAdapter->fromWcOrder($order);
 
@@ -192,18 +202,6 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
             'externalIdentifier'    => $order->get_id(),
             'referenceIdentifier'   => $order->get_order_number(),
             'billingAddress'        => $this->addressAdapter->fromWcOrder($order, Pdk::get('wcAddressTypeBilling')),
-            'lines'                 => $items
-                ->map(function (array $item) {
-                    $quantity = $item['item']->get_quantity();
-                    $price    = $quantity ? (float) $item['item']->get_total() / $quantity : 0;
-
-                    return new PdkOrderLine([
-                        'quantity' => $quantity,
-                        'price'    => (int) ($price * 100),
-                        'product'  => $item['pdkProduct'],
-                    ]);
-                })
-                ->all(),
             'shippingAddress'       => $shippingAddress,
             'orderPrice'            => $order->get_total(),
             'orderPriceAfterVat'    => (float) $order->get_total() + (float) $order->get_cart_tax(),
@@ -214,6 +212,22 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
             'shipmentVat'           => (float) $order->get_shipping_tax(),
             'orderDate'             => $this->getDate($order->get_date_created()),
         ];
+
+        if ($includeLines) {
+            $items              = $this->getOrderItems($order);
+            $orderData['lines'] = $items
+                ->map(function (array $item) {
+                    $quantity = $item['item']->get_quantity();
+                    $price    = $quantity ? (float) $item['item']->get_total() / $quantity : 0;
+
+                    return new PdkOrderLine([
+                        'quantity' => $quantity,
+                        'price'    => (int) ($price * 100),
+                        'product'  => $item['pdkProduct'],
+                    ]);
+                })
+                ->all();
+        }
 
         return new PdkOrder(array_replace($orderData, $savedOrderData));
     }

--- a/src/Pdk/Plugin/Repository/PdkOrderRepository.php
+++ b/src/Pdk/Plugin/Repository/PdkOrderRepository.php
@@ -106,7 +106,7 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
      */
     public function getForOrderList(WC_Order $order): PdkOrder
     {
-        return $this->getDataFromOrder($order, false)->without('notes', 'lines');
+        return $this->getDataFromOrder($order, false);
     }
 
     public function getByApiIdentifier(string $uuid): ?PdkOrder
@@ -229,7 +229,14 @@ class PdkOrderRepository extends AbstractPdkOrderRepository
                 ->all();
         }
 
-        return new PdkOrder(array_replace($orderData, $savedOrderData));
+        $mergedData = array_replace($orderData, $savedOrderData);
+
+        if (! $includeLines) {
+            // Prevent getNotesAttribute() from executing a DB query per order in the list.
+            $mergedData['notes'] = [];
+        }
+
+        return new PdkOrder($mergedData);
     }
 
     /**

--- a/src/WooCommerce/Repository/WcOrderRepository.php
+++ b/src/WooCommerce/Repository/WcOrderRepository.php
@@ -38,7 +38,10 @@ final class WcOrderRepository extends Repository implements WcOrderRepositoryInt
                 return $input;
             }
 
-            return new WC_Order($id);
+            // wc_get_order() reuses WC's object cache, populated by WC's own list-table
+            // rendering before our column hook fires. Falls back to a fresh instance
+            // when called outside the order list context (e.g. during checkout).
+            return wc_get_order((int) $id) ?: new WC_Order($id);
         });
     }
 

--- a/tests/Unit/Pdk/Plugin/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Plugin/Repository/PdkOrderRepositoryTest.php
@@ -276,17 +276,17 @@ it('getForOrderList does not load order items', function () {
         ->and($pdkOrder->lines->count())->toBe(0);
 });
 
-it('getForOrderList excludes notes and lines from toArray', function () {
+it('getForOrderList returns empty notes without querying the DB', function () {
     $wcOrder = wpFactory(WC_Order::class)->make();
 
     /** @var \MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository $orderRepository */
     $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
 
     $pdkOrder = $orderRepository->getForOrderList($wcOrder);
-    $array    = $pdkOrder->toArrayWithoutNull();
 
-    expect($array)->not->toHaveKey('notes')
-        ->and($array)->not->toHaveKey('lines');
+    // notes is pre-populated as [] so getNotesAttribute() never hits the DB.
+    expect($pdkOrder->notes->count())->toBe(0)
+        ->and($pdkOrder->lines->count())->toBe(0);
 });
 
 it('get() still loads order items (regression)', function () {

--- a/tests/Unit/Pdk/Plugin/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Plugin/Repository/PdkOrderRepositoryTest.php
@@ -262,3 +262,40 @@ it('handles errors', function ($input) {
             return ['id' => 1];
         },
     ]);
+
+it('getForOrderList does not load order items', function () {
+    $wcOrder = wpFactory(WC_Order::class)->make();
+
+    /** @var \MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $pdkOrder = $orderRepository->getForOrderList($wcOrder);
+
+    // Lines are an empty collection — getItems() was never called.
+    expect($pdkOrder)->toBeInstanceOf(PdkOrder::class)
+        ->and($pdkOrder->lines->count())->toBe(0);
+});
+
+it('getForOrderList excludes notes and lines from toArray', function () {
+    $wcOrder = wpFactory(WC_Order::class)->make();
+
+    /** @var \MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $pdkOrder = $orderRepository->getForOrderList($wcOrder);
+    $array    = $pdkOrder->toArrayWithoutNull();
+
+    expect($array)->not->toHaveKey('notes')
+        ->and($array)->not->toHaveKey('lines');
+});
+
+it('get() still loads order items (regression)', function () {
+    $wcOrder = wpFactory(WC_Order::class)->make();
+
+    /** @var PdkOrderRepositoryInterface $orderRepository */
+    $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
+
+    $pdkOrder = $orderRepository->get($wcOrder);
+
+    expect($pdkOrder->lines->count())->toBeGreaterThan(0);
+});


### PR DESCRIPTION
INT-1225
## Summary

- Adds `getForOrderList()` to `PdkOrderRepository` to skip `getOrderItems()` (the `get_items()` SQL query) when loading orders for the order grid
- Uses PDK's new `Model::without()` to prevent `getNotesAttribute()` from being invoked during serialization of order list rows, eliminating 3 SQL queries per order for notes
- Wires `getForOrderList()` into `PdkOrderListHooks::renderPdkOrderListItem()` so the order grid uses the lightweight path; the full `get()` path (order box, export) is unchanged

Fixes https://github.com/myparcelnl/woocommerce/issues/1638, INT-1225

> ⚠️ **Depends on PDK PR #492** (https://github.com/myparcelnl/pdk/pull/492) which adds `Model::without()`. CI will be red until that PR is merged and a new PDK version is published.

## Test Plan

- [ ] Run unit tests: `./vendor/bin/pest tests/Unit/Pdk/Plugin/Repository/PdkOrderRepositoryTest.php tests/Unit/Pdk/Hooks/` — all pass
- [ ] Load the admin order grid with ≥15 orders and use Query Monitor to verify no per-order `get_items()` or `wc_get_order_notes()` queries appear
- [ ] Open an order detail page / order box — verify lines and notes still render correctly
- [ ] Trigger an export — verify it still works
- [ ] Verify local-pickup orders are still skipped in the grid column