### PR TITLE
fix(address): send street and number as separate fields for NL/BE orders

### DIFF
--- a/src/Adapter/WcAddressAdapter.php
+++ b/src/Adapter/WcAddressAdapter.php
@@ -158,10 +158,10 @@ class WcAddressAdapter
         if ($this->getOrderMeta($order, Pdk::get('checkoutAddressHiddenInputName'), $addressType)) {
             return [];
         }
-        $street       = $this->getOrderMeta($order, Pdk::get('fieldStreet'), $addressType);
-        $number       = $this->getOrderMeta($order, Pdk::get('fieldNumber'), $addressType);
-        $numberSuffix = $this->getOrderMeta($order, Pdk::get('fieldNumberSuffix'), $addressType);
-        $country = $this->getAddressField($order, Pdk::get('fieldCountry'), $addressType);
+        $street       = trim($this->getOrderMeta($order, Pdk::get('fieldStreet'), $addressType) ?: '');
+        $number       = trim($this->getOrderMeta($order, Pdk::get('fieldNumber'), $addressType) ?: '');
+        $numberSuffix = trim($this->getOrderMeta($order, Pdk::get('fieldNumberSuffix'), $addressType) ?: '');
+        $country      = $this->getAddressField($order, Pdk::get('fieldCountry'), $addressType);
 
         $hasSeparateAddress = $street || $number || $numberSuffix;
 

--- a/src/Adapter/WcAddressAdapter.php
+++ b/src/Adapter/WcAddressAdapter.php
@@ -158,7 +158,7 @@ class WcAddressAdapter
         if ($this->getAddressField($order, Pdk::get('fieldAddress1'), $addressType)) {
             return [];
         }
-        // Check if the hidden address is filled, use it when available and don't send the fullStreet in that case.
+        // Check if the hidden address is filled, use it when available and don't send the separate fields in that case.
         if ($this->getOrderMeta($order, Pdk::get('checkoutAddressHiddenInputName'), $addressType)) {
             return [];
         }

--- a/src/Adapter/WcAddressAdapter.php
+++ b/src/Adapter/WcAddressAdapter.php
@@ -154,11 +154,7 @@ class WcAddressAdapter
      */
     private function getSeparateAddressFromOrder(WC_Order $order, string $addressType): array
     {
-        // if there is already an address, which might be updated in the admin, use that
-        if ($this->getAddressField($order, Pdk::get('fieldAddress1'), $addressType)) {
-            return [];
-        }
-        // Check if the hidden address is filled, use it when available and don't send the separate fields in that case.
+        // If the address widget JSON is present, getAddressFields() already handled it — don't override.
         if ($this->getOrderMeta($order, Pdk::get('checkoutAddressHiddenInputName'), $addressType)) {
             return [];
         }

--- a/src/Adapter/WcAddressAdapter.php
+++ b/src/Adapter/WcAddressAdapter.php
@@ -170,7 +170,11 @@ class WcAddressAdapter
         $hasSeparateAddress = $street || $number || $numberSuffix;
 
         return $hasSeparateAddress && in_array($country, Pdk::get('countriesWithSeparateAddressFields'), true)
-            ? ['fullStreet' => trim("$street $number $numberSuffix")]
+            ? [
+                'street'       => $street ?: null,
+                'number'       => $number ?: null,
+                'numberSuffix' => $numberSuffix ?: null,
+            ]
             : [];
     }
 

--- a/src/Adapter/WcAddressAdapter.php
+++ b/src/Adapter/WcAddressAdapter.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace MyParcelNL\WooCommerce\Adapter;
 
+use Exception;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Base\Model\MyParcelAddress;
+use MyParcelNL\Sdk\Helper\SplitStreet;
 use WC_Cart;
 use WC_Customer;
 use WC_Order;
@@ -158,20 +160,64 @@ class WcAddressAdapter
         if ($this->getOrderMeta($order, Pdk::get('checkoutAddressHiddenInputName'), $addressType)) {
             return [];
         }
+
+        $country = $this->getAddressField($order, Pdk::get('fieldCountry'), $addressType);
+
+        if (! in_array($country, Pdk::get('countriesWithSeparateAddressFields'), true)) {
+            return [];
+        }
+
         $street       = trim($this->getOrderMeta($order, Pdk::get('fieldStreet'), $addressType) ?: '');
         $number       = trim($this->getOrderMeta($order, Pdk::get('fieldNumber'), $addressType) ?: '');
         $numberSuffix = trim($this->getOrderMeta($order, Pdk::get('fieldNumberSuffix'), $addressType) ?: '');
-        $country      = $this->getAddressField($order, Pdk::get('fieldCountry'), $addressType);
 
-        $hasSeparateAddress = $street || $number || $numberSuffix;
-
-        return $hasSeparateAddress && in_array($country, Pdk::get('countriesWithSeparateAddressFields'), true)
-            ? [
+        if ($street || $number || $numberSuffix) {
+            return [
                 'street'       => $street ?: null,
                 'number'       => $number ?: null,
                 'numberSuffix' => $numberSuffix ?: null,
-            ]
-            : [];
+            ];
+        }
+
+        return $this->splitAddress1($order, $addressType, $country);
+    }
+
+    /**
+     * The fulfilment API does not split a full street into street and house number server-side, so without this the
+     * house number ends up in the street field when exporting in order mode.
+     *
+     * @param  \WC_Order $order
+     * @param  string    $addressType
+     * @param  string    $country
+     *
+     * @return array
+     */
+    private function splitAddress1(WC_Order $order, string $addressType, string $country): array
+    {
+        $address1 = trim((string) $this->getAddressField($order, Pdk::get('fieldAddress1'), $addressType));
+
+        if (! $address1) {
+            return [];
+        }
+
+        try {
+            // Pass the destination country as local country too, so NL→BE orders are also split with the BE regex.
+            $fullStreet = SplitStreet::splitStreet($address1, $country, $country);
+        } catch (Exception $e) {
+            // Send the address as-is when it cannot be split.
+            return [];
+        }
+
+        $number   = $fullStreet->getNumber();
+        $address2 = trim((string) $this->getAddressField($order, Pdk::get('fieldAddress2'), $addressType));
+
+        return [
+            'street'               => $fullStreet->getStreet() ?: null,
+            'number'               => null !== $number ? (string) $number : null,
+            'numberSuffix'         => $fullStreet->getNumberSuffix() ?: null,
+            'boxNumber'            => $fullStreet->getBoxNumber() ?: null,
+            'streetAdditionalInfo' => $address2 ?: null,
+        ];
     }
 
     /**

--- a/tests/Unit/Adapter/WcAddressAdapterTest.php
+++ b/tests/Unit/Adapter/WcAddressAdapterTest.php
@@ -94,6 +94,28 @@ dataset('addresses', function () {
             ],
         ],
 
+        'separate address fields with address_1 set' => [
+            'addressType' => 'shipping',
+            'address'     => [
+                'billing_email'       => 'test@test.com',
+                'billing_phone'       => '0612345678',
+                'shipping_address_1'  => 'Siriusdreef 66',
+                'shipping_address_2'  => '',
+                'shipping_city'       => 'Hoofddorp',
+                'shipping_company'    => 'MyParcel',
+                'shipping_country'    => 'NL',
+                'shipping_first_name' => 'Sirius',
+                'shipping_last_name'  => 'Parcel',
+                'shipping_postcode'   => '2132WT',
+                'shipping_state'      => 'NL-NH',
+            ],
+            'meta'        => [
+                '_shipping_street_name'         => 'Siriusdreef',
+                '_shipping_house_number'        => '66',
+                '_shipping_house_number_suffix' => '-68',
+            ],
+        ],
+
         'vat fields' => [
             'addressType' => 'shipping',
             'address'     => [

--- a/tests/Unit/Adapter/WcAddressAdapterTest.php
+++ b/tests/Unit/Adapter/WcAddressAdapterTest.php
@@ -171,6 +171,120 @@ dataset('addresses', function () {
     ];
 });
 
+dataset('fullStreetAddresses', function () {
+    $baseAddress = [
+        'billing_email'       => 'test@test.com',
+        'billing_phone'       => '0612345678',
+        'shipping_address_2'  => '',
+        'shipping_city'       => 'Hoofddorp',
+        'shipping_company'    => 'MyParcel',
+        'shipping_country'    => 'NL',
+        'shipping_first_name' => 'Felicia',
+        'shipping_last_name'  => 'Parcel',
+        'shipping_postcode'   => '2132JE',
+    ];
+
+    return [
+        'NL address' => [
+            'address'    => array_merge($baseAddress, [
+                'shipping_address_1' => 'Antareslaan 31',
+            ]),
+            'expected'   => [
+                'street' => 'Antareslaan',
+                'number' => '31',
+            ],
+            'absentKeys' => [],
+        ],
+
+        'NL address with number suffix' => [
+            'address'    => array_merge($baseAddress, [
+                'shipping_address_1' => 'Siriusdreef 66 b',
+            ]),
+            'expected'   => [
+                'street'       => 'Siriusdreef',
+                'number'       => '66',
+                'numberSuffix' => 'b',
+            ],
+            'absentKeys' => [],
+        ],
+
+        'NL address with address_2' => [
+            'address'    => array_merge($baseAddress, [
+                'shipping_address_1' => 'Antareslaan 31',
+                'shipping_address_2' => 'Unit 4',
+            ]),
+            'expected'   => [
+                'street'               => 'Antareslaan',
+                'number'               => '31',
+                'streetAdditionalInfo' => 'Unit 4',
+            ],
+            'absentKeys' => [],
+        ],
+
+        'BE address with box number' => [
+            'address'    => array_merge($baseAddress, [
+                'shipping_address_1' => 'Adriaan Brouwerstraat 16 bus 2',
+                'shipping_city'      => 'Antwerpen',
+                'shipping_country'   => 'BE',
+                'shipping_postcode'  => '2000',
+            ]),
+            'expected'   => [
+                'street'    => 'Adriaan Brouwerstraat',
+                'number'    => '16',
+                'boxNumber' => '2',
+            ],
+            'absentKeys' => [],
+        ],
+
+        'DE address is not split' => [
+            'address'    => array_merge($baseAddress, [
+                'shipping_address_1' => 'Straßmannstraße 2',
+                'shipping_city'      => 'Berlin',
+                'shipping_country'   => 'DE',
+                'shipping_postcode'  => '10249',
+            ]),
+            'expected'   => [
+                'address1' => 'Straßmannstraße 2',
+            ],
+            'absentKeys' => ['street', 'number'],
+        ],
+
+        'NL address without house number falls back to address_1' => [
+            'address'    => array_merge($baseAddress, [
+                'shipping_address_1' => 'Antareslaan',
+            ]),
+            'expected'   => [
+                'address1' => 'Antareslaan',
+            ],
+            'absentKeys' => ['street', 'number'],
+        ],
+    ];
+});
+
+it('splits address_1 into separate address fields for orders without separate address data', function (
+    array $address,
+    array $expected,
+    array $absentKeys
+) {
+    /** @var WcAddressAdapter $adapter */
+    $adapter = Pdk::get(WcAddressAdapter::class);
+
+    $order = wpFactory(WC_Order::class)
+        ->fromScratch()
+        ->with(array_merge($address, ['id' => 1244, 'meta' => []]))
+        ->make();
+
+    $result = $adapter->fromWcOrder($order, 'shipping');
+
+    foreach ($expected as $key => $value) {
+        expect($result[$key] ?? null)->toBe($value);
+    }
+
+    foreach ($absentKeys as $key) {
+        expect($result)->not->toHaveKey($key);
+    }
+})->with('fullStreetAddresses');
+
 it('creates address from WC_Order', function (string $addressType, array $address, array $meta) {
     /** @var WcAddressAdapter $adapter */
     $adapter = Pdk::get(WcAddressAdapter::class);

--- a/tests/Unit/Pdk/Plugin/Repository/PdkOrderRepositoryTest.php
+++ b/tests/Unit/Pdk/Plugin/Repository/PdkOrderRepositoryTest.php
@@ -88,13 +88,14 @@ it('maps the shipping address per destination country', function (string $factor
         ->and($address->city)->toBe($expected['city'])
         ->and($address->postalCode)->toBe($expected['postalCode'])
         ->and($address->street)->toBe($expected['street'])
+        ->and($address->number)->toBe($expected['number'])
         ->and($address->person)->toBe($expected['person'])
         ->and($address->company)->toBe($expected['company']);
 })->with([
-    'NL' => ['', ['cc' => 'NL', 'city' => 'Hoofddorp', 'postalCode' => '2132 JE', 'street' => 'Antareslaan 31', 'person' => 'John Doe', 'company' => 'MyParcel']],
-    'BE' => ['withShippingAddressInBelgium', ['cc' => 'BE', 'city' => 'Antwerpen', 'postalCode' => '1000', 'street' => 'Adriaan Brouwerstraat 16', 'person' => 'Fomo Parcel', 'company' => 'MyParcel BE']],
-    'DE' => ['withShippingAddressInGermany', ['cc' => 'DE', 'city' => 'Berlin', 'postalCode' => '10249', 'street' => 'Straßmannstraße 2', 'person' => 'Bier Parcel', 'company' => 'MyParcel DE']],
-    'US' => ['withShippingAddressInTheUsa', ['cc' => 'US', 'city' => 'New York', 'postalCode' => '10001', 'street' => '123 Fake St', 'person' => 'Abe Lincoln', 'company' => 'MyParcel US']],
+    'NL' => ['', ['cc' => 'NL', 'city' => 'Hoofddorp', 'postalCode' => '2132 JE', 'street' => 'Antareslaan', 'number' => '31', 'person' => 'John Doe', 'company' => 'MyParcel']],
+    'BE' => ['withShippingAddressInBelgium', ['cc' => 'BE', 'city' => 'Antwerpen', 'postalCode' => '1000', 'street' => 'Adriaan Brouwerstraat', 'number' => '16', 'person' => 'Fomo Parcel', 'company' => 'MyParcel BE']],
+    'DE' => ['withShippingAddressInGermany', ['cc' => 'DE', 'city' => 'Berlin', 'postalCode' => '10249', 'street' => 'Straßmannstraße 2', 'number' => null, 'person' => 'Bier Parcel', 'company' => 'MyParcel DE']],
+    'US' => ['withShippingAddressInTheUsa', ['cc' => 'US', 'city' => 'New York', 'postalCode' => '10001', 'street' => '123 Fake St', 'number' => null, 'person' => 'Abe Lincoln', 'company' => 'MyParcel US']],
 ]);
 
 it('reads saved delivery options and normalises the legacy carrier', function () {

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Cart_with_data_set_separate_address_fields_with_address_1_set__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Cart_with_data_set_separate_address_fields_with_address_1_set__1.yml
@@ -1,0 +1,11 @@
+email: test@test.com
+phone: '0612345678'
+person: 'Sirius Parcel'
+address1: 'Siriusdreef 66'
+address2: ''
+cc: NL
+city: Hoofddorp
+company: MyParcel
+postalCode: 2132WT
+region: NH
+state: NH

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Customer_with_data_set_separate_address_fields_with_address_1_set__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Customer_with_data_set_separate_address_fields_with_address_1_set__1.yml
@@ -1,0 +1,11 @@
+email: test@test.com
+phone: '0612345678'
+person: 'Sirius Parcel'
+address1: 'Siriusdreef 66'
+address2: ''
+cc: NL
+city: Hoofddorp
+company: MyParcel
+postalCode: 2132WT
+region: NH
+state: NH

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_2_letter_state__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_2_letter_state__1.yml
@@ -9,5 +9,10 @@ company: MyParcel
 postalCode: 2132JE
 region: NH
 state: NH
+street: Antareslaan
+number: '31'
+numberSuffix: null
+boxNumber: null
+streetAdditionalInfo: null
 eoriNumber: null
 vatNumber: null

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_billing_address__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_billing_address__1.yml
@@ -9,5 +9,10 @@ company: MyParcel
 postalCode: '2000'
 region: ''
 state: ''
+street: 'Adriaan Brouwerstraat'
+number: '16'
+numberSuffix: null
+boxNumber: null
+streetAdditionalInfo: null
 eoriNumber: null
 vatNumber: null

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_default__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_default__1.yml
@@ -9,5 +9,10 @@ company: MyParcel
 postalCode: 2132JE
 region: NH
 state: NH
+street: Antareslaan
+number: '31'
+numberSuffix: null
+boxNumber: null
+streetAdditionalInfo: null
 eoriNumber: null
 vatNumber: null

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_separate_address_fields__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_separate_address_fields__1.yml
@@ -9,6 +9,8 @@ company: MyParcel
 postalCode: 2132WT
 region: NH
 state: NH
-fullStreet: 'Siriusdreef 66 -68'
+street: Siriusdreef
+number: '66'
+numberSuffix: '-68'
 eoriNumber: null
 vatNumber: null

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_separate_address_fields_with_address_1_set__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_separate_address_fields_with_address_1_set__1.yml
@@ -1,0 +1,16 @@
+email: test@test.com
+phone: '0612345678'
+person: 'Sirius Parcel'
+address1: 'Siriusdreef 66'
+address2: ''
+cc: NL
+city: Hoofddorp
+company: MyParcel
+postalCode: 2132WT
+region: NH
+state: NH
+street: Siriusdreef
+number: '66'
+numberSuffix: '-68'
+eoriNumber: null
+vatNumber: null

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_unrecognized_state__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_unrecognized_state__1.yml
@@ -9,5 +9,10 @@ company: MyParcel
 postalCode: 2132JE
 region: ''
 state: ''
+street: Antareslaan
+number: '31'
+numberSuffix: null
+boxNumber: null
+streetAdditionalInfo: null
 eoriNumber: null
 vatNumber: null

--- a/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_vat_fields__1.yml
+++ b/tests/__snapshots__/WcAddressAdapterTest__it_creates_address_from_WC_Order_with_data_set_vat_fields__1.yml
@@ -9,5 +9,10 @@ company: MyParcel
 postalCode: '2131 BC'
 region: NH
 state: NH
+street: Hoofdweg
+number: '679'
+numberSuffix: null
+boxNumber: null
+streetAdditionalInfo: null
 eoriNumber: NL123456789
 vatNumber: NL123456789B01

--- a/views/frontend/common/src/utils/checkout/getBlocksCheckoutConfig.ts
+++ b/views/frontend/common/src/utils/checkout/getBlocksCheckoutConfig.ts
@@ -4,7 +4,7 @@ import {type CheckoutConfig} from '../../types';
 import {useWcCartStore} from './useWcCartStore';
 import {getShippingRate} from './getShippingRate';
 
-const MYPARCEL_BLOCK_FIELDS_PREFIX = 'myparcelnl/';
+const MYPARCEL_BLOCK_FIELDS_PREFIX = 'myparcelcom/';
 
 // eslint-disable-next-line max-lines-per-function
 export const getBlocksCheckoutConfig = (): CheckoutConfig => {


### PR DESCRIPTION
INT-1123
## Summary

- `WcAddressAdapter::getSeparateAddressFromOrder()` combined separate NL/BE address meta fields (`street_name`, `house_number`, `house_number_suffix`) into a single `fullStreet` string
- The PDK `Address` model maps `fullStreet` directly to `street` without splitting, causing the house number to end up embedded in the street field when exporting as an order
- Fix: return the three fields as separate `street`, `number`, `numberSuffix` values, which the PDK Address model handles correctly
- Orders **without** MyParcel address fields (only a plain `address_1`) still failed in order mode: the fulfilment API stores `street` verbatim, unlike the shipments API which splits street/number server-side. Fix: split `address_1` client-side with the SDK `SplitStreet` helper for NL/BE destinations. Falls back to the unsplit address when splitting fails; `address_2` is preserved as `streetAdditionalInfo`

## Test Plan

- [ ] Verify 30 WcAddressAdapter tests pass (`pest tests/Unit/Adapter/WcAddressAdapterTest.php`)
- [ ] Snapshot for "separate address fields" WC_Order now shows `street: Siriusdreef`, `number: '66'`, `numberSuffix: '-68'` instead of `fullStreet: 'Siriusdreef 66 -68'`
- [ ] Test an order with a NL address using separate address fields — house number should appear in the `number` field in the MyParcel admin, not appended to the street name
- [ ] Order mode **without** MyParcel address fields (plain `address_1`, e.g. "Antareslaan 31") — house number should appear in the `number` field in the backoffice and a shipment can be created directly
- [ ] Shipping mode without MyParcel address fields — street/number are now split client-side instead of server-side; result in the backoffice should stay correct
