### PR TITLE
chore: run PDK console commands from the plugin locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ You can download the .zip file of the [latest release], or install it on your we
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+## Running PDK console commands
+
+This plugin is built on the [MyParcel PDK](https://github.com/myparcelnl/pdk). With the PDK linked locally for development (`pdk-dev-on`), you can run any PDK console command from the plugin root:
+
+```sh
+composer console <command>
+```
+
+Run `composer console list` to see all available commands, or `composer console help <command>` for a command's full usage.
+
 [Backoffice]: https://backoffice.myparcel.nl/
 [Delivery options]: https://github.com/myparcelnl/delivery-options
 [Plugin manual]: https://developer.myparcel.nl/nl/documentatie/10.woocommerce.html

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "php": "7.4"
   },
   "scripts": {
+    "console": "php vendor/myparcelnl/pdk/bin/console",
     "analyse": "php -dmemory_limit=-1 vendor/bin/phpstan analyse",
     "analyse:generate": "composer run analyse -- --generate-baseline phpstan-baseline.php --allow-empty-baseline",
     "analyze": "composer run analyse",


### PR DESCRIPTION
Adds a `console` composer script so developers can run any MyParcel PDK console command from the plugin locally — e.g. the timestamped-migration scaffolder (`generate:migration`) and the code generators — when the PDK is dev-linked via `pdk-dev-on`.

Run `composer console list` for available commands and `composer console help <command>` for usage. README has a short pointer.

Independent of any PDK change; works against the dev-linked PDK.

Refs INT-951

🤖 Generated with [Claude Code](https://claude.com/claude-code)