### PR TITLE
fix(checkout): fix prices in blocks checkout not updating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,13 +89,13 @@ For long-running migrations, use **chunked cron jobs**:
 Always run PHP tests via Docker to use the correct PHP version:
 
 ```bash
-cd ~/projects/docker-wordpress && PHP_VERSION=7.4 docker compose run --rm php bash -c 'cd /var/www/html/wp-content/plugins/myparcelnl-woocommerce && ./vendor/bin/pest <args>'
+cd ~/projects/docker-wordpress && PHP_VERSION=7.4 docker compose run --rm php bash -c 'cd /var/www/html/wp-content/plugins/woocommerce-myparcel && ./vendor/bin/pest <args>'
 ```
 
 Before running tests, install composer dependencies inside the container:
 
 ```bash
-cd ~/projects/docker-wordpress && docker compose run --rm php bash -c "cd /var/www/html/wp-content/plugins/myparcelnl-woocommerce && composer install --ignore-platform-req=ext-gd"
+cd ~/projects/docker-wordpress && docker compose run --rm php bash -c "cd /var/www/html/wp-content/plugins/woocommerce-myparcel && composer install --ignore-platform-req=ext-gd"
 ```
 
 Never run `./vendor/bin/pest` or `composer install` directly on the host — the host PHP version may differ from the Docker container.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,46 @@ For long-running migrations, use **chunked cron jobs**:
 5. `CartFeesHooks` processes this on AJAX cart updates; `PdkCheckoutPlaceOrderHooks` saves on order placement
 6. Both create `new DeliveryOptions(json_decode(...))` — the constructor normalizes legacy carrier names
 
+### Blocks checkout: delivery-option fee gotchas (hard-won — don't relearn)
+
+The live delivery-option fee in the **blocks** checkout uses `extensionCartUpdate`
+(`views/blocks/delivery-options/src/frontend.tsx`). Its response applies the **entire** server cart
+back into `wc/store/cart` (`receiveCart`), so a badly-timed push corrupts other cart state. There is
+**no** WC Blocks alternative that puts a fee in the grand total (checkout filters and totals
+slot/fills are display-only). These invariants must hold — each fixes a real bug we hit:
+
+- **Never push at order placement.** Forcing `extensionCartUpdate` there reverts the chosen shipping
+  method on the resulting order. The order POST already carries the selection in its `extensions`
+  payload; the server primes the fee from it in `CartFeesHooks::stashBlocksCheckoutSelection` (hooked
+  on `woocommerce_store_api_checkout_update_customer_from_request`, which runs *before*
+  `OrderController::update_order_from_cart` recalculates fees). Do **not** read `php://input` in the
+  fee calc (`woocommerce_cart_calculate_fees`) — it corrupts the order build (duplicate lines, 500s).
+- **The push must block the place-order flow while in flight.** An `extensionCartUpdate` overlapping
+  the order POST duplicates the order's line items/fees, and an in-flight request can't be cancelled.
+  Wrap the push in `dispatch(CHECKOUT_STORE_KEY).__internalIncrementCalculating()` /
+  `__internalDecrementCalculating()` (the `isCalculating` the place-order flow already waits on).
+- **Dedupe widget re-emits on a fee-relevant key** (ignore the volatile `date`) held **module-level**
+  so it survives the remount Blocks does on every shipping/pickup toggle; otherwise the toggle
+  re-emit fires a spurious push that races the shipping commit.
+
+**Known WooCommerce core bug (not ours):** rapidly toggling "Afhalen in de winkel" ↔ "Verzenden" then
+ordering can place the order on the *previous* method (WC fails to commit the final local-pickup
+toggle server-side). Reproduces with all our checkout JS disabled. Normal single toggles are fine;
+treat rapid back-and-forth as an upstream stress-case.
+
 ## Development Environment
 
 - The plugin runs inside a Docker-based WordPress setup. Use `docker compose exec php wp ...` from the docker-wordpress project root for WP-CLI commands.
 - PDK (PHP) is linked locally as a path dependency in `composer.json` — check the `repositories` section for the local path.
 - JS-PDK apps are linked via `portal:` in `package.json` — check `devDependencies` for the local paths.
+
+### Building JS (nx cache gotcha)
+
+Editing the shared `views/frontend/common` package does **not** invalidate nx's build cache for
+dependent bundles (e.g. `frontend-checkout-core`), so a plain `yarn build` can silently replay a
+stale bundle and your change won't reach the browser. Build with `--skip-nx-cache` (or run
+`npx nx reset` first). Verify a change landed with `grep` on the `dist/*.iife.js` / `dist/*.js`
+(the dev build keeps variable names; the production build minifies).
 
 ### Running Tests
 

--- a/config/pdk.php
+++ b/config/pdk.php
@@ -116,7 +116,7 @@ return [
         return '?';
     }),
 
-    'minimumWooCommerceVersion' => value('5.0.0'),
+    'minimumWooCommerceVersion' => value('8.6.0'),
 
     'isWooCommerceVersionSupported' => factory(function (): bool {
         return version_compare(WooCommerce::getVersion(), PdkFacade::get('minimumWooCommerceVersion'), '>=');

--- a/config/pdk.php
+++ b/config/pdk.php
@@ -116,7 +116,7 @@ return [
         return '?';
     }),
 
-    'minimumWooCommerceVersion' => value('8.6.0'),
+    'minimumWooCommerceVersion' => value('5.0.0'),
 
     'isWooCommerceVersionSupported' => factory(function (): bool {
         return version_compare(WooCommerce::getVersion(), PdkFacade::get('minimumWooCommerceVersion'), '>=');

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,9 @@
 Contributors: freekkie, joerimyparcel, nabilazahaf, richardperdaan
 Tags: woocommerce, export, delivery, packages, myparcel
 Requires at least: 5.2.0
-Tested up to: 6.8
+Tested up to: 7.0
+WC requires at least: 8.6
+WC tested up to: 10.3
 Stable tag: 4.24.3
 Requires PHP: 7.4
 License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,6 @@ Contributors: freekkie, joerimyparcel, nabilazahaf, richardperdaan
 Tags: woocommerce, export, delivery, packages, myparcel
 Requires at least: 5.2.0
 Tested up to: 7.0
-WC requires at least: 8.6
 WC tested up to: 10.3
 Stable tag: 4.24.3
 Requires PHP: 7.4

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -45,6 +45,12 @@ final class CartFeesHooks implements WordPressHooksInterface
         // the Store API callback directly instead of deferring it — still before any REST request.
         $this->registerStoreApiUpdateCallback();
 
+        // Blocks order placement: prime the session from the checkout request *before* the order is
+        // built, so an order placed within the debounce window (before the live extensionCartUpdate
+        // fires) still charges the chosen option's fee. This hook runs before the order-building cart
+        // recalculation (OrderController::update_order_from_cart), which is what sets the order's fees.
+        add_action('woocommerce_store_api_checkout_update_customer_from_request', [$this, 'stashBlocksCheckoutSelection'], 10, 2);
+
         // Drop the stashed selection once it's no longer relevant, so it can't apply to a later cart.
         add_action('woocommerce_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
         add_action('woocommerce_blocks_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
@@ -175,6 +181,36 @@ final class CartFeesHooks implements WordPressHooksInterface
                 }
             },
         ]);
+    }
+
+    /**
+     * Stashes the blocks-checkout selection in the session during order placement, before the order
+     * is built from the cart. Without this, an order placed within the debounce window (before the
+     * live extensionCartUpdate fires) would charge the fee from the previous selection. Reads the
+     * raw request body — the same source PdkCheckoutPlaceOrderHooks uses — because the request's
+     * `extensions` param only carries namespaces registered on the checkout schema.
+     *
+     * @param  \WC_Customer     $customer Unused; part of the hook signature.
+     * @param  \WP_REST_Request $request  Unused; the selection is read from the raw body (see above).
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function stashBlocksCheckoutSelection($customer, $request): void
+    {
+        // eslint-disable-next-line camelcase
+        global $HTTP_RAW_POST_DATA;
+
+        if (! is_string($HTTP_RAW_POST_DATA) || '' === $HTTP_RAW_POST_DATA) {
+            return;
+        }
+
+        $decoded = json_decode(wp_unslash($HTTP_RAW_POST_DATA), true);
+        $key     = PdkBootstrapper::PLUGIN_NAMESPACE . '-delivery-options';
+        $data    = is_array($decoded) ? ($decoded['extensions'][$key] ?? null) : null;
+
+        // @phpstan-ignore if.alwaysTrue (WC()->session is nullable; the WooCommerce stub omits null)
+        if (! empty($data) && is_array($data) && WC()->session) {
+            WC()->session->set(self::DELIVERY_OPTIONS_SESSION_KEY, $data);
+        }
     }
 
     public function clearDeliveryOptionsSession(): void

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -52,7 +52,7 @@ final class CartFeesHooks implements WordPressHooksInterface
 
         // Drop the stashed selection once it's no longer relevant, so it can't apply to a later cart.
         add_action('woocommerce_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
-        add_action('woocommerce_blocks_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
+        add_action('woocommerce_store_api_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
         add_action('woocommerce_cart_emptied', [$this, 'clearDeliveryOptionsSession']);
     }
 

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -45,10 +45,9 @@ final class CartFeesHooks implements WordPressHooksInterface
         // the Store API callback directly instead of deferring it — still before any REST request.
         $this->registerStoreApiUpdateCallback();
 
-        // Blocks order placement: prime the session from the checkout request *before* the order is
-        // built, so an order placed within the debounce window (before the live extensionCartUpdate
-        // fires) still charges the chosen option's fee. This hook runs before the order-building cart
-        // recalculation (OrderController::update_order_from_cart), which is what sets the order's fees.
+        // Blocks order placement: prime the session from the checkout request before the order-building
+        // cart recalc (OrderController::update_order_from_cart) sets the fees, so an order placed within
+        // the debounce window (before the live extensionCartUpdate fires) still charges the chosen fee.
         add_action('woocommerce_store_api_checkout_update_customer_from_request', [$this, 'stashBlocksCheckoutSelection'], 10, 2);
 
         // Drop the stashed selection once it's no longer relevant, so it can't apply to a later cart.
@@ -184,19 +183,18 @@ final class CartFeesHooks implements WordPressHooksInterface
     }
 
     /**
-     * Stashes the blocks-checkout selection in the session during order placement, before the order
-     * is built from the cart. Without this, an order placed within the debounce window (before the
-     * live extensionCartUpdate fires) would charge the fee from the previous selection. Reads the
-     * raw request body — the same source PdkCheckoutPlaceOrderHooks uses — because the request's
-     * `extensions` param only carries namespaces registered on the checkout schema.
+     * Primes the session with the blocks-checkout selection at order placement, before the order is
+     * built from the cart — otherwise an order placed within the debounce window (before the live
+     * extensionCartUpdate fires) charges the previous selection's fee. Reads the raw body (like
+     * PdkCheckoutPlaceOrderHooks) because the request's `extensions` param only carries namespaces
+     * registered on the checkout schema.
      *
      * @param  \WC_Customer     $customer Unused; part of the hook signature.
-     * @param  \WP_REST_Request $request  Unused; the selection is read from the raw body (see above).
+     * @param  \WP_REST_Request $request  Unused; the selection is read from the raw body.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function stashBlocksCheckoutSelection($customer, $request): void
     {
-        // eslint-disable-next-line camelcase
         global $HTTP_RAW_POST_DATA;
 
         if (! is_string($HTTP_RAW_POST_DATA) || '' === $HTTP_RAW_POST_DATA) {

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace MyParcelNL\WooCommerce\Hooks;
 
 use Exception;
+use MyParcelNL\Pdk\App\Cart\Model\PdkCart;
 use MyParcelNL\Pdk\App\Cart\Model\PdkCartFee;
 use MyParcelNL\Pdk\App\DeliveryOptions\Contract\DeliveryOptionsFeesServiceInterface;
+use MyParcelNL\Pdk\App\Order\Contract\PdkProductRepositoryInterface;
 use MyParcelNL\Pdk\Base\PdkBootstrapper;
 use MyParcelNL\Pdk\Facade\Language;
 use MyParcelNL\Pdk\Facade\Logger;
@@ -60,10 +62,9 @@ final class CartFeesHooks implements WordPressHooksInterface
             return;
         }
 
-        // Local pickup ("Afhalen in de winkel") ships no parcel, so MyParcel delivery-options
-        // surcharges must not be charged even if a selection lingers from before the customer
-        // switched away from "Verzenden".
-        if ($this->isLocalPickupChosen()) {
+        // Don't charge for a parcel that won't ship. Skip-only: a stashed selection is left in place,
+        // so it applies again once the cart qualifies (this re-runs on every recalculation).
+        if ($this->isLocalPickupChosen() || ! $this->cartHasDeliveryOptions($cart)) {
             return;
         }
 
@@ -106,6 +107,24 @@ final class CartFeesHooks implements WordPressHooksInterface
 
             $cart->add_fee(Language::translate($fee->translation), $amount, (bool) $tax, $tax);
         });
+    }
+
+    /**
+     * Whether delivery options apply to this cart (false for virtual-only carts or products that
+     * disable them). A minimal PdkCart is enough: only its lines drive PdkShippingMethod::hasDeliveryOptions.
+     */
+    private function cartHasDeliveryOptions(WC_Cart $cart): bool
+    {
+        $productRepository = Pdk::get(PdkProductRepositoryInterface::class);
+
+        $lines = array_map(static function (array $item) use ($productRepository): array {
+            return [
+                'quantity' => (int) $item['quantity'],
+                'product'  => $productRepository->getProduct($item['data']),
+            ];
+        }, array_values($cart->get_cart()));
+
+        return (new PdkCart(['lines' => $lines]))->shippingMethod->hasDeliveryOptions;
     }
 
     /**

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -7,6 +7,7 @@ namespace MyParcelNL\WooCommerce\Hooks;
 use Exception;
 use MyParcelNL\Pdk\App\Cart\Model\PdkCartFee;
 use MyParcelNL\Pdk\App\DeliveryOptions\Contract\DeliveryOptionsFeesServiceInterface;
+use MyParcelNL\Pdk\Base\PdkBootstrapper;
 use MyParcelNL\Pdk\Facade\Language;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
@@ -15,8 +16,20 @@ use MyParcelNL\WooCommerce\Hooks\Contract\WordPressHooksInterface;
 use MyParcelNL\WooCommerce\Pdk\Service\WcTaxService;
 use WC_Cart;
 
+/**
+ * Adds the delivery-options fees (signature, same-day, pickup discount, ...) to the cart total
+ * during checkout.
+ *
+ * Classic checkout re-posts the selection in $_POST on every recalculation; blocks checkout
+ * recalculates via a stateless Store API request that carries no post data. The blocks frontend
+ * therefore pushes the selection through the cart-extensions endpoint, the update callback stashes
+ * it in the WC session, and resolveDeliveryOptionsData() reads from whichever source applies so the
+ * fee logic stays identical for both checkouts.
+ */
 final class CartFeesHooks implements WordPressHooksInterface
 {
+    private const DELIVERY_OPTIONS_SESSION_KEY = '_myparcelcom_delivery_options';
+
     /** @var WcTaxService */
     private $taxService;
 
@@ -25,6 +38,15 @@ final class CartFeesHooks implements WordPressHooksInterface
     public function apply(): void
     {
         add_action('woocommerce_cart_calculate_fees', [$this, 'calculateDeliveryOptionsFees'], 20);
+
+        // apply() runs on init priority 9999, after woocommerce_init has already fired, so register
+        // the Store API callback directly instead of deferring it — still before any REST request.
+        $this->registerStoreApiUpdateCallback();
+
+        // Drop the stashed selection once it's no longer relevant, so it can't apply to a later cart.
+        add_action('woocommerce_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
+        add_action('woocommerce_blocks_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
+        add_action('woocommerce_cart_emptied', [$this, 'clearDeliveryOptionsSession']);
     }
 
     /**
@@ -38,17 +60,7 @@ final class CartFeesHooks implements WordPressHooksInterface
             return;
         }
 
-        $post = wp_unslash(filter_input_array(INPUT_POST));
-
-        if (isset($post['post_data'])) {
-            // non-default post data for AJAX calls
-            parse_str($post['post_data'], $postData);
-        } else {
-            // checkout finalization
-            $postData = $post;
-        }
-
-        $deliveryOptionsData = $postData[Pdk::get('checkoutHiddenInputName')] ?? null;
+        $deliveryOptionsData = $this->resolveDeliveryOptionsData();
 
         if (empty($deliveryOptionsData)) {
             return;
@@ -57,7 +69,7 @@ final class CartFeesHooks implements WordPressHooksInterface
         $deliveryOptions = null;
 
         try {
-            $deliveryOptions = new DeliveryOptions(json_decode(stripslashes($deliveryOptionsData), true));
+            $deliveryOptions = new DeliveryOptions($deliveryOptionsData);
 
             /** @var DeliveryOptionsFeesServiceInterface $feesService */
             $feesService = Pdk::get(DeliveryOptionsFeesServiceInterface::class);
@@ -77,15 +89,76 @@ final class CartFeesHooks implements WordPressHooksInterface
 
         $fees->each(function (PdkCartFee $fee) use ($tax, $cart) {
             $amount = $fee->amount;
-            
+
             // For pickup fee, ensure total shipping costs don't go below 0
             if ($fee->id === 'delivery_type_pickup') {
                 $shippingTotal = $cart->get_shipping_total();
                 // Limit the pickup discount so shipping + pickup >= 0
                 $amount = max(-$shippingTotal, $fee->amount);
             }
-            
+
             $cart->add_fee(Language::translate($fee->translation), $amount, (bool) $tax, $tax);
         });
+    }
+
+    /**
+     * Stashes the blocks-checkout selection in the session when extensionCartUpdate fires, for
+     * calculateDeliveryOptionsFees() to read on the recalculation that follows.
+     */
+    public function registerStoreApiUpdateCallback(): void
+    {
+        if (! function_exists('woocommerce_store_api_register_update_callback')) {
+            return;
+        }
+
+        woocommerce_store_api_register_update_callback([
+            'namespace' => PdkBootstrapper::PLUGIN_NAMESPACE . '-delivery-options',
+            'callback'  => static function (array $data): void {
+                if (WC()->session) {
+                    WC()->session->set(self::DELIVERY_OPTIONS_SESSION_KEY, $data);
+                }
+            },
+        ]);
+    }
+
+    public function clearDeliveryOptionsSession(): void
+    {
+        if (WC()->session) {
+            WC()->session->set(self::DELIVERY_OPTIONS_SESSION_KEY, null);
+        }
+    }
+
+    /**
+     * Returns the selection from the posted checkout input (classic) or, failing that, the WC
+     * session written by the Store API callback (blocks).
+     */
+    private function resolveDeliveryOptionsData(): ?array
+    {
+        $post = wp_unslash(filter_input_array(INPUT_POST));
+
+        if (isset($post['post_data'])) {
+            // non-default post data for AJAX calls
+            parse_str($post['post_data'], $postData);
+        } else {
+            // checkout finalization
+            $postData = $post ?? [];
+        }
+
+        $posted = $postData[Pdk::get('checkoutHiddenInputName')] ?? null;
+
+        if (! empty($posted)) {
+            return json_decode(stripslashes($posted), true);
+        }
+
+        // Blocks checkout: the Store API update callback stashes the selection in the session.
+        if (WC()->session) {
+            $sessionData = WC()->session->get(self::DELIVERY_OPTIONS_SESSION_KEY);
+
+            if (! empty($sessionData)) {
+                return $sessionData;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -115,6 +115,7 @@ final class CartFeesHooks implements WordPressHooksInterface
      */
     private function isLocalPickupChosen(): bool
     {
+        // @phpstan-ignore booleanNot.alwaysFalse (WC()->session is nullable; the WooCommerce stub omits null)
         if (! WC()->session) {
             return false;
         }
@@ -149,6 +150,7 @@ final class CartFeesHooks implements WordPressHooksInterface
         woocommerce_store_api_register_update_callback([
             'namespace' => PdkBootstrapper::PLUGIN_NAMESPACE . '-delivery-options',
             'callback'  => static function (array $data): void {
+                // @phpstan-ignore if.alwaysTrue (WC()->session is nullable; the WooCommerce stub omits null)
                 if (WC()->session) {
                     WC()->session->set(self::DELIVERY_OPTIONS_SESSION_KEY, $data);
                 }
@@ -158,6 +160,7 @@ final class CartFeesHooks implements WordPressHooksInterface
 
     public function clearDeliveryOptionsSession(): void
     {
+        // @phpstan-ignore if.alwaysTrue (WC()->session is nullable; the WooCommerce stub omits null)
         if (WC()->session) {
             WC()->session->set(self::DELIVERY_OPTIONS_SESSION_KEY, null);
         }
@@ -186,6 +189,7 @@ final class CartFeesHooks implements WordPressHooksInterface
         }
 
         // Blocks checkout: the Store API update callback stashes the selection in the session.
+        // @phpstan-ignore if.alwaysTrue (WC()->session is nullable; the WooCommerce stub omits null)
         if (WC()->session) {
             $sessionData = WC()->session->get(self::DELIVERY_OPTIONS_SESSION_KEY);
 

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -205,7 +205,7 @@ final class CartFeesHooks implements WordPressHooksInterface
         $key     = PdkBootstrapper::PLUGIN_NAMESPACE . '-delivery-options';
         $data    = is_array($decoded) ? ($decoded['extensions'][$key] ?? null) : null;
 
-        // @phpstan-ignore if.alwaysTrue (WC()->session is nullable; the WooCommerce stub omits null)
+        // @phpstan-ignore booleanAnd.rightAlwaysTrue (WC()->session is nullable; the WooCommerce stub omits null)
         if (! empty($data) && is_array($data) && WC()->session) {
             WC()->session->set(self::DELIVERY_OPTIONS_SESSION_KEY, $data);
         }

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -185,23 +185,23 @@ final class CartFeesHooks implements WordPressHooksInterface
     /**
      * Primes the session with the blocks-checkout selection at order placement, before the order is
      * built from the cart — otherwise an order placed within the debounce window (before the live
-     * extensionCartUpdate fires) charges the previous selection's fee. Reads the raw body (like
-     * PdkCheckoutPlaceOrderHooks) because the request's `extensions` param only carries namespaces
-     * registered on the checkout schema.
+     * extensionCartUpdate fires) charges the previous selection's fee. Reads the raw request body
+     * because the request's `extensions` param only carries namespaces registered on the checkout
+     * schema.
      *
      * @param  \WC_Customer     $customer Unused; part of the hook signature.
-     * @param  \WP_REST_Request $request  Unused; the selection is read from the raw body.
+     * @param  \WP_REST_Request $request  Carries the raw checkout body with the selection.
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function stashBlocksCheckoutSelection($customer, $request): void
     {
-        global $HTTP_RAW_POST_DATA;
+        $body = $request->get_body();
 
-        if (! is_string($HTTP_RAW_POST_DATA) || '' === $HTTP_RAW_POST_DATA) {
+        if (! is_string($body) || '' === $body) {
             return;
         }
 
-        $decoded = json_decode(wp_unslash($HTTP_RAW_POST_DATA), true);
+        $decoded = json_decode(wp_unslash($body), true);
         $key     = PdkBootstrapper::PLUGIN_NAMESPACE . '-delivery-options';
         $data    = is_array($decoded) ? ($decoded['extensions'][$key] ?? null) : null;
 
@@ -225,20 +225,23 @@ final class CartFeesHooks implements WordPressHooksInterface
      */
     private function resolveDeliveryOptionsData(): ?array
     {
-        $post = wp_unslash(filter_input_array(INPUT_POST));
+        $input = filter_input_array(INPUT_POST);
+        $post  = is_array($input) ? wp_unslash($input) : [];
 
         if (isset($post['post_data'])) {
             // non-default post data for AJAX calls
             parse_str($post['post_data'], $postData);
         } else {
             // checkout finalization
-            $postData = $post ?? [];
+            $postData = $post;
         }
 
         $posted = $postData[Pdk::get('checkoutHiddenInputName')] ?? null;
 
         if (! empty($posted)) {
-            return json_decode(stripslashes($posted), true);
+            $decoded = json_decode(stripslashes($posted), true);
+
+            return is_array($decoded) ? $decoded : null;
         }
 
         // Blocks checkout: the Store API update callback stashes the selection in the session.

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -60,6 +60,13 @@ final class CartFeesHooks implements WordPressHooksInterface
             return;
         }
 
+        // Local pickup ("Afhalen in de winkel") ships no parcel, so MyParcel delivery-options
+        // surcharges must not be charged even if a selection lingers from before the customer
+        // switched away from "Verzenden".
+        if ($this->isLocalPickupChosen()) {
+            return;
+        }
+
         $deliveryOptionsData = $this->resolveDeliveryOptionsData();
 
         if (empty($deliveryOptionsData)) {
@@ -99,6 +106,34 @@ final class CartFeesHooks implements WordPressHooksInterface
 
             $cart->add_fee(Language::translate($fee->translation), $amount, (bool) $tax, $tax);
         });
+    }
+
+    /**
+     * Whether the customer chose local pickup for the whole cart. Matches both the classic
+     * shipping-zone method (`local_pickup:N`) and the blocks "Afhalen in de winkel" method
+     * (`pickup_location:N`). Returns false on mixed carts that still ship a parcel.
+     */
+    private function isLocalPickupChosen(): bool
+    {
+        if (! WC()->session) {
+            return false;
+        }
+
+        $chosenMethods = (array) WC()->session->get('chosen_shipping_methods', []);
+
+        if (empty($chosenMethods)) {
+            return false;
+        }
+
+        foreach ($chosenMethods as $method) {
+            $method = (string) $method;
+
+            if (strpos($method, 'local_pickup') !== 0 && strpos($method, 'pickup_location') !== 0) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -30,7 +30,7 @@ use WC_Cart;
  */
 final class CartFeesHooks implements WordPressHooksInterface
 {
-    private const DELIVERY_OPTIONS_SESSION_KEY = '_myparcelcom_delivery_options';
+    private const DELIVERY_OPTIONS_SESSION_KEY = '_' . PdkBootstrapper::PLUGIN_NAMESPACE . '_delivery_options';
 
     /** @var WcTaxService */
     private $taxService;

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -13,9 +13,12 @@ use MyParcelNL\Pdk\Base\PdkBootstrapper;
 use MyParcelNL\Pdk\Facade\Language;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Facade\Settings;
+use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\WooCommerce\Hooks\Contract\WooCommerceInitCallbacksInterface;
 use MyParcelNL\WooCommerce\Hooks\Contract\WordPressHooksInterface;
+use MyParcelNL\WooCommerce\Pdk\Service\WcShippingClassMatrixService;
 use MyParcelNL\WooCommerce\Pdk\Service\WcTaxService;
 use WC_Cart;
 
@@ -36,7 +39,14 @@ final class CartFeesHooks implements WordPressHooksInterface, WooCommerceInitCal
     /** @var WcTaxService */
     private $taxService;
 
-    public function __construct(WcTaxService $taxService) { $this->taxService = $taxService; }
+    /** @var WcShippingClassMatrixService */
+    private $shippingClassMatrixService;
+
+    public function __construct(WcTaxService $taxService, WcShippingClassMatrixService $shippingClassMatrixService)
+    {
+        $this->taxService                 = $taxService;
+        $this->shippingClassMatrixService = $shippingClassMatrixService;
+    }
 
     public function apply(): void
     {
@@ -121,8 +131,12 @@ final class CartFeesHooks implements WordPressHooksInterface, WooCommerceInitCal
     }
 
     /**
-     * Whether delivery options apply to this cart (false for virtual-only carts or products that
-     * disable them). A minimal PdkCart is enough: only its lines drive PdkShippingMethod::hasDeliveryOptions.
+     * Whether delivery options apply to this cart — i.e. whether the checkout widget would show any
+     * option for it, so the fee mirrors what the customer actually sees. Returns false when:
+     * - a product is virtual or has delivery options disabled (PdkShippingMethod::hasDeliveryOptions);
+     * - the chosen shipping method is assigned no package type in the allowed-shipping-methods matrix
+     *   (empty allowedPackageTypes — the merchant switched delivery options off for that method); or
+     * - a product's shipping class is assigned no package type in that matrix (mirrors WcContextService).
      */
     private function cartHasDeliveryOptions(WC_Cart $cart): bool
     {
@@ -135,7 +149,67 @@ final class CartFeesHooks implements WordPressHooksInterface, WooCommerceInitCal
             ];
         }, array_values($cart->get_cart()));
 
-        return (new PdkCart(['lines' => $lines]))->shippingMethod->hasDeliveryOptions;
+        // Build with the chosen shipping method so allowedPackageTypes resolves against the matrix.
+        $shippingMethod = (new PdkCart([
+            'lines'          => $lines,
+            'shippingMethod' => ['id' => $this->getChosenShippingMethodId()],
+        ]))->shippingMethod;
+
+        if (! $shippingMethod->hasDeliveryOptions) {
+            return false;
+        }
+
+        if ($shippingMethod->allowedPackageTypes->isEmpty()) {
+            return false;
+        }
+
+        return ! $this->cartHasShippingClassWithoutDeliveryOptions($cart);
+    }
+
+    /**
+     * Whether any cart product's shipping class is assigned to no package type in the
+     * allowed-shipping-methods matrix, which disables delivery options for the whole cart. An empty
+     * matrix is unconfigured (legacy default: everything allowed), so it never disables.
+     */
+    private function cartHasShippingClassWithoutDeliveryOptions(WC_Cart $cart): bool
+    {
+        $allowedShippingMethods = Settings::get(CheckoutSettings::ALLOWED_SHIPPING_METHODS, CheckoutSettings::ID);
+
+        if (empty($allowedShippingMethods)) {
+            return false;
+        }
+
+        foreach ($cart->get_cart() as $item) {
+            $shippingClassName = $this->shippingClassMatrixService->resolveShippingClassName(
+                $item['data']->get_shipping_class()
+            );
+
+            if (null === $shippingClassName) {
+                continue;
+            }
+
+            if (null === $this->shippingClassMatrixService->getAssociatedPackageType($shippingClassName, $allowedShippingMethods)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The first chosen shipping method rate id from the session (e.g. "flat_rate:1"), or null when
+     * none is chosen yet.
+     */
+    private function getChosenShippingMethodId(): ?string
+    {
+        // @phpstan-ignore booleanNot.alwaysFalse (WC()->session is nullable; the WooCommerce stub omits null)
+        if (! WC()->session) {
+            return null;
+        }
+
+        $chosenMethods = (array) WC()->session->get('chosen_shipping_methods', []);
+
+        return isset($chosenMethods[0]) ? (string) $chosenMethods[0] : null;
     }
 
     /**

--- a/src/Hooks/CartFeesHooks.php
+++ b/src/Hooks/CartFeesHooks.php
@@ -14,6 +14,7 @@ use MyParcelNL\Pdk\Facade\Language;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\WooCommerce\Hooks\Contract\WooCommerceInitCallbacksInterface;
 use MyParcelNL\WooCommerce\Hooks\Contract\WordPressHooksInterface;
 use MyParcelNL\WooCommerce\Pdk\Service\WcTaxService;
 use WC_Cart;
@@ -28,7 +29,7 @@ use WC_Cart;
  * it in the WC session, and resolveDeliveryOptionsData() reads from whichever source applies so the
  * fee logic stays identical for both checkouts.
  */
-final class CartFeesHooks implements WordPressHooksInterface
+final class CartFeesHooks implements WordPressHooksInterface, WooCommerceInitCallbacksInterface
 {
     private const DELIVERY_OPTIONS_SESSION_KEY = '_' . PdkBootstrapper::PLUGIN_NAMESPACE . '_delivery_options';
 
@@ -41,10 +42,6 @@ final class CartFeesHooks implements WordPressHooksInterface
     {
         add_action('woocommerce_cart_calculate_fees', [$this, 'calculateDeliveryOptionsFees'], 20);
 
-        // apply() runs on init priority 9999, after woocommerce_init has already fired, so register
-        // the Store API callback directly instead of deferring it — still before any REST request.
-        $this->registerStoreApiUpdateCallback();
-
         // Blocks order placement: prime the session from the checkout request before the order-building
         // cart recalc (OrderController::update_order_from_cart) sets the fees, so an order placed within
         // the debounce window (before the live extensionCartUpdate fires) still charges the chosen fee.
@@ -54,6 +51,15 @@ final class CartFeesHooks implements WordPressHooksInterface
         add_action('woocommerce_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
         add_action('woocommerce_store_api_checkout_order_processed', [$this, 'clearDeliveryOptionsSession']);
         add_action('woocommerce_cart_emptied', [$this, 'clearDeliveryOptionsSession']);
+    }
+
+    /**
+     * Register the blocks-checkout Store API update callback once WooCommerce is initialized, so it's
+     * in place before any Store API request is dispatched.
+     */
+    public function onWoocommerceInit(): void
+    {
+        $this->registerStoreApiUpdateCallback();
     }
 
     /**

--- a/src/Pdk/Context/Service/WcContextService.php
+++ b/src/Pdk/Context/Service/WcContextService.php
@@ -72,7 +72,7 @@ final class WcContextService extends ContextService
 
         $highestShippingClass = $disableDeliveryOptions
             ? null
-            : $this->resolveHighestShippingClass($cart, $candidates, $checkoutContext->config->packageType);
+            : $this->resolveHighestShippingClass($cart, $candidates, $checkoutContext->config->packageType ?? null);
 
         $settingsToMerge = [
             'highestShippingClass' => $highestShippingClass ?? '', // frontend expects empty string when not set

--- a/src/Pdk/Context/Service/WcContextService.php
+++ b/src/Pdk/Context/Service/WcContextService.php
@@ -14,7 +14,7 @@ use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
-use WP_Term;
+use MyParcelNL\WooCommerce\Pdk\Service\WcShippingClassMatrixService;
 
 final class WcContextService extends ContextService
 {
@@ -25,8 +25,8 @@ final class WcContextService extends ContextService
      */
     public function createCheckoutContext(?PdkCart $cart): CheckoutContext
     {
-        $allowedShippingMethods  = Settings::get(CheckoutSettings::ALLOWED_SHIPPING_METHODS, CheckoutSettings::ID);
-        $createShippingClassName = Pdk::get('createShippingClassName');
+        $allowedShippingMethods = Settings::get(CheckoutSettings::ALLOWED_SHIPPING_METHODS, CheckoutSettings::ID);
+        $matrixService          = Pdk::get(WcShippingClassMatrixService::class);
 
         $disableDeliveryOptions = false;
         // Candidate list of shipping-class → package-type pairs collected from cart products.
@@ -42,14 +42,12 @@ final class WcContextService extends ContextService
                     continue;
                 }
 
-                $shippingClass = $WC_product->get_shipping_class();
-                if (! $shippingClass) {
+                $shippingClassName = $matrixService->resolveShippingClassName($WC_product->get_shipping_class());
+                if (null === $shippingClassName) {
                     continue;
                 }
 
-                $shippingClassName = $createShippingClassName($this->getShippingClassId($shippingClass));
-
-                $packageType = $this->getAssociatedPackageType($shippingClassName, $allowedShippingMethods);
+                $packageType = $matrixService->getAssociatedPackageType($shippingClassName, $allowedShippingMethods);
 
                 if ((string) TriStateService::INHERIT === $packageType) {
                     continue;
@@ -166,52 +164,4 @@ final class WcContextService extends ContextService
         return null;
     }
 
-    /**
-     * @param  string $shippingClassName
-     * @param  array  $allowedShippingMethods
-     *
-     * @return null|string the package type name or null if none is associated
-     */
-    protected function getAssociatedPackageType(string $shippingClassName, array $allowedShippingMethods): ?string
-    {
-        foreach ($allowedShippingMethods as $packageType => $methods) {
-            if (in_array($shippingClassName, $methods, true)) {
-                return (string) $packageType;
-            }
-        }
-
-        // No package type associated with this shipping class, this means don’t display
-        // delivery options.
-        return null;
-    }
-
-    /**
-     * @param  string $shippingClass
-     *
-     * @return null|int
-     */
-    private function getShippingClassId(string $shippingClass): ?int
-    {
-        $term = get_term_by('slug', $shippingClass, 'product_shipping_class');
-
-        return $this->getTermId($term);
-    }
-
-    /**
-     * @param  WP_Term|array|null $term
-     *
-     * @return null|int
-     */
-    private function getTermId($term): ?int
-    {
-        $termId = null;
-
-        if ($term instanceof WP_Term) {
-            $termId = $term->term_id;
-        } elseif (is_array($term)) {
-            $termId = $term['term_id'] ?? null;
-        }
-
-        return $termId ? (int) $termId : null;
-    }
 }

--- a/src/Pdk/Hooks/PdkCheckoutPlaceOrderHooks.php
+++ b/src/Pdk/Hooks/PdkCheckoutPlaceOrderHooks.php
@@ -34,25 +34,32 @@ final class PdkCheckoutPlaceOrderHooks implements WordPressHooksInterface
     public function apply(): void
     {
         add_action('woocommerce_checkout_order_processed', [$this, 'saveDeliveryOptions'], 10, 3);
-        add_action('woocommerce_blocks_checkout_order_processed', [$this, 'saveBlocksDeliveryOptions'], 10, 1);
+        add_action('woocommerce_store_api_checkout_update_order_from_request', [$this, 'saveBlocksDeliveryOptions'], 10, 2);
     }
 
     /**
      * Saves the delivery options to the new PDK order.
      *
-     * @param  WC_Order $wcOrder
+     * @param  WC_Order         $wcOrder
+     * @param  \WP_REST_Request $request Carries the raw checkout body with the selection.
      *
      * @return void
      */
-    public function saveBlocksDeliveryOptions(WC_Order $wcOrder): void
+    public function saveBlocksDeliveryOptions(WC_Order $wcOrder, $request): void
     {
-        // eslint-disable-next-line camelcase
-        global $HTTP_RAW_POST_DATA;
         $namespace = PdkBootstrapper::PLUGIN_NAMESPACE;
 
         try {
-            $postData            = json_decode(wp_unslash($HTTP_RAW_POST_DATA), true);
-            $deliveryOptionsData = $postData['extensions']["$namespace-delivery-options"] ?? null;
+            $body = $request->get_body();
+
+            if (! is_string($body) || '' === $body) {
+                return;
+            }
+
+            $postData            = json_decode(wp_unslash($body), true);
+            $deliveryOptionsData = is_array($postData)
+                ? ($postData['extensions']["$namespace-delivery-options"] ?? null)
+                : null;
 
             if (empty($deliveryOptionsData)) {
                 return;

--- a/src/Pdk/Service/WcShippingClassMatrixService.php
+++ b/src/Pdk/Service/WcShippingClassMatrixService.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Pdk\Service;
+
+use MyParcelNL\Pdk\Facade\Pdk;
+use WP_Term;
+
+/**
+ * Resolves a WooCommerce shipping class against the delivery-options "allowed shipping methods"
+ * matrix (CheckoutSettings::ALLOWED_SHIPPING_METHODS).
+ *
+ * The matrix maps each package type (or TriStateService::INHERIT) to a list of identifiers, which
+ * mix shipping-method rate ids (e.g. "flat_rate:1") and shipping-class names (e.g.
+ * "shipping_class:12"). This service owns the shipping-class side of that lookup so both the
+ * checkout context (which decides whether to render the widget) and the cart-fee guard (which
+ * decides whether to charge the delivery-option fee) share one source of truth — a product whose
+ * shipping class maps to no package type disables delivery options entirely, and the fee must
+ * follow that same rule.
+ */
+final class WcShippingClassMatrixService
+{
+    /**
+     * Build the matrix name ("shipping_class:<termId>") for a WooCommerce shipping-class slug.
+     * Returns null when the slug is empty or its term can't be resolved.
+     *
+     * @param  string $shippingClassSlug
+     *
+     * @return null|string
+     */
+    public function resolveShippingClassName(string $shippingClassSlug): ?string
+    {
+        if ('' === $shippingClassSlug) {
+            return null;
+        }
+
+        $termId = $this->getShippingClassId($shippingClassSlug);
+
+        if (null === $termId) {
+            return null;
+        }
+
+        return Pdk::get('createShippingClassName')($termId);
+    }
+
+    /**
+     * The package type a shipping-class name maps to in the matrix, or null when the class is
+     * assigned to no package type (delivery options disabled). The returned value may be a concrete
+     * package type name or TriStateService::INHERIT — callers interpret it.
+     *
+     * @param  string $shippingClassName
+     * @param  array  $allowedShippingMethods
+     *
+     * @return null|string
+     */
+    public function getAssociatedPackageType(string $shippingClassName, array $allowedShippingMethods): ?string
+    {
+        foreach ($allowedShippingMethods as $packageType => $methods) {
+            if (is_array($methods) && in_array($shippingClassName, $methods, true)) {
+                return (string) $packageType;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  string $shippingClass
+     *
+     * @return null|int
+     */
+    private function getShippingClassId(string $shippingClass): ?int
+    {
+        return $this->getTermId(get_term_by('slug', $shippingClass, 'product_shipping_class'));
+    }
+
+    /**
+     * @param  WP_Term|array|false|null $term
+     *
+     * @return null|int
+     */
+    private function getTermId($term): ?int
+    {
+        $termId = null;
+
+        if ($term instanceof WP_Term) {
+            $termId = $term->term_id;
+        } elseif (is_array($term)) {
+            $termId = $term['term_id'] ?? null;
+        }
+
+        return $termId ? (int) $termId : null;
+    }
+}

--- a/src/Service/WordPressHookService.php
+++ b/src/Service/WordPressHookService.php
@@ -129,6 +129,7 @@ final class WordPressHookService
     private function getWoocommerceInitHooks(): array
     {
         return [
+            CartFeesHooks::class,
             SeparateAddressFieldsHooks::class,
             TaxFieldsHooks::class,
         ];

--- a/src/WooCommerce/Repository/WcOrderRepository.php
+++ b/src/WooCommerce/Repository/WcOrderRepository.php
@@ -82,8 +82,12 @@ final class WcOrderRepository extends Repository implements WcOrderRepositoryInt
      */
     public function hasLocalPickup($input): bool
     {
-        return $this->get($input)
-            ->has_shipping_method('local_pickup');
+        $order = $this->get($input);
+
+        // Classic checkout uses `local_pickup`, blocks checkout uses `pickup_location` — match both,
+        // consistent with CartFeesHooks::isLocalPickupChosen.
+        return $order->has_shipping_method('local_pickup')
+            || $order->has_shipping_method('pickup_location');
     }
 
     protected function getKeyPrefix(): string

--- a/tests/Mock/MockWcCart.php
+++ b/tests/Mock/MockWcCart.php
@@ -17,6 +17,41 @@ class MockWcCart extends MockWcClass
     public $cart_contents = [];
 
     /**
+     * Fees recorded via add_fee(), so tests can assert what was applied to the cart.
+     *
+     * @var array<int, array{name: string, amount: float, taxable: bool, taxClass: string}>
+     */
+    public $fees = [];
+
+    /**
+     * @param  string $name
+     * @param  float  $amount
+     * @param  bool   $taxable
+     * @param  string $taxClass
+     *
+     * @return void
+     * @see \WC_Cart::add_fee()
+     */
+    public function add_fee($name, $amount, $taxable = false, $taxClass = ''): void
+    {
+        $this->fees[] = [
+            'name'     => $name,
+            'amount'   => (float) $amount,
+            'taxable'  => (bool) $taxable,
+            'taxClass' => $taxClass,
+        ];
+    }
+
+    /**
+     * @return float
+     * @see \WC_Cart::get_shipping_total()
+     */
+    public function get_shipping_total(): float
+    {
+        return (float) ($this->attributes['shipping_total'] ?? 0);
+    }
+
+    /**
      * @param  int   $productId
      * @param  int   $quantity
      * @param  int   $variationId

--- a/tests/Mock/MockWcOrder.php
+++ b/tests/Mock/MockWcOrder.php
@@ -46,7 +46,7 @@ class MockWcOrder extends MockWcClass
 
     public function has_shipping_method(string $shippingMethod): bool
     {
-        return 'local_pickup' !== $shippingMethod;
+        return in_array($shippingMethod, (array) ($this->attributes['shipping_methods'] ?? []), true);
     }
 
     /**

--- a/tests/Mock/MockWcSession.php
+++ b/tests/Mock/MockWcSession.php
@@ -16,17 +16,16 @@ class MockWcSession implements StaticMockInterface
     ];
 
     /**
-     * @param $key
+     * Mirrors WC_Session::get(): returns the stored value or the given default (null) when unset.
      *
-     * @return array
+     * @param  mixed $key
+     * @param  mixed $default
+     *
+     * @return mixed
      */
-    public function get($key): array
+    public function get($key, $default = null)
     {
-        return self::$session[$key] ?? [
-            'rates' => [
-                'flat_rate:0' => [],
-            ],
-        ];
+        return self::$session[$key] ?? $default;
     }
 
     /**

--- a/tests/Unit/Hooks/CartFeesHooksTest.php
+++ b/tests/Unit/Hooks/CartFeesHooksTest.php
@@ -195,6 +195,44 @@ it('registers a store api update callback that stashes the selection in the sess
     expect(WC()->session->get(SESSION_KEY))->toBe(['carrier' => 'postnl']);
 });
 
+it('stashes the blocks-checkout selection from the request body at order placement', function () {
+    WC()->session->set(SESSION_KEY, null);
+
+    $request = new class {
+        public function get_body(): string
+        {
+            return json_encode([
+                'extensions' => [
+                    'myparcelcom-delivery-options' => ['carrier' => 'postnl'],
+                ],
+            ]);
+        }
+    };
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->stashBlocksCheckoutSelection(WC()->customer, $request);
+
+    expect(WC()->session->get(SESSION_KEY))->toBe(['carrier' => 'postnl']);
+});
+
+it('does not stash anything when the request body has no selection', function () {
+    WC()->session->set(SESSION_KEY, null);
+
+    $request = new class {
+        public function get_body(): string
+        {
+            return '{}';
+        }
+    };
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->stashBlocksCheckoutSelection(WC()->customer, $request);
+
+    expect(WC()->session->get(SESSION_KEY))->toBeNull();
+});
+
 it('clears the stashed selection from the session', function () {
     WC()->session->set(SESSION_KEY, ['carrier' => 'postnl']);
 

--- a/tests/Unit/Hooks/CartFeesHooksTest.php
+++ b/tests/Unit/Hooks/CartFeesHooksTest.php
@@ -1,0 +1,300 @@
+<?php
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Hooks;
+
+use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
+use MyParcelNL\Pdk\Base\Support\SettingKey;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesDeliveryTypeV2;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use WC_Cart;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockWcPdkInstance());
+
+const SESSION_KEY = '_myparcelcom_delivery_options';
+
+/*
+ * Shadow filter_input_array() within this namespace so the classic-checkout path of
+ * CartFeesHooks::resolveDeliveryOptionsData() reads $_POST. The real filter_input_array(INPUT_POST)
+ * reads the SAPI request body, which is always empty under the CLI test runner, so tests could
+ * otherwise never exercise the posted-selection branch. For non-POST input types it delegates to
+ * the genuine function. Behaviour is identical to the real one when $_POST is empty (returns null).
+ */
+if (! function_exists(__NAMESPACE__ . '\\filter_input_array')) {
+    function filter_input_array($type, $options = null, $addEmpty = true)
+    {
+        if (INPUT_POST === $type) {
+            return $_POST ?: null;
+        }
+
+        return \filter_input_array($type, $options, $addEmpty);
+    }
+}
+
+beforeEach(function () {
+    $_POST = [];
+
+    TestBootstrapper::hasAccount();
+
+    // Return early in WcTaxService::getShippingTaxClass() instead of hitting WC_Tax.
+    update_option('woocommerce_shipping_tax_class', 'standard');
+
+    // Configure POSTNL prices so the fee service produces fees.
+    /** @var PdkSettingsRepositoryInterface $settingsRepo */
+    $settingsRepo = Pdk::get(PdkSettingsRepositoryInterface::class);
+    $settingsRepo->store(Pdk::get('createSettingsKey')('carrier'), [
+        'POSTNL' => [
+            SettingKey::priceDeliveryType(RefTypesDeliveryTypeV2::STANDARD) => 4.5,
+            (new SignatureDefinition())->getPriceSettingsKey()             => 1.1,
+        ],
+    ]);
+});
+
+afterEach(function () {
+    // Don't leak posted data into other tests in this namespace that share the filter_input_array shadow.
+    $_POST = [];
+});
+
+it('adds delivery-options fees from the blocks session when no post data is present', function () {
+    WC()->session->set(SESSION_KEY, [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(2)
+        ->and(array_column($cart->fees, 'amount'))->toBe([4.5, 1.1]);
+});
+
+it('still adds fees when a regular shipping method is chosen', function () {
+    WC()->session->set(SESSION_KEY, [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+    WC()->session->set('chosen_shipping_methods', ['flat_rate:1']);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(2);
+});
+
+it('adds no fees when classic local pickup is chosen', function () {
+    WC()->session->set(SESSION_KEY, [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+    WC()->session->set('chosen_shipping_methods', ['local_pickup:1']);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toBeEmpty();
+});
+
+it('adds no fees when the blocks pickup_location method is chosen', function () {
+    WC()->session->set(SESSION_KEY, [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+    WC()->session->set('chosen_shipping_methods', ['pickup_location:0']);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toBeEmpty();
+});
+
+it('adds no fees when there is no selection in post data or session', function () {
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toBeEmpty();
+});
+
+it('registers a store api update callback that stashes the selection in the session', function () {
+    $GLOBALS['__mpwc_store_api_update_callbacks'] = [];
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->registerStoreApiUpdateCallback();
+
+    $callback = $GLOBALS['__mpwc_store_api_update_callbacks']['myparcelcom-delivery-options'] ?? null;
+
+    expect($callback)->toBeCallable();
+
+    $callback(['carrier' => 'postnl']);
+
+    expect(WC()->session->get(SESSION_KEY))->toBe(['carrier' => 'postnl']);
+});
+
+it('clears the stashed selection from the session', function () {
+    WC()->session->set(SESSION_KEY, ['carrier' => 'postnl']);
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->clearDeliveryOptionsSession();
+
+    expect(WC()->session->get(SESSION_KEY))->toBeNull();
+});
+
+it('adds fees from the classic post_data selection (AJAX recalculation)', function () {
+    // Classic checkout AJAX posts the form as a urlencoded string under `post_data`.
+    $_POST['post_data'] = http_build_query([
+        Pdk::get('checkoutHiddenInputName') => json_encode([
+            'carrier'         => 'postnl',
+            'shipmentOptions' => [
+                (new SignatureDefinition())->getShipmentOptionsKey() => true,
+            ],
+        ]),
+    ]);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(2)
+        ->and(array_column($cart->fees, 'amount'))->toBe([4.5, 1.1]);
+});
+
+it('adds fees from the directly posted selection (classic checkout finalization)', function () {
+    // On order placement the selection arrives directly under the hidden input name, not in post_data.
+    $_POST[Pdk::get('checkoutHiddenInputName')] = json_encode([
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(2)
+        ->and(array_column($cart->fees, 'amount'))->toBe([4.5, 1.1]);
+});
+
+it('prefers the posted selection over the stashed session selection', function () {
+    // Posted selection has signature → 2 fees.
+    $_POST[Pdk::get('checkoutHiddenInputName')] = json_encode([
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+    // Session selection has no signature → only 1 fee; it must be ignored when post data is present.
+    WC()->session->set(SESSION_KEY, ['carrier' => 'postnl']);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(2);
+});
+
+it('still adds fees when only some packages use local pickup', function () {
+    WC()->session->set(SESSION_KEY, [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+    // Mixed cart: one package is picked up, another still ships a parcel → fees still apply.
+    WC()->session->set('chosen_shipping_methods', ['local_pickup:1', 'flat_rate:2']);
+
+    $cart = new WC_Cart();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(2);
+});
+
+it('clamps the pickup discount so shipping + pickup never goes below zero', function () {
+    /** @var PdkSettingsRepositoryInterface $settingsRepo */
+    $settingsRepo = Pdk::get(PdkSettingsRepositoryInterface::class);
+    $settingsRepo->store(Pdk::get('createSettingsKey')('carrier'), [
+        'POSTNL' => [
+            SettingKey::priceDeliveryType(RefTypesDeliveryTypeV2::PICKUP) => -5.0,
+        ],
+    ]);
+
+    WC()->session->set(SESSION_KEY, [
+        'carrier'      => 'postnl',
+        'deliveryType' => 'pickup',
+    ]);
+
+    // Shipping is only 2.00, so the -5.00 pickup discount must be clamped to -2.00.
+    $cart = new WC_Cart(['shipping_total' => 2.0]);
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(1)
+        ->and($cart->fees[0]['amount'])->toBe(-2.0);
+});
+
+it('applies the full pickup discount when shipping covers it', function () {
+    /** @var PdkSettingsRepositoryInterface $settingsRepo */
+    $settingsRepo = Pdk::get(PdkSettingsRepositoryInterface::class);
+    $settingsRepo->store(Pdk::get('createSettingsKey')('carrier'), [
+        'POSTNL' => [
+            SettingKey::priceDeliveryType(RefTypesDeliveryTypeV2::PICKUP) => -3.0,
+        ],
+    ]);
+
+    WC()->session->set(SESSION_KEY, [
+        'carrier'      => 'postnl',
+        'deliveryType' => 'pickup',
+    ]);
+
+    // Shipping (10.00) fully covers the discount, so the full -3.00 applies.
+    $cart = new WC_Cart(['shipping_total' => 10.0]);
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(1)
+        ->and($cart->fees[0]['amount'])->toBe(-3.0);
+});

--- a/tests/Unit/Hooks/CartFeesHooksTest.php
+++ b/tests/Unit/Hooks/CartFeesHooksTest.php
@@ -9,12 +9,16 @@ use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
 use MyParcelNL\Pdk\Base\Support\SettingKey;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
+use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesDeliveryTypeV2;
 use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
 use WC_Cart;
+use WC_Product;
 use function MyParcelNL\Pdk\Tests\usesShared;
+use function MyParcelNL\WooCommerce\Tests\wpFactory;
 
 usesShared(new UsesMockWcPdkInstance());
 
@@ -36,6 +40,37 @@ if (! function_exists(__NAMESPACE__ . '\\filter_input_array')) {
 
         return \filter_input_array($type, $options, $addEmpty);
     }
+}
+
+/**
+ * Builds a cart containing one product so it qualifies (or not) for delivery options. The fee guard
+ * resolves WC_Cart -> PdkCart and reads PdkShippingMethod::hasDeliveryOptions, which is true only for
+ * a deliverable (non-virtual) product that doesn't have delivery options disabled. Each call uses a
+ * fresh product id so the per-id PdkProduct cache can't bleed between tests.
+ */
+function cartWithProduct(bool $needsShipping = true, array $productSettings = [], float $shippingTotal = 0.0): WC_Cart
+{
+    static $nextId = 7100;
+
+    $factory = wpFactory(WC_Product::class)
+        ->withId($nextId++)
+        ->withNeedsShipping($needsShipping);
+
+    if ($productSettings) {
+        $factory = $factory->withMeta([Pdk::get('metaKeyProductSettings') => $productSettings]);
+    }
+
+    $cart                = new WC_Cart(['shipping_total' => $shippingTotal]);
+    $cart->cart_contents = [
+        'item' => [
+            'data'              => $factory->make(),
+            'quantity'          => 1,
+            'line_subtotal'     => 0.0,
+            'line_subtotal_tax' => 0.0,
+        ],
+    ];
+
+    return $cart;
 }
 
 beforeEach(function () {
@@ -70,7 +105,7 @@ it('adds delivery-options fees from the blocks session when no post data is pres
         ],
     ]);
 
-    $cart = new WC_Cart();
+    $cart = cartWithProduct();
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -89,7 +124,7 @@ it('still adds fees when a regular shipping method is chosen', function () {
     ]);
     WC()->session->set('chosen_shipping_methods', ['flat_rate:1']);
 
-    $cart = new WC_Cart();
+    $cart = cartWithProduct();
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -135,7 +170,7 @@ it('adds no fees when the blocks pickup_location method is chosen', function () 
 });
 
 it('adds no fees when there is no selection in post data or session', function () {
-    $cart = new WC_Cart();
+    $cart = cartWithProduct();
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -181,7 +216,7 @@ it('adds fees from the classic post_data selection (AJAX recalculation)', functi
         ]),
     ]);
 
-    $cart = new WC_Cart();
+    $cart = cartWithProduct();
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -200,7 +235,7 @@ it('adds fees from the directly posted selection (classic checkout finalization)
         ],
     ]);
 
-    $cart = new WC_Cart();
+    $cart = cartWithProduct();
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -221,7 +256,7 @@ it('prefers the posted selection over the stashed session selection', function (
     // Session selection has no signature → only 1 fee; it must be ignored when post data is present.
     WC()->session->set(SESSION_KEY, ['carrier' => 'postnl']);
 
-    $cart = new WC_Cart();
+    $cart = cartWithProduct();
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -240,7 +275,7 @@ it('still adds fees when only some packages use local pickup', function () {
     // Mixed cart: one package is picked up, another still ships a parcel → fees still apply.
     WC()->session->set('chosen_shipping_methods', ['local_pickup:1', 'flat_rate:2']);
 
-    $cart = new WC_Cart();
+    $cart = cartWithProduct();
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -264,7 +299,7 @@ it('clamps the pickup discount so shipping + pickup never goes below zero', func
     ]);
 
     // Shipping is only 2.00, so the -5.00 pickup discount must be clamped to -2.00.
-    $cart = new WC_Cart(['shipping_total' => 2.0]);
+    $cart = cartWithProduct(true, [], 2.0);
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -289,7 +324,7 @@ it('applies the full pickup discount when shipping covers it', function () {
     ]);
 
     // Shipping (10.00) fully covers the discount, so the full -3.00 applies.
-    $cart = new WC_Cart(['shipping_total' => 10.0]);
+    $cart = cartWithProduct(true, [], 10.0);
 
     /** @var CartFeesHooks $hooks */
     $hooks = Pdk::get(CartFeesHooks::class);
@@ -297,4 +332,47 @@ it('applies the full pickup discount when shipping covers it', function () {
 
     expect($cart->fees)->toHaveCount(1)
         ->and($cart->fees[0]['amount'])->toBe(-3.0);
+});
+
+it('adds no fees when the cart no longer needs shipping (virtual-only)', function () {
+    $selection = [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ];
+    WC()->session->set(SESSION_KEY, $selection);
+
+    // A virtual product makes the cart non-deliverable, so a lingering selection must not be charged.
+    $cart = cartWithProduct(false);
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    // Skip-only: no fees, and the stashed selection is left intact (restored if a parcel is re-added).
+    expect($cart->fees)->toBeEmpty()
+        ->and(WC()->session->get(SESSION_KEY))->toBe($selection);
+});
+
+it('adds no fees when a product has delivery options disabled', function () {
+    $selection = [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ];
+    WC()->session->set(SESSION_KEY, $selection);
+
+    // Deliverable product, but its product setting disables delivery options for the whole cart.
+    $cart = cartWithProduct(true, [
+        ProductSettings::DISABLE_DELIVERY_OPTIONS => TriStateService::ENABLED,
+    ]);
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toBeEmpty()
+        ->and(WC()->session->get(SESSION_KEY))->toBe($selection);
 });

--- a/tests/Unit/Hooks/CartFeesHooksTest.php
+++ b/tests/Unit/Hooks/CartFeesHooksTest.php
@@ -9,6 +9,7 @@ use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
 use MyParcelNL\Pdk\Base\Support\SettingKey;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
+use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
 use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
@@ -17,6 +18,8 @@ use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesDeliveryTypeV2;
 use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
 use WC_Cart;
 use WC_Product;
+use WP_Term;
+use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
 use function MyParcelNL\WooCommerce\Tests\wpFactory;
 
@@ -48,13 +51,21 @@ if (! function_exists(__NAMESPACE__ . '\\filter_input_array')) {
  * a deliverable (non-virtual) product that doesn't have delivery options disabled. Each call uses a
  * fresh product id so the per-id PdkProduct cache can't bleed between tests.
  */
-function cartWithProduct(bool $needsShipping = true, array $productSettings = [], float $shippingTotal = 0.0): WC_Cart
-{
+function cartWithProduct(
+    bool $needsShipping = true,
+    array $productSettings = [],
+    float $shippingTotal = 0.0,
+    ?int $shippingClassId = null
+): WC_Cart {
     static $nextId = 7100;
 
     $factory = wpFactory(WC_Product::class)
         ->withId($nextId++)
         ->withNeedsShipping($needsShipping);
+
+    if (null !== $shippingClassId) {
+        $factory = $factory->withShippingClassId($shippingClassId);
+    }
 
     if ($productSettings) {
         $factory = $factory->withMeta([Pdk::get('metaKeyProductSettings') => $productSettings]);
@@ -413,4 +424,89 @@ it('adds no fees when a product has delivery options disabled', function () {
 
     expect($cart->fees)->toBeEmpty()
         ->and(WC()->session->get(SESSION_KEY))->toBe($selection);
+});
+
+it('adds no fees when the chosen shipping method has delivery options disabled in the matrix', function () {
+    // The allowed-shipping-methods matrix assigns package types to flat_rate:99 only, so the chosen
+    // flat_rate:1 resolves to no package types → the widget shows nothing → no fee should apply.
+    factory(CheckoutSettings::class)
+        ->withAllowedShippingMethods(['package' => ['flat_rate:99']])
+        ->store();
+
+    $selection = [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ];
+    WC()->session->set(SESSION_KEY, $selection);
+    WC()->session->set('chosen_shipping_methods', ['flat_rate:1']);
+
+    $cart = cartWithProduct();
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toBeEmpty();
+});
+
+it('adds no fees when a product shipping class has delivery options disabled in the matrix', function () {
+    // The chosen method flat_rate:1 IS enabled in the matrix (so the method gate passes), but the
+    // cart product's shipping class (999) is assigned to no package type → delivery options are
+    // disabled for the whole cart (mirrors WcContextService), so no fee should apply.
+    factory(CheckoutSettings::class)
+        ->withAllowedShippingMethods(['mailbox' => ['flat_rate:1', 'shipping_class:12']])
+        ->store();
+
+    $term          = new WP_Term();
+    $term->term_id = 999;
+    $term->slug    = $term->name = 'disabled-class';
+    wp_cache_add('999', $term, 'terms');
+
+    WC()->session->set(SESSION_KEY, [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+    WC()->session->set('chosen_shipping_methods', ['flat_rate:1']);
+
+    $cart = cartWithProduct(true, [], 0.0, 999);
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toBeEmpty();
+});
+
+it('still adds fees when the chosen method and shipping class are enabled in the matrix', function () {
+    // Regression guard: a configured matrix that DOES include the chosen method and the product's
+    // shipping class must not block the fee.
+    factory(CheckoutSettings::class)
+        ->withAllowedShippingMethods(['mailbox' => ['flat_rate:1', 'shipping_class:999']])
+        ->store();
+
+    $term          = new WP_Term();
+    $term->term_id = 999;
+    $term->slug    = $term->name = 'enabled-class';
+    wp_cache_add('999', $term, 'terms');
+
+    WC()->session->set(SESSION_KEY, [
+        'carrier'         => 'postnl',
+        'shipmentOptions' => [
+            (new SignatureDefinition())->getShipmentOptionsKey() => true,
+        ],
+    ]);
+    WC()->session->set('chosen_shipping_methods', ['flat_rate:1']);
+
+    $cart = cartWithProduct(true, [], 0.0, 999);
+
+    /** @var CartFeesHooks $hooks */
+    $hooks = Pdk::get(CartFeesHooks::class);
+    $hooks->calculateDeliveryOptionsFees($cart);
+
+    expect($cart->fees)->toHaveCount(2)
+        ->and(array_column($cart->fees, 'amount'))->toBe([4.5, 1.1]);
 });

--- a/tests/Unit/Hooks/PdkCheckoutPlaceOrderHooksTest.php
+++ b/tests/Unit/Hooks/PdkCheckoutPlaceOrderHooksTest.php
@@ -24,7 +24,7 @@ beforeEach(function () {
 
 it('saves delivery options for the blocks checkout', function ($orderId, $deliveryOptions, $expectedCarrier) {
     $namespace = PdkBootstrapper::PLUGIN_NAMESPACE;
-    $GLOBALS['HTTP_RAW_POST_DATA'] = json_encode([
+    $body      = json_encode([
         'extensions' => [
             "$namespace-delivery-options" => [
                 'carrier'     => $deliveryOptions['carrier'],
@@ -33,13 +33,29 @@ it('saves delivery options for the blocks checkout', function ($orderId, $delive
         ],
     ]);
 
+    // The Store API hook passes a WP_REST_Request; the selection is read from its raw body.
+    $request = new class($body) {
+        /** @var string */
+        private $body;
+
+        public function __construct(string $body)
+        {
+            $this->body = $body;
+        }
+
+        public function get_body(): string
+        {
+            return $this->body;
+        }
+    };
+
     $wcOrder            =
         wpFactory(WC_Order::class)
             ->withId($orderId)
             ->make();
     $checkoutHooksClass = Pdk::get(PdkCheckoutPlaceOrderHooks::class);
 
-    $checkoutHooksClass->saveBlocksDeliveryOptions($wcOrder);
+    $checkoutHooksClass->saveBlocksDeliveryOptions($wcOrder, $request);
 
     $orderRepository = Pdk::get(PdkOrderRepositoryInterface::class);
     $pdkOrder        = $orderRepository->get($wcOrder->get_id());

--- a/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
@@ -22,6 +22,9 @@
     "woocommerce_cart_calculate_fees": [
         "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::calculateDeliveryOptionsFees"
     ],
+    "woocommerce_store_api_checkout_update_customer_from_request": [
+        "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::stashBlocksCheckoutSelection"
+    ],
     "woocommerce_checkout_order_processed": [
         "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession",
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveDeliveryOptions"

--- a/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
@@ -22,6 +22,17 @@
     "woocommerce_cart_calculate_fees": [
         "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::calculateDeliveryOptionsFees"
     ],
+    "woocommerce_checkout_order_processed": [
+        "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession",
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveDeliveryOptions"
+    ],
+    "woocommerce_blocks_checkout_order_processed": [
+        "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession",
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveBlocksDeliveryOptions"
+    ],
+    "woocommerce_cart_emptied": [
+        "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession"
+    ],
     "wp": [
         "MyParcelNL\\WooCommerce\\Hooks\\CheckoutScriptHooks::enqueueFrontendScripts"
     ],
@@ -33,12 +44,6 @@
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkEndpointHooks::registerEndpointRoutes",
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkFrontendEndpointHooks::registerPdkRoutes",
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkWebhookHooks::registerWebhookRoutes"
-    ],
-    "woocommerce_checkout_order_processed": [
-        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveDeliveryOptions"
-    ],
-    "woocommerce_blocks_checkout_order_processed": [
-        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveBlocksDeliveryOptions"
     ],
     "admin_enqueue_scripts": [
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::registerPdkScripts"

--- a/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
@@ -29,9 +29,8 @@
         "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession",
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveDeliveryOptions"
     ],
-    "woocommerce_blocks_checkout_order_processed": [
-        "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession",
-        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveBlocksDeliveryOptions"
+    "woocommerce_store_api_checkout_order_processed": [
+        "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession"
     ],
     "woocommerce_cart_emptied": [
         "MyParcelNL\\WooCommerce\\Hooks\\CartFeesHooks::clearDeliveryOptionsSession"
@@ -47,6 +46,9 @@
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkEndpointHooks::registerEndpointRoutes",
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkFrontendEndpointHooks::registerPdkRoutes",
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkWebhookHooks::registerWebhookRoutes"
+    ],
+    "woocommerce_store_api_checkout_update_order_from_request": [
+        "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCheckoutPlaceOrderHooks::saveBlocksDeliveryOptions"
     ],
     "admin_enqueue_scripts": [
         "MyParcelNL\\WooCommerce\\Pdk\\Hooks\\PdkCoreHooks::registerPdkScripts"

--- a/tests/mock_wc_functions.php
+++ b/tests/mock_wc_functions.php
@@ -18,6 +18,16 @@ function get_woocommerce_currency(): string
 function register_block_type($blockType, $args = []): void {}
 
 /**
+ * Captures registered Store API update callbacks keyed by namespace so tests can invoke them.
+ *
+ * @see \Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema::register_update_callback()
+ */
+function woocommerce_store_api_register_update_callback($args): void
+{
+    $GLOBALS['__mpwc_store_api_update_callbacks'][$args['namespace']] = $args['callback'];
+}
+
+/**
  * @return \stdClass[]
  * @see \wc_get_order_notes()
  */

--- a/tests/mock_wp_functions.php
+++ b/tests/mock_wp_functions.php
@@ -183,6 +183,12 @@ function wp_unslash($value)
     return $value;
 }
 
+/** @see \is_admin() */
+function is_admin(): bool
+{
+    return false;
+}
+
 function wp_enqueue_script($handle, $src = '', $deps = [], $ver = false, $in_footer = false)
 {
     MockWpEnqueue::add($handle, $src, $deps, $ver, $in_footer);

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -13,11 +13,8 @@ const CART_UPDATE_DEBOUNCE_MS = 300;
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-// A stable key over only the fee-relevant fields of a selection (carrier, deliveryType, packageType,
-// isPickup, shipmentOptions) — the chosen `date` is dropped because it doesn't affect the fee and the
-// widget recomputes it on remount. Used to dedupe pushes: a shipping toggle remounts the widget and
-// re-emits the same selection, which must NOT trigger a cart refresh (that would race the shipping
-// commit); only a genuine option change produces a different key.
+// Fee-relevant key of a selection (drops the volatile `date`). Dedupes pushes so the widget's
+// remount re-emit on a shipping toggle — same options — doesn't fire a needless, race-prone refresh.
 const feeKey = (selection: Record<string, unknown>): string => {
   const {date, ...rest} = selection;
   void date;
@@ -25,13 +22,10 @@ const feeKey = (selection: Record<string, unknown>): string => {
   return JSON.stringify(rest);
 };
 
-// Tracks whether the wrapper has mounted before this page load. The first mount drives the PDK's
-// one-time initialization (which mounts the widget); only later remounts need an explicit render.
+// First mount runs the PDK's one-time widget init; later remounts (one per toggle) need an explicit re-render.
 let hasInitiallyMounted = false;
 
-// The fee-relevant key of the last selection actually pushed. Module-level so it survives the
-// remounts Blocks does on every shipping/pickup toggle — otherwise the post-toggle re-emit wouldn't
-// be recognized as already-pushed and would fire a clobbering cart refresh.
+// Last pushed fee-key. Module-level so it survives the toggle remounts (else the re-emit looks new).
 let lastPushedFeeKey: string | undefined;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -46,34 +40,28 @@ const DeliveryOptionsWrapper = () => {
     const setExtensionData = dispatch.setExtensionData ?? dispatch.__internalSetExtensionData;
 
     let cartUpdateTimeout: ReturnType<typeof setTimeout> | undefined;
-    // The latest valid selection that still needs to reach the Store API session.
+    // Latest selection awaiting a push.
     let pendingSelection: Record<string, unknown> | undefined;
-    // The selected shipping rate observed on the previous settle check; the push only fires once this
-    // is unchanged across a settle window AND the cart is idle (see flushCartUpdate).
+    // Selected rate seen on the previous settle check; the push waits until it holds steady.
     let lastSettleRate: string | undefined;
 
-    // Snapshot of the cart's shipping selection + busy flags, used to gate our push and to enforce the
-    // self-heal invariant below. `rate` is the selected rate id (or 'NONE'); `pkg` is its package id.
-    const cartState = (): {rate: string; pkg?: unknown; busy: boolean} => {
+    // Selected shipping rate id (or 'NONE') and whether the cart is mid-update — the scheduler holds
+    // the push until the cart is idle and the rate has settled.
+    const cartState = (): {rate: string; busy: boolean} => {
       const cart = wp.data.select(CART_STORE_KEY) as Record<string, undefined | ((...a: unknown[]) => unknown)>;
-      const pkg = (
-        cart?.getShippingRates?.() as
-          | undefined
-          | {package_id?: unknown; shipping_rates?: {rate_id: string; selected: boolean}[]}[]
-      )?.[0];
-      const rate = (pkg?.shipping_rates ?? []).find((r) => r.selected);
+      const rates = (
+        cart?.getShippingRates?.() as undefined | {shipping_rates?: {rate_id: string; selected: boolean}[]}[]
+      )?.[0]?.shipping_rates;
+      const rate = (rates ?? []).find((r) => r.selected);
 
       return {
         rate: rate?.rate_id ?? 'NONE',
-        pkg: pkg?.package_id,
         busy: Boolean(cart?.isShippingRateBeingSelected?.() || cart?.isCustomerDataUpdating?.()),
       };
     };
 
-    // Push the pending selection to the Store API now, cancelling any scheduled push. This drives the
-    // live fee in the cart/order summary; the selection is persisted for the order separately via
-    // setExtensionData. Deciding *when* it is safe to push is the scheduler's job (scheduleCartUpdate);
-    // this function just pushes.
+    // Push the pending selection now (drives the live summary fee). The scheduler decides when this is
+    // safe to call; the selection is separately persisted for the order via setExtensionData.
     const flushCartUpdate = (): Promise<unknown> => {
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);
@@ -84,11 +72,8 @@ const DeliveryOptionsWrapper = () => {
         return Promise.resolve();
       }
 
-      // Never push while the order is being placed. A cart-extensions request concurrent with the
-      // order POST races WooCommerce's draft-order build and duplicates its line items/fees. The
-      // selection is still persisted via setExtensionData and the server stashes it for the fee at
-      // order time (CartFeesHooks::stashBlocksCheckoutSelection), so skipping the push here is safe.
-      // Keep the pending selection so a push still happens if the order doesn't go through.
+      // Don't push while the order is being placed — a cart request concurrent with the order POST
+      // duplicates its line items. The server stashes the fee at order time, so skipping here is safe.
       if (select.isBeforeProcessing?.() || select.isProcessing?.()) {
         return Promise.resolve();
       }
@@ -97,14 +82,9 @@ const DeliveryOptionsWrapper = () => {
       pendingSelection = undefined;
       lastPushedFeeKey = feeKey(selection);
 
-      // The shipping selection the customer has chosen, captured the instant before our push, so the
-      // self-heal below can detect (and undo) any change the push's response makes to it.
-      const before = cartState();
-
-      // Mark the checkout "calculating" for the whole push. WooCommerce's place-order flow waits for
-      // isCalculating to clear before building the order, so this makes it block on our in-flight
-      // request instead of running concurrently — an overlapping cart request duplicates the order's
-      // line items, and an in-flight request can't be cancelled, so we make the checkout wait for it.
+      // Mark the checkout "calculating" for the push so WooCommerce's place-order flow blocks on it:
+      // an in-flight cart request overlapping the order POST duplicates the order's line items, and it
+      // can't be cancelled once sent — so we make the checkout wait for it to finish.
       const checkoutCalc = dispatch as {
         __internalIncrementCalculating?: () => void;
         __internalDecrementCalculating?: () => void;
@@ -112,25 +92,6 @@ const DeliveryOptionsWrapper = () => {
       checkoutCalc.__internalIncrementCalculating?.();
 
       return extensionCartUpdate({namespace: NAME, data: selection})
-        .then(() => {
-          // Invariant: extensionCartUpdate must not change the chosen shipping rate. It applies the
-          // server's *entire* cart response, which during a rapid Verzenden/Afhalen toggle can carry
-          // a stale rate (the server momentarily still has the previous method) and overwrite the
-          // customer's choice — making the delivery options vanish. No client-side "cart is busy"
-          // signal reliably prevents this (the flags read idle while a selection is committing
-          // server-side), so we enforce the invariant after the fact: if our push moved the rate,
-          // re-select the original one to reconverge client and server. selectShippingRate commits to
-          // the server, so once it lands every subsequent push echoes the correct rate and this stops.
-          const after = cartState();
-
-          if (before.rate !== 'NONE' && after.rate !== before.rate) {
-            const cartDispatch = wp.data.dispatch(CART_STORE_KEY) as {
-              selectShippingRate?: (rateId: string, packageId?: unknown) => unknown;
-            };
-
-            void cartDispatch.selectShippingRate?.(before.rate, before.pkg);
-          }
-        })
         .catch((error) => {
           // eslint-disable-next-line no-console
           console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
@@ -140,13 +101,9 @@ const DeliveryOptionsWrapper = () => {
         });
     };
 
-    // Debounced, settle-aware scheduler for the cart push. extensionCartUpdate applies the *entire*
-    // server cart response back into the cart store, so pushing while a shipping-rate selection is in
-    // flight — or in the brief idle gap between two rapid selections — races WooCommerce's own commit:
-    // the server returns a snapshot with the previous method still selected, which overwrites the
-    // client and drops the pending selection (a fast "Afhalen" -> "Verzenden" toggle snaps back to
-    // local pickup, hiding the delivery options). So we wait until the cart is idle AND the selected
-    // rate has held steady across a settle window before pushing; until then we keep re-arming.
+    // Debounced push scheduler. extensionCartUpdate replaces the whole cart, so pushing during a
+    // shipping change reverts the chosen method; wait out the debounce, then hold until the cart is
+    // idle and the rate has settled before pushing. Re-arms until then.
     const scheduleCartUpdate = (): void => {
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);
@@ -170,58 +127,32 @@ const DeliveryOptionsWrapper = () => {
     const handleUpdatedDeliveryOptions = (event: Event): void => {
       const {detail} = event as CustomEvent;
 
-      // The widget emits `null`/`undefined` when there's no valid selection yet (initial load,
-      // loading, or reset). Forwarding that as `data` makes the Store API reject the request, so
-      // skip until we have an actual delivery-options object.
+      // The widget emits null/undefined when there's no valid selection yet; the Store API rejects
+      // that, so wait for a real object.
       if (!isPlainObject(detail)) {
         return;
       }
 
-      // Persist the selection so it's saved on order placement.
+      // Persist the selection so it's saved on the order.
       void setExtensionData(NAME, detail);
 
-      // The widget re-emits its current selection whenever it remounts — which Blocks does every time
-      // the customer toggles "Verzenden"/"Afhalen in de winkel". That re-emit carries the same
-      // fee-relevant selection we already pushed, so skip it: pushing here would fire a cart update
-      // mid-toggle and race the shipping-rate commit. Genuine option changes differ and fall through.
+      // Skip re-emits of the same options — the widget re-emits on the remount every toggle causes,
+      // and a push here would race the shipping commit. Genuine changes differ and fall through.
       if (feeKey(detail) === lastPushedFeeKey) {
         return;
       }
 
-      // Schedule a debounced, settle-aware push so the cart recalculates delivery-options fees in the
-      // order summary without firing a request per tick. Only the latest selection is sent.
+      // Debounced push so the summary fee recalculates without a request per tick.
       pendingSelection = detail;
       scheduleCartUpdate();
     };
 
-    // We never push to the cart at order placement: forcing an extensionCartUpdate here raced
-    // WooCommerce's own shipping-rate commit and reverted the chosen method on the order. Instead the
-    // selection rides along in the order POST's `extensions` payload (setExtensionData above) and the
-    // server primes the fee from it (CartFeesHooks::stashBlocksCheckoutSelection).
-    //
-    // What we *do* need here: cancel any still-pending debounced push so it can't fire concurrently
-    // with the order POST. A cart-extensions request overlapping the checkout request races the
-    // draft-order build and duplicates its line items/fees. This only clears a timer — no cart write,
-    // no shipping touch — so it can't affect the chosen method.
-    let wasBeforeProcessing = false;
-    const unsubscribe = wp.data.subscribe(() => {
-      const isBeforeProcessing = Boolean(select.isBeforeProcessing?.());
-
-      if (isBeforeProcessing && !wasBeforeProcessing && cartUpdateTimeout) {
-        clearTimeout(cartUpdateTimeout);
-        cartUpdateTimeout = undefined;
-      }
-
-      wasBeforeProcessing = isBeforeProcessing;
-    }, CHECKOUT_STORE_KEY);
-
     document.addEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
     document.dispatchEvent(new CustomEvent('myparcel_wc_delivery_options_ready'));
 
-    // Blocks recreates this wrapper's DOM when toggling "Verzenden"/"Afhalen in de winkel". The PDK
-    // only initializes the widget once per page load, so on remounts we must tell the widget to
-    // (re)mount into the fresh #myparcel-delivery-options element. `myparcel_render_delivery_options`
-    // is the widget's public render event; it unmounts any stale app and mounts fresh.
+    // Blocks recreates this wrapper on every Verzenden/Afhalen toggle, but the PDK inits the widget
+    // once per page load — so on remounts tell it to re-mount into the fresh element via its public
+    // render event (it unmounts any stale app and mounts fresh).
     if (hasInitiallyMounted) {
       document.dispatchEvent(new Event('myparcel_render_delivery_options'));
     }
@@ -230,7 +161,6 @@ const DeliveryOptionsWrapper = () => {
 
     return () => {
       document.removeEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
-      unsubscribe();
 
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -23,11 +23,37 @@ const DeliveryOptionsWrapper = () => {
 
   useEffect(() => {
     const dispatch = wp.data.dispatch(CHECKOUT_STORE_KEY);
+    const select = wp.data.select(CHECKOUT_STORE_KEY);
 
     // Public checkout action since WooCommerce 9.9.0; fall back to the deprecated one on older versions.
     const setExtensionData = dispatch.setExtensionData ?? dispatch.__internalSetExtensionData;
 
     let cartUpdateTimeout: ReturnType<typeof setTimeout> | undefined;
+    // The latest valid selection that still needs to reach the Store API session.
+    let pendingSelection: Record<string, unknown> | undefined;
+
+    // Push the latest pending selection to the Store API now, cancelling any debounce. Returns the
+    // request promise so the pre-submit flush below can rely on extensionCartUpdate having been
+    // dispatched (it marks the cart as calculating, which the blocks checkout waits on before
+    // placing the order — so the session is written server-side before the order POST).
+    const flushCartUpdate = (): Promise<unknown> => {
+      if (cartUpdateTimeout) {
+        clearTimeout(cartUpdateTimeout);
+        cartUpdateTimeout = undefined;
+      }
+
+      if (!pendingSelection) {
+        return Promise.resolve();
+      }
+
+      const selection = pendingSelection;
+      pendingSelection = undefined;
+
+      return extensionCartUpdate({namespace: NAME, data: selection}).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
+      });
+    };
 
     const handleUpdatedDeliveryOptions = (event: Event): void => {
       const {detail} = event as CustomEvent;
@@ -42,18 +68,35 @@ const DeliveryOptionsWrapper = () => {
       // Persist the selection so it's saved on order placement.
       void setExtensionData(NAME, detail);
 
-      // Push to the Store API so the cart recalculates delivery-options fees in the order summary.
+      // Debounce the Store API push so the cart recalculates delivery-options fees in the order
+      // summary without firing a request per tick. Only the latest selection is sent.
+      pendingSelection = detail;
+
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);
       }
 
       cartUpdateTimeout = setTimeout(() => {
-        void extensionCartUpdate({namespace: NAME, data: detail}).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
-        });
+        cartUpdateTimeout = undefined;
+        void flushCartUpdate();
       }, CART_UPDATE_DEBOUNCE_MS);
     };
+
+    // Flush any debounced selection the moment the customer places the order. Without this, an
+    // order placed within the debounce window would recalculate fees from the *previous* selection
+    // (the session the fee calc reads is only written by extensionCartUpdate) while the order is
+    // saved with the latest one — charging a fee that doesn't match the chosen delivery option.
+    let wasBeforeProcessing = false;
+    const unsubscribe = wp.data.subscribe(() => {
+      const isBeforeProcessing = Boolean(select.isBeforeProcessing?.());
+
+      // Rising edge only, and only when there's actually something pending to flush.
+      if (isBeforeProcessing && !wasBeforeProcessing && (cartUpdateTimeout || pendingSelection)) {
+        void flushCartUpdate();
+      }
+
+      wasBeforeProcessing = isBeforeProcessing;
+    }, CHECKOUT_STORE_KEY);
 
     document.addEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
     document.dispatchEvent(new CustomEvent('myparcel_wc_delivery_options_ready'));
@@ -70,6 +113,7 @@ const DeliveryOptionsWrapper = () => {
 
     return () => {
       document.removeEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
+      unsubscribe();
 
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -13,6 +13,10 @@ const CART_UPDATE_DEBOUNCE_MS = 300;
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+// Tracks whether the wrapper has mounted before this page load. The first mount drives the PDK's
+// one-time initialization (which mounts the widget); only later remounts need an explicit render.
+let hasInitiallyMounted = false;
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const DeliveryOptionsWrapper = () => {
   const data = getSetting<{style?: string; context: string}>(`${NAME}_data`, {});
@@ -53,6 +57,16 @@ const DeliveryOptionsWrapper = () => {
 
     document.addEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
     document.dispatchEvent(new CustomEvent('myparcel_wc_delivery_options_ready'));
+
+    // Blocks recreates this wrapper's DOM when toggling "Verzenden"/"Afhalen in de winkel". The PDK
+    // only initializes the widget once per page load, so on remounts we must tell the widget to
+    // (re)mount into the fresh #myparcel-delivery-options element. `myparcel_render_delivery_options`
+    // is the widget's public render event; it unmounts any stale app and mounts fresh.
+    if (hasInitiallyMounted) {
+      document.dispatchEvent(new Event('myparcel_render_delivery_options'));
+    }
+
+    hasInitiallyMounted = true;
 
     return () => {
       document.removeEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -13,9 +13,26 @@ const CART_UPDATE_DEBOUNCE_MS = 300;
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+// A stable key over only the fee-relevant fields of a selection (carrier, deliveryType, packageType,
+// isPickup, shipmentOptions) — the chosen `date` is dropped because it doesn't affect the fee and the
+// widget recomputes it on remount. Used to dedupe pushes: a shipping toggle remounts the widget and
+// re-emits the same selection, which must NOT trigger a cart refresh (that would race the shipping
+// commit); only a genuine option change produces a different key.
+const feeKey = (selection: Record<string, unknown>): string => {
+  const {date, ...rest} = selection;
+  void date;
+
+  return JSON.stringify(rest);
+};
+
 // Tracks whether the wrapper has mounted before this page load. The first mount drives the PDK's
 // one-time initialization (which mounts the widget); only later remounts need an explicit render.
 let hasInitiallyMounted = false;
+
+// The fee-relevant key of the last selection actually pushed. Module-level so it survives the
+// remounts Blocks does on every shipping/pickup toggle — otherwise the post-toggle re-emit wouldn't
+// be recognized as already-pushed and would fire a clobbering cart refresh.
+let lastPushedFeeKey: string | undefined;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const DeliveryOptionsWrapper = () => {
@@ -31,9 +48,6 @@ const DeliveryOptionsWrapper = () => {
     let cartUpdateTimeout: ReturnType<typeof setTimeout> | undefined;
     // The latest valid selection that still needs to reach the Store API session.
     let pendingSelection: Record<string, unknown> | undefined;
-    // JSON of the last selection actually pushed, so widget re-emits with identical data (e.g. on the
-    // remount that happens when toggling Verzenden/Afhalen) don't trigger a redundant cart push.
-    let lastPushedSelection: string | undefined;
     // The selected shipping rate observed on the previous settle check; the push only fires once this
     // is unchanged across a settle window AND the cart is idle (see flushCartUpdate).
     let lastSettleRate: string | undefined;
@@ -70,13 +84,32 @@ const DeliveryOptionsWrapper = () => {
         return Promise.resolve();
       }
 
+      // Never push while the order is being placed. A cart-extensions request concurrent with the
+      // order POST races WooCommerce's draft-order build and duplicates its line items/fees. The
+      // selection is still persisted via setExtensionData and the server stashes it for the fee at
+      // order time (CartFeesHooks::stashBlocksCheckoutSelection), so skipping the push here is safe.
+      // Keep the pending selection so a push still happens if the order doesn't go through.
+      if (select.isBeforeProcessing?.() || select.isProcessing?.()) {
+        return Promise.resolve();
+      }
+
       const selection = pendingSelection;
       pendingSelection = undefined;
-      lastPushedSelection = JSON.stringify(selection);
+      lastPushedFeeKey = feeKey(selection);
 
       // The shipping selection the customer has chosen, captured the instant before our push, so the
       // self-heal below can detect (and undo) any change the push's response makes to it.
       const before = cartState();
+
+      // Mark the checkout "calculating" for the whole push. WooCommerce's place-order flow waits for
+      // isCalculating to clear before building the order, so this makes it block on our in-flight
+      // request instead of running concurrently — an overlapping cart request duplicates the order's
+      // line items, and an in-flight request can't be cancelled, so we make the checkout wait for it.
+      const checkoutCalc = dispatch as {
+        __internalIncrementCalculating?: () => void;
+        __internalDecrementCalculating?: () => void;
+      };
+      checkoutCalc.__internalIncrementCalculating?.();
 
       return extensionCartUpdate({namespace: NAME, data: selection})
         .then(() => {
@@ -101,6 +134,9 @@ const DeliveryOptionsWrapper = () => {
         .catch((error) => {
           // eslint-disable-next-line no-console
           console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
+        })
+        .finally(() => {
+          checkoutCalc.__internalDecrementCalculating?.();
         });
     };
 
@@ -145,10 +181,10 @@ const DeliveryOptionsWrapper = () => {
       void setExtensionData(NAME, detail);
 
       // The widget re-emits its current selection whenever it remounts — which Blocks does every time
-      // the customer toggles "Verzenden"/"Afhalen in de winkel". That re-emit carries the *same* data
-      // we already pushed, so skip it: pushing here would fire a cart update mid-toggle and race the
-      // shipping-rate commit. Genuine selection changes still differ and fall through.
-      if (JSON.stringify(detail) === lastPushedSelection) {
+      // the customer toggles "Verzenden"/"Afhalen in de winkel". That re-emit carries the same
+      // fee-relevant selection we already pushed, so skip it: pushing here would fire a cart update
+      // mid-toggle and race the shipping-rate commit. Genuine option changes differ and fall through.
+      if (feeKey(detail) === lastPushedFeeKey) {
         return;
       }
 

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -60,7 +60,11 @@ const DeliveryOptionsWrapper = () => {
     // request promise so the pre-submit flush below can rely on extensionCartUpdate having been
     // dispatched (it marks the cart as calculating, which the blocks checkout waits on before
     // placing the order — so the session is written server-side before the order POST).
-    const flushCartUpdate = (): Promise<unknown> => {
+    //
+    // `force` bypasses the settle gate. The gate exists to avoid racing interactive shipping-method
+    // toggles; at order placement there is no such toggle in progress, and deferring there would let
+    // the order POST before the session is written (a fee mismatch), so the pre-submit caller forces.
+    const flushCartUpdate = (force = false): Promise<unknown> => {
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);
         cartUpdateTimeout = undefined;
@@ -79,7 +83,7 @@ const DeliveryOptionsWrapper = () => {
       // cart to be idle AND the selected rate to be unchanged across a settle window before pushing.
       const before = cartState();
 
-      if (before.busy || before.rate !== lastSettleRate) {
+      if (!force && (before.busy || before.rate !== lastSettleRate)) {
         lastSettleRate = before.rate;
         cartUpdateTimeout = setTimeout(() => {
           cartUpdateTimeout = undefined;
@@ -162,9 +166,11 @@ const DeliveryOptionsWrapper = () => {
     const unsubscribe = wp.data.subscribe(() => {
       const isBeforeProcessing = Boolean(select.isBeforeProcessing?.());
 
-      // Rising edge only, and only when there's actually something pending to flush.
+      // Rising edge only, and only when there's actually something pending to flush. Force past the
+      // settle gate: the session must be written before the order POST, and no shipping toggle is in
+      // progress at order placement.
       if (isBeforeProcessing && !wasBeforeProcessing && (cartUpdateTimeout || pendingSelection)) {
-        void flushCartUpdate();
+        void flushCartUpdate(true);
       }
 
       wasBeforeProcessing = isBeforeProcessing;

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -23,6 +23,7 @@ const DeliveryOptionsWrapper = () => {
 
   useEffect(() => {
     const dispatch = wp.data.dispatch(CHECKOUT_STORE_KEY);
+    const select = wp.data.select(CHECKOUT_STORE_KEY);
 
     // Public checkout action since WooCommerce 9.9.0; fall back to the deprecated one on older versions.
     const setExtensionData = dispatch.setExtensionData ?? dispatch.__internalSetExtensionData;
@@ -157,11 +158,27 @@ const DeliveryOptionsWrapper = () => {
       scheduleCartUpdate();
     };
 
-    // No pre-submit flush: forcing an extensionCartUpdate at order placement raced WooCommerce's own
-    // shipping-rate commit and could revert the chosen method on the resulting order (by order time
-    // the shipping method is already locked server-side, so re-asserting it from here is too late).
-    // The order POST carries the selection in its `extensions` payload (via setExtensionData above),
-    // so the chosen option is always saved on the order itself.
+    // We never push to the cart at order placement: forcing an extensionCartUpdate here raced
+    // WooCommerce's own shipping-rate commit and reverted the chosen method on the order. Instead the
+    // selection rides along in the order POST's `extensions` payload (setExtensionData above) and the
+    // server primes the fee from it (CartFeesHooks::stashBlocksCheckoutSelection).
+    //
+    // What we *do* need here: cancel any still-pending debounced push so it can't fire concurrently
+    // with the order POST. A cart-extensions request overlapping the checkout request races the
+    // draft-order build and duplicates its line items/fees. This only clears a timer — no cart write,
+    // no shipping touch — so it can't affect the chosen method.
+    let wasBeforeProcessing = false;
+    const unsubscribe = wp.data.subscribe(() => {
+      const isBeforeProcessing = Boolean(select.isBeforeProcessing?.());
+
+      if (isBeforeProcessing && !wasBeforeProcessing && cartUpdateTimeout) {
+        clearTimeout(cartUpdateTimeout);
+        cartUpdateTimeout = undefined;
+      }
+
+      wasBeforeProcessing = isBeforeProcessing;
+    }, CHECKOUT_STORE_KEY);
+
     document.addEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
     document.dispatchEvent(new CustomEvent('myparcel_wc_delivery_options_ready'));
 
@@ -177,6 +194,7 @@ const DeliveryOptionsWrapper = () => {
 
     return () => {
       document.removeEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
+      unsubscribe();
 
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -23,7 +23,6 @@ const DeliveryOptionsWrapper = () => {
 
   useEffect(() => {
     const dispatch = wp.data.dispatch(CHECKOUT_STORE_KEY);
-    const select = wp.data.select(CHECKOUT_STORE_KEY);
 
     // Public checkout action since WooCommerce 9.9.0; fall back to the deprecated one on older versions.
     const setExtensionData = dispatch.setExtensionData ?? dispatch.__internalSetExtensionData;
@@ -56,11 +55,10 @@ const DeliveryOptionsWrapper = () => {
       };
     };
 
-    // Push the pending selection to the Store API right now, cancelling any scheduled push. Returns
-    // the request promise so the pre-submit flush below can rely on extensionCartUpdate having been
-    // dispatched (it marks the cart as calculating, which the blocks checkout waits on before placing
-    // the order — so the session is written server-side before the order POST). Deciding *when* it is
-    // safe to push is the scheduler's job (see scheduleCartUpdate); this function just pushes.
+    // Push the pending selection to the Store API now, cancelling any scheduled push. This drives the
+    // live fee in the cart/order summary; the selection is persisted for the order separately via
+    // setExtensionData. Deciding *when* it is safe to push is the scheduler's job (scheduleCartUpdate);
+    // this function just pushes.
     const flushCartUpdate = (): Promise<unknown> => {
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);
@@ -159,24 +157,11 @@ const DeliveryOptionsWrapper = () => {
       scheduleCartUpdate();
     };
 
-    // Flush any debounced selection the moment the customer places the order. Without this, an
-    // order placed within the debounce window would recalculate fees from the *previous* selection
-    // (the session the fee calc reads is only written by extensionCartUpdate) while the order is
-    // saved with the latest one — charging a fee that doesn't match the chosen delivery option.
-    let wasBeforeProcessing = false;
-    const unsubscribe = wp.data.subscribe(() => {
-      const isBeforeProcessing = Boolean(select.isBeforeProcessing?.());
-
-      // Rising edge only, and only when there's actually something pending to flush. Push immediately
-      // (cancelling any scheduled settle wait): the session must be written before the order POST, and
-      // no shipping toggle is in progress at order placement.
-      if (isBeforeProcessing && !wasBeforeProcessing && (cartUpdateTimeout || pendingSelection)) {
-        void flushCartUpdate();
-      }
-
-      wasBeforeProcessing = isBeforeProcessing;
-    }, CHECKOUT_STORE_KEY);
-
+    // No pre-submit flush: forcing an extensionCartUpdate at order placement raced WooCommerce's own
+    // shipping-rate commit and could revert the chosen method on the resulting order (by order time
+    // the shipping method is already locked server-side, so re-asserting it from here is too late).
+    // The order POST carries the selection in its `extensions` payload (via setExtensionData above),
+    // so the chosen option is always saved on the order itself.
     document.addEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
     document.dispatchEvent(new CustomEvent('myparcel_wc_delivery_options_ready'));
 
@@ -192,7 +177,6 @@ const DeliveryOptionsWrapper = () => {
 
     return () => {
       document.removeEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
-      unsubscribe();
 
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -2,10 +2,16 @@
 import React, {useEffect} from 'react';
 import {registerPlugin} from '@wordpress/plugins';
 import {getSetting} from '@woocommerce/settings';
-import {ExperimentalOrderShippingPackages} from '@woocommerce/blocks-checkout';
+import {ExperimentalOrderShippingPackages, extensionCartUpdate} from '@woocommerce/blocks-checkout';
 import {CHECKOUT_STORE_KEY} from '@woocommerce/block-data';
 
 const NAME = 'myparcelcom-delivery-options';
+
+// Debounce pushes to the Store API so rapid widget changes don't fire a request per tick.
+const CART_UPDATE_DEBOUNCE_MS = 300;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const DeliveryOptionsWrapper = () => {
@@ -14,11 +20,47 @@ const DeliveryOptionsWrapper = () => {
   useEffect(() => {
     const dispatch = wp.data.dispatch(CHECKOUT_STORE_KEY);
 
-    document.addEventListener('myparcel_updated_delivery_options', (event) => {
-      void dispatch.__internalSetExtensionData(NAME, (event as CustomEvent).detail);
-    });
+    // Public checkout action since WooCommerce 9.9.0; fall back to the deprecated one on older versions.
+    const setExtensionData = dispatch.setExtensionData ?? dispatch.__internalSetExtensionData;
 
+    let cartUpdateTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const handleUpdatedDeliveryOptions = (event: Event): void => {
+      const {detail} = event as CustomEvent;
+
+      // The widget emits `null`/`undefined` when there's no valid selection yet (initial load,
+      // loading, or reset). Forwarding that as `data` makes the Store API reject the request, so
+      // skip until we have an actual delivery-options object.
+      if (!isPlainObject(detail)) {
+        return;
+      }
+
+      // Persist the selection so it's saved on order placement.
+      void setExtensionData(NAME, detail);
+
+      // Push to the Store API so the cart recalculates delivery-options fees in the order summary.
+      if (cartUpdateTimeout) {
+        clearTimeout(cartUpdateTimeout);
+      }
+
+      cartUpdateTimeout = setTimeout(() => {
+        void extensionCartUpdate({namespace: NAME, data: detail}).catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
+        });
+      }, CART_UPDATE_DEBOUNCE_MS);
+    };
+
+    document.addEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
     document.dispatchEvent(new CustomEvent('myparcel_wc_delivery_options_ready'));
+
+    return () => {
+      document.removeEventListener('myparcel_updated_delivery_options', handleUpdatedDeliveryOptions);
+
+      if (cartUpdateTimeout) {
+        clearTimeout(cartUpdateTimeout);
+      }
+    };
   }, []);
 
   return (

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -3,7 +3,7 @@ import React, {useEffect} from 'react';
 import {registerPlugin} from '@wordpress/plugins';
 import {getSetting} from '@woocommerce/settings';
 import {ExperimentalOrderShippingPackages, extensionCartUpdate} from '@woocommerce/blocks-checkout';
-import {CHECKOUT_STORE_KEY} from '@woocommerce/block-data';
+import {CART_STORE_KEY, CHECKOUT_STORE_KEY} from '@woocommerce/block-data';
 
 const NAME = 'myparcelcom-delivery-options';
 
@@ -31,6 +31,30 @@ const DeliveryOptionsWrapper = () => {
     let cartUpdateTimeout: ReturnType<typeof setTimeout> | undefined;
     // The latest valid selection that still needs to reach the Store API session.
     let pendingSelection: Record<string, unknown> | undefined;
+    // JSON of the last selection actually pushed, so widget re-emits with identical data (e.g. on the
+    // remount that happens when toggling Verzenden/Afhalen) don't trigger a redundant cart push.
+    let lastPushedSelection: string | undefined;
+    // The selected shipping rate observed on the previous settle check; the push only fires once this
+    // is unchanged across a settle window AND the cart is idle (see flushCartUpdate).
+    let lastSettleRate: string | undefined;
+
+    // Snapshot of the cart's shipping selection + busy flags, used to gate our push and to enforce the
+    // self-heal invariant below. `rate` is the selected rate id (or 'NONE'); `pkg` is its package id.
+    const cartState = (): {rate: string; pkg?: unknown; busy: boolean} => {
+      const cart = wp.data.select(CART_STORE_KEY) as Record<string, undefined | ((...a: unknown[]) => unknown)>;
+      const pkg = (
+        cart?.getShippingRates?.() as
+          | undefined
+          | {package_id?: unknown; shipping_rates?: {rate_id: string; selected: boolean}[]}[]
+      )?.[0];
+      const rate = (pkg?.shipping_rates ?? []).find((r) => r.selected);
+
+      return {
+        rate: rate?.rate_id ?? 'NONE',
+        pkg: pkg?.package_id,
+        busy: Boolean(cart?.isShippingRateBeingSelected?.() || cart?.isCustomerDataUpdating?.()),
+      };
+    };
 
     // Push the latest pending selection to the Store API now, cancelling any debounce. Returns the
     // request promise so the pre-submit flush below can rely on extensionCartUpdate having been
@@ -46,13 +70,53 @@ const DeliveryOptionsWrapper = () => {
         return Promise.resolve();
       }
 
+      // Only push once the cart has fully settled. extensionCartUpdate applies the *entire* server
+      // cart response back into the cart store, so issuing it while a shipping-rate selection is in
+      // flight — or in the brief idle gap between two rapid selections — races WooCommerce's own
+      // commit: the server returns a snapshot with the previous method still selected, which
+      // overwrites the client and drops the pending selection (a fast "Afhalen" -> "Verzenden"
+      // toggle snaps back to local pickup, hiding the delivery options). We therefore require the
+      // cart to be idle AND the selected rate to be unchanged across a settle window before pushing.
+      const before = cartState();
+
+      if (before.busy || before.rate !== lastSettleRate) {
+        lastSettleRate = before.rate;
+        cartUpdateTimeout = setTimeout(() => {
+          cartUpdateTimeout = undefined;
+          void flushCartUpdate();
+        }, CART_UPDATE_DEBOUNCE_MS);
+
+        return Promise.resolve();
+      }
+
       const selection = pendingSelection;
       pendingSelection = undefined;
+      lastPushedSelection = JSON.stringify(selection);
 
-      return extensionCartUpdate({namespace: NAME, data: selection}).catch((error) => {
-        // eslint-disable-next-line no-console
-        console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
-      });
+      return extensionCartUpdate({namespace: NAME, data: selection})
+        .then(() => {
+          // Invariant: extensionCartUpdate must not change the chosen shipping rate. It applies the
+          // server's *entire* cart response, which during a rapid Verzenden/Afhalen toggle can carry
+          // a stale rate (the server momentarily still has the previous method) and overwrite the
+          // customer's choice — making the delivery options vanish. No client-side "cart is busy"
+          // signal reliably prevents this (the flags read idle while a selection is committing
+          // server-side), so we enforce the invariant after the fact: if our push moved the rate,
+          // re-select the original one to reconverge client and server. selectShippingRate commits to
+          // the server, so once it lands every subsequent push echoes the correct rate and this stops.
+          const after = cartState();
+
+          if (before.rate !== 'NONE' && after.rate !== before.rate) {
+            const cartDispatch = wp.data.dispatch(CART_STORE_KEY) as {
+              selectShippingRate?: (rateId: string, packageId?: unknown) => unknown;
+            };
+
+            void cartDispatch.selectShippingRate?.(before.rate, before.pkg);
+          }
+        })
+        .catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
+        });
     };
 
     const handleUpdatedDeliveryOptions = (event: Event): void => {
@@ -67,6 +131,14 @@ const DeliveryOptionsWrapper = () => {
 
       // Persist the selection so it's saved on order placement.
       void setExtensionData(NAME, detail);
+
+      // The widget re-emits its current selection whenever it remounts — which Blocks does every time
+      // the customer toggles "Verzenden"/"Afhalen in de winkel". That re-emit carries the *same* data
+      // we already pushed, so skip it: pushing here would fire a cart update mid-toggle and race the
+      // shipping-rate commit. Genuine selection changes still differ and fall through.
+      if (JSON.stringify(detail) === lastPushedSelection) {
+        return;
+      }
 
       // Debounce the Store API push so the cart recalculates delivery-options fees in the order
       // summary without firing a request per tick. Only the latest selection is sent.

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -45,9 +45,9 @@ const DeliveryOptionsWrapper = () => {
     // Selected rate seen on the previous settle check; the push waits until it holds steady.
     let lastSettleRate: string | undefined;
 
-    // Selected shipping rate id (or 'NONE') and whether the cart is mid-update — the scheduler holds
-    // the push until the cart is idle and the rate has settled.
-    const cartState = (): {rate: string; busy: boolean} => {
+    // Selected shipping rate id (or undefined when none) and whether the cart is mid-update — the
+    // scheduler holds the push until the cart is idle and the rate has settled.
+    const cartState = (): {rate: string | undefined; busy: boolean} => {
       const cart = wp.data.select(CART_STORE_KEY) as Record<string, undefined | ((...a: unknown[]) => unknown)>;
       const rates = (
         cart?.getShippingRates?.() as undefined | {shipping_rates?: {rate_id: string; selected: boolean}[]}[]
@@ -55,7 +55,7 @@ const DeliveryOptionsWrapper = () => {
       const rate = (rates ?? []).find((r) => r.selected);
 
       return {
-        rate: rate?.rate_id ?? 'NONE',
+        rate: rate?.rate_id,
         busy: Boolean(cart?.isShippingRateBeingSelected?.() || cart?.isCustomerDataUpdating?.()),
       };
     };

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -82,23 +82,34 @@ const DeliveryOptionsWrapper = () => {
       pendingSelection = undefined;
       lastPushedFeeKey = feeKey(selection);
 
+      // Push the fee, warning-and-continuing on failure so the promise never rejects.
+      const runPush = (): Promise<unknown> =>
+        extensionCartUpdate({namespace: NAME, data: selection}).catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
+        });
+
       // Mark the checkout "calculating" for the push so WooCommerce's place-order flow blocks on it:
       // an in-flight cart request overlapping the order POST duplicates the order's line items, and it
       // can't be cancelled once sent — so we make the checkout wait for it to finish.
+      //
+      // `disableCheckoutFor` is the public thunk since WooCommerce 9.9.0; fall back to the deprecated
+      // increment/decrement pair on older versions (mirrors the setExtensionData fallback above).
       const checkoutCalc = dispatch as {
+        disableCheckoutFor?: (asyncFunc: () => Promise<unknown>) => Promise<unknown>;
         __internalIncrementCalculating?: () => void;
         __internalDecrementCalculating?: () => void;
       };
+
+      if (checkoutCalc.disableCheckoutFor) {
+        return checkoutCalc.disableCheckoutFor(runPush);
+      }
+
       checkoutCalc.__internalIncrementCalculating?.();
 
-      return extensionCartUpdate({namespace: NAME, data: selection})
-        .catch((error) => {
-          // eslint-disable-next-line no-console
-          console.warn('[woocommerce-myparcel] delivery-options cart update failed', error);
-        })
-        .finally(() => {
-          checkoutCalc.__internalDecrementCalculating?.();
-        });
+      return runPush().finally(() => {
+        checkoutCalc.__internalDecrementCalculating?.();
+      });
     };
 
     // Debounced push scheduler. extensionCartUpdate replaces the whole cart, so pushing during a

--- a/views/blocks/delivery-options/src/frontend.tsx
+++ b/views/blocks/delivery-options/src/frontend.tsx
@@ -56,15 +56,12 @@ const DeliveryOptionsWrapper = () => {
       };
     };
 
-    // Push the latest pending selection to the Store API now, cancelling any debounce. Returns the
-    // request promise so the pre-submit flush below can rely on extensionCartUpdate having been
-    // dispatched (it marks the cart as calculating, which the blocks checkout waits on before
-    // placing the order — so the session is written server-side before the order POST).
-    //
-    // `force` bypasses the settle gate. The gate exists to avoid racing interactive shipping-method
-    // toggles; at order placement there is no such toggle in progress, and deferring there would let
-    // the order POST before the session is written (a fee mismatch), so the pre-submit caller forces.
-    const flushCartUpdate = (force = false): Promise<unknown> => {
+    // Push the pending selection to the Store API right now, cancelling any scheduled push. Returns
+    // the request promise so the pre-submit flush below can rely on extensionCartUpdate having been
+    // dispatched (it marks the cart as calculating, which the blocks checkout waits on before placing
+    // the order — so the session is written server-side before the order POST). Deciding *when* it is
+    // safe to push is the scheduler's job (see scheduleCartUpdate); this function just pushes.
+    const flushCartUpdate = (): Promise<unknown> => {
       if (cartUpdateTimeout) {
         clearTimeout(cartUpdateTimeout);
         cartUpdateTimeout = undefined;
@@ -74,28 +71,13 @@ const DeliveryOptionsWrapper = () => {
         return Promise.resolve();
       }
 
-      // Only push once the cart has fully settled. extensionCartUpdate applies the *entire* server
-      // cart response back into the cart store, so issuing it while a shipping-rate selection is in
-      // flight — or in the brief idle gap between two rapid selections — races WooCommerce's own
-      // commit: the server returns a snapshot with the previous method still selected, which
-      // overwrites the client and drops the pending selection (a fast "Afhalen" -> "Verzenden"
-      // toggle snaps back to local pickup, hiding the delivery options). We therefore require the
-      // cart to be idle AND the selected rate to be unchanged across a settle window before pushing.
-      const before = cartState();
-
-      if (!force && (before.busy || before.rate !== lastSettleRate)) {
-        lastSettleRate = before.rate;
-        cartUpdateTimeout = setTimeout(() => {
-          cartUpdateTimeout = undefined;
-          void flushCartUpdate();
-        }, CART_UPDATE_DEBOUNCE_MS);
-
-        return Promise.resolve();
-      }
-
       const selection = pendingSelection;
       pendingSelection = undefined;
       lastPushedSelection = JSON.stringify(selection);
+
+      // The shipping selection the customer has chosen, captured the instant before our push, so the
+      // self-heal below can detect (and undo) any change the push's response makes to it.
+      const before = cartState();
 
       return extensionCartUpdate({namespace: NAME, data: selection})
         .then(() => {
@@ -123,6 +105,33 @@ const DeliveryOptionsWrapper = () => {
         });
     };
 
+    // Debounced, settle-aware scheduler for the cart push. extensionCartUpdate applies the *entire*
+    // server cart response back into the cart store, so pushing while a shipping-rate selection is in
+    // flight — or in the brief idle gap between two rapid selections — races WooCommerce's own commit:
+    // the server returns a snapshot with the previous method still selected, which overwrites the
+    // client and drops the pending selection (a fast "Afhalen" -> "Verzenden" toggle snaps back to
+    // local pickup, hiding the delivery options). So we wait until the cart is idle AND the selected
+    // rate has held steady across a settle window before pushing; until then we keep re-arming.
+    const scheduleCartUpdate = (): void => {
+      if (cartUpdateTimeout) {
+        clearTimeout(cartUpdateTimeout);
+      }
+
+      cartUpdateTimeout = setTimeout(() => {
+        cartUpdateTimeout = undefined;
+
+        const {busy, rate} = cartState();
+
+        if (busy || rate !== lastSettleRate) {
+          lastSettleRate = rate;
+          scheduleCartUpdate();
+          return;
+        }
+
+        void flushCartUpdate();
+      }, CART_UPDATE_DEBOUNCE_MS);
+    };
+
     const handleUpdatedDeliveryOptions = (event: Event): void => {
       const {detail} = event as CustomEvent;
 
@@ -144,18 +153,10 @@ const DeliveryOptionsWrapper = () => {
         return;
       }
 
-      // Debounce the Store API push so the cart recalculates delivery-options fees in the order
-      // summary without firing a request per tick. Only the latest selection is sent.
+      // Schedule a debounced, settle-aware push so the cart recalculates delivery-options fees in the
+      // order summary without firing a request per tick. Only the latest selection is sent.
       pendingSelection = detail;
-
-      if (cartUpdateTimeout) {
-        clearTimeout(cartUpdateTimeout);
-      }
-
-      cartUpdateTimeout = setTimeout(() => {
-        cartUpdateTimeout = undefined;
-        void flushCartUpdate();
-      }, CART_UPDATE_DEBOUNCE_MS);
+      scheduleCartUpdate();
     };
 
     // Flush any debounced selection the moment the customer places the order. Without this, an
@@ -166,11 +167,11 @@ const DeliveryOptionsWrapper = () => {
     const unsubscribe = wp.data.subscribe(() => {
       const isBeforeProcessing = Boolean(select.isBeforeProcessing?.());
 
-      // Rising edge only, and only when there's actually something pending to flush. Force past the
-      // settle gate: the session must be written before the order POST, and no shipping toggle is in
-      // progress at order placement.
+      // Rising edge only, and only when there's actually something pending to flush. Push immediately
+      // (cancelling any scheduled settle wait): the session must be written before the order POST, and
+      // no shipping toggle is in progress at order placement.
       if (isBeforeProcessing && !wasBeforeProcessing && (cartUpdateTimeout || pendingSelection)) {
-        void flushCartUpdate(true);
+        void flushCartUpdate();
       }
 
       wasBeforeProcessing = isBeforeProcessing;

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -12,6 +12,8 @@
  * License: MIT
  * License URI: https://opensource.org/license/mit
  * Requires Plugins: woocommerce
+ * WC requires at least: 8.6
+ * WC tested up to: 10.3
  */
 
 declare(strict_types=1);
@@ -26,7 +28,6 @@ use MyParcelNL\WooCommerce\Facade\WooCommerce;
 use MyParcelNL\WooCommerce\Integration\WcBlocksLoader;
 use MyParcelNL\WooCommerce\Service\WordPressHookService;
 
-use MyParcelNL\WooCommerce\Tests\Mock\WordPressOptions;
 use function MyParcelNL\WooCommerce\bootPdk;
 
 require plugin_dir_path(__FILE__) . 'vendor/autoload.php';

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -12,7 +12,6 @@
  * License: MIT
  * License URI: https://opensource.org/license/mit
  * Requires Plugins: woocommerce
- * WC requires at least: 8.6
  * WC tested up to: 10.3
  */
 


### PR DESCRIPTION
INT-1674

- Records significant findings about the blocks checkout in claude.md.
- Removes deprecated hook and global, after careful consideration and research. 
- Corrects order grid display for blocks local pickup (different from classic local pickup).
- Fixes warning on confirmation page (INT-1657).
- Corrects plugin location in claude.md.

Closes #1535 