### PR TITLE
chore: normalize yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6496,14 +6496,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sigstore/core@npm:^3.1.0":
-  version: 3.2.1
-  resolution: "@sigstore/core@npm:3.2.1"
-  checksum: 10c0/b7f7dadf07234b6fa110dfeedd8453c6d81fa0fc77731c097dc72b3fb9e0e8750e7b3fa82c33f4b9d8bdda1be634eda18231f5dad1679bdf31f204f855926f61
-  languageName: node
-  linkType: hard
-
-"@sigstore/core@npm:^3.2.1":
+"@sigstore/core@npm:^3.1.0, @sigstore/core@npm:^3.2.1":
   version: 3.2.1
   resolution: "@sigstore/core@npm:3.2.1"
   checksum: 10c0/b7f7dadf07234b6fa110dfeedd8453c6d81fa0fc77731c097dc72b3fb9e0e8750e7b3fa82c33f4b9d8bdda1be634eda18231f5dad1679bdf31f204f855926f61


### PR DESCRIPTION
## Summary

- Dependabot's `@sigstore/core` bump (#1659) updated the resolved version of the `^3.1.0` lockfile entry without merging it with the pre-existing `^3.2.1` entry
- Yarn's hardened mode (enabled automatically on public PR runs) re-resolves the lockfile, wants to merge those descriptors into one entry, and refuses to install because that would modify the lockfile (`YN0028`) — failing `build`, `test-backend` and `test-frontend` on **every open PR** since the merge
- Regenerated the lockfile with `yarn install` (yarn 4.12.0, as pinned) so both descriptors share one entry again; the diff is exactly the normalization hardened mode expects

## Test Plan

- [ ] `YARN_ENABLE_HARDENED_MODE=1 yarn install --mode update-lockfile` runs clean locally (verified, no `YN0028`)
- [ ] CI checks on this PR pass
- [ ] After merge: re-run checks on an open PR (e.g. #1644) — should be green again