### PR TITLE
fix: declare HPOS (custom_order_tables) compatibility

### DIFF
--- a/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/BootTest__it_adds_all_hooks_on_plugin_init__1.json
@@ -1,6 +1,6 @@
 {
     "before_woocommerce_init": [
-        "MyParcelNLWooCommerce::declareBlocksCompatibility"
+        "MyParcelNLWooCommerce::declareWooCommerceCompatibility"
     ],
     "activate_woocommerce-myparcel": [
         "MyParcelNLWooCommerce::install"

--- a/tests/__snapshots__/EntryTest__it_adds_necessary_hooks_on_plugin_init__1.json
+++ b/tests/__snapshots__/EntryTest__it_adds_necessary_hooks_on_plugin_init__1.json
@@ -1,6 +1,6 @@
 {
     "before_woocommerce_init": [
-        "MyParcelNLWooCommerce::declareBlocksCompatibility"
+        "MyParcelNLWooCommerce::declareWooCommerceCompatibility"
     ],
     "activate_woocommerce-myparcel": [
         "MyParcelNLWooCommerce::install"

--- a/tests/__snapshots__/EntryTest__it_instantiates_the_plugin__1.json
+++ b/tests/__snapshots__/EntryTest__it_instantiates_the_plugin__1.json
@@ -1,6 +1,6 @@
 {
     "before_woocommerce_init": [
-        "MyParcelNLWooCommerce::declareBlocksCompatibility"
+        "MyParcelNLWooCommerce::declareWooCommerceCompatibility"
     ],
     "activate_woocommerce-myparcel": [
         "MyParcelNLWooCommerce::install"

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -43,7 +43,7 @@ final class MyParcelNLWooCommerce
     {
         $this->boot();
 
-        add_action('before_woocommerce_init', [$this, 'declareBlocksCompatibility']);
+        add_action('before_woocommerce_init', [$this, 'declareWooCommerceCompatibility']);
 
         register_activation_hook(__FILE__, [$this, 'install']);
         register_deactivation_hook(__FILE__, [$this, 'uninstall']);
@@ -133,10 +133,11 @@ final class MyParcelNLWooCommerce
     /**
      * @return void
      */
-    public function declareBlocksCompatibility(): void
+    public function declareWooCommerceCompatibility(): void
     {
         if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
             FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__);
+            FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__);
         }
     }
 


### PR DESCRIPTION
INT-1713, INT-1710

## Summary

Since v6.7.0 WooCommerce lists this plugin as **incompatible with HPOS** (High-Performance Order Storage). This PR fixes that by declaring `custom_order_tables` compatibility via `FeaturesUtil`.

### Root cause

- v6.7.0 (#1652) added the `WC tested up to: 10.3` plugin header.
- That header is exactly what makes WooCommerce treat a plugin as "WooCommerce-aware" (`PluginUtil::is_woocommerce_aware_plugin()`).
- For the HPOS feature, `plugins_are_incompatible_by_default => true`, so any woo-aware plugin that does not call `FeaturesUtil::declare_compatibility('custom_order_tables', ...)` is shown as incompatible in the HPOS settings UI.
- The plugin never declared HPOS compatibility — before 6.7.0 it simply wasn't on WooCommerce's radar, so no warning appeared.

The plugin is already functionally HPOS-compatible: all order meta goes through `WC_Order::get_meta()`/`update_meta_data()`, the order-grid column hook is HPOS-aware, and there is no direct `wp_posts`/`postmeta` access for orders. Only the declaration was missing.

### Changes

- Declare `custom_order_tables` compatibility alongside the existing `cart_checkout_blocks` declaration on `before_woocommerce_init`.
- Renamed `declareBlocksCompatibility()` to `declareWooCommerceCompatibility()` since it now covers two features; updated hook snapshots accordingly.

## Verification

Verified in the Docker dev environment (WooCommerce 10.2.2) via `FeaturesController`:

- **Before:** `get_compatible_plugins_for_feature('custom_order_tables')` → plugin in `uncertain`, which the HPOS UI reports as incompatible (`PluginUtil::get_items_considered_incompatible()` merges `uncertain` into `incompatible` for HPOS).
- **After:** plugin listed under `compatible`.
- Full Pest suite passes (204 tests) on PHP 7.4.

Fixes #1671