### PR TITLE
feat: add admin banner announcing MyParcel for WooCommerce 6.0

### DIFF
--- a/includes/admin/MessagesRepository.php
+++ b/includes/admin/MessagesRepository.php
@@ -12,17 +12,20 @@ class MessagesRepository
 {
     use HasInstance;
 
-    public const ORDERS_PAGE   = 'edit-shop_order';
-    public const SETTINGS_PAGE = 'woocommerce_page_wcmp_settings';
-    public const PLUGINS_PAGE  = 'plugins';
+    public const ORDERS_PAGE      = 'edit-shop_order';
+    public const ORDERS_PAGE_HPOS = 'woocommerce_page_wc-orders';
+    public const SETTINGS_PAGE    = 'woocommerce_page_wcmp_settings';
+    public const PLUGINS_PAGE     = 'plugins';
+    public const HOME_PAGE        = 'woocommerce_page_wc-admin';
 
     private const OPTION_NOTICE_DISMISSED = 'myparcel_notice_dismissed';
     private const OPTION_NOTICE_PERSISTED = 'myparcel_notice_persisted';
 
     // https://wp-mix.com/wordpress-basic-allowed-html-wp_kses/
     public const ALLOWED_HTML = [
-        'p' => ['class' => [],],
-        'a' => ['href' => [], 'class' => [], 'rel' => [], 'target' => [],],
+        'h3' => ['class' => [],],
+        'p'  => ['class' => [],],
+        'a'  => ['href' => [], 'class' => [], 'rel' => [], 'target' => [],],
     ];
 
     /**
@@ -97,16 +100,31 @@ class MessagesRepository
             if ($this->shouldMessageBeShown($message)) {
                 $cssClassDismiss = $message['messageId'] ? 'is-dismissible' : '';
                 printf(
-                    '<div class="wcmp__notice notice myparcel-dismiss-notice notice-%s %s" data-messageid="%s"><p>%s</p></div>',
+                    '<div class="wcmp__notice notice myparcel-dismiss-notice notice-%s %s" data-messageid="%s">%s</div>',
                     esc_html($message['level']),
                     esc_html($cssClassDismiss),
                     esc_html($message['messageId']),
-                    wp_kses($message['message'], self::ALLOWED_HTML)
+                    wp_kses($this->wrapMessage($message['message']), self::ALLOWED_HTML)
                 );
             }
         }
 
         $this->messages = [];
+    }
+
+    /**
+     * Wrap plain messages in a paragraph. Messages that already start with a
+     * block-level tag (e.g. a heading) are passed through unchanged.
+     *
+     * @param  string $message
+     *
+     * @return string
+     */
+    private function wrapMessage(string $message): string
+    {
+        return preg_match('~^\s*<(?:p|h[1-6]|div|ul|ol)\b~i', $message)
+            ? $message
+            : "<p>$message</p>";
     }
 
     /**

--- a/includes/admin/UpgradeBanner.php
+++ b/includes/admin/UpgradeBanner.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\includes\admin;
+
+defined('ABSPATH') or die();
+
+/**
+ * Admin banner on the plugin settings and orders pages telling merchants still
+ * on 4.x that MyParcel for WooCommerce 6.0 is available. It renders through the
+ * plugin's own Messages system, so it only shows while 4.x is active and is gone
+ * once the merchant moves to 6.x. Dismissal is remembered per shop.
+ */
+class UpgradeBanner
+{
+    private const MESSAGE_ID    = 'notice_v6_upgrade';
+    private const MIGRATION_URL = 'https://developer.myparcel.nl/nl/documentatie/10.woocommerce-v6.0.html';
+
+    public static function show(): void
+    {
+        $link = sprintf(
+            '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+            esc_url(self::MIGRATION_URL),
+            esc_html__('notice_v6_upgrade_link', 'woocommerce-myparcel')
+        );
+
+        Messages::showAdminNotice(
+            sprintf(
+                '<h3>%s</h3><p>%s</p>',
+                esc_html__('notice_v6_upgrade_title', 'woocommerce-myparcel'),
+                // The body translation holds a %s placeholder for the link.
+                sprintf(esc_html__('notice_v6_upgrade_body', 'woocommerce-myparcel'), $link)
+            ),
+            Messages::NOTICE_LEVEL_INFO,
+            self::MESSAGE_ID,
+            [
+                MessagesRepository::ORDERS_PAGE,
+                MessagesRepository::ORDERS_PAGE_HPOS,
+                MessagesRepository::SETTINGS_PAGE,
+                MessagesRepository::HOME_PAGE,
+                MessagesRepository::PLUGINS_PAGE,
+            ]
+        );
+    }
+}

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 use MyParcelNL\WooCommerce\includes\admin\Messages;
 use MyParcelNL\WooCommerce\includes\admin\MessagesRepository;
+use MyParcelNL\WooCommerce\includes\admin\UpgradeBanner;
 use MyParcelNL\WooCommerce\includes\admin\views\MyParcelWidget;
 use MyParcelNL\WooCommerce\includes\Concerns\HasApiKey;
 use MyParcelNL\WooCommerce\includes\Concerns\HasInstance;
@@ -256,6 +257,8 @@ if (! class_exists('WCMYPA')) :
                 'message_insurance_belgium_2022',
                 [MessagesRepository::SETTINGS_PAGE, MessagesRepository::PLUGINS_PAGE]
             );
+
+            UpgradeBanner::show();
         }
 
         /**


### PR DESCRIPTION
adds an admin banner telling merchants still on the 4.x plugin that a new major version (6.0) is available, with a link to the migration guide.

It shows on the plugin settings page, the orders overview, the WooCommerce home and the plugins page. The banner renders through the plugin's own Messages system, so it only appears while 4.x is active and is gone once the merchant updates to 6.x. Merchants can dismiss it and the choice is remembered per shop.

Fixes INT-1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
