### PR TITLE
fix(insurance): refresh stored carrier data to stop using deprecated insurance amounts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "version": "6.8.0",
   "require": {
     "myparcelnl/sdk": "^11.0.0-beta.28",
-    "myparcelnl/pdk": "^4.6.0",
+    "myparcelnl/pdk": "^4.7.0",
     "guzzlehttp/guzzle": "^7.5.0",
     "psr/log": "*",
     "php": ">= 7.4"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "version": "6.9.0",
   "require": {
     "myparcelnl/sdk": "^11.0.0-beta.28",
-    "myparcelnl/pdk": "^4.7.3",
+    "myparcelnl/pdk": "^4.7.4",
     "guzzlehttp/guzzle": "^7.5.0",
     "psr/log": "*",
     "php": ">= 7.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4296c1aed81f69eabff6a2ae46b4869",
+    "content-hash": "15470ee4bea49302b9efaf7131b565cf",
     "packages": [
         {
             "name": "fruitcake/php-cors",
@@ -471,16 +471,16 @@
         },
         {
             "name": "myparcelnl/pdk",
-            "version": "4.7.3",
+            "version": "4.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/pdk.git",
-                "reference": "d14c0d1cedc5465aa209997946ec2081f741d86e"
+                "reference": "17a4165408c5b46efb1136f5a7f90c7022af88a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/d14c0d1cedc5465aa209997946ec2081f741d86e",
-                "reference": "d14c0d1cedc5465aa209997946ec2081f741d86e",
+                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/17a4165408c5b46efb1136f5a7f90c7022af88a8",
+                "reference": "17a4165408c5b46efb1136f5a7f90c7022af88a8",
                 "shasum": ""
             },
             "require": {
@@ -527,9 +527,9 @@
             "homepage": "https://myparcel.nl",
             "support": {
                 "issues": "https://github.com/myparcelnl/pdk/issues",
-                "source": "https://github.com/myparcelnl/pdk/tree/v4.7.3"
+                "source": "https://github.com/myparcelnl/pdk/tree/v4.7.4"
             },
-            "time": "2026-08-18T13:19:29+00:00"
+            "time": "2026-08-19T11:14:15+00:00"
         },
         {
             "name": "myparcelnl/sdk",
@@ -5706,12 +5706,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">= 7.4"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a9a62e532a057606d5054f794196258",
+    "content-hash": "bc3cbf2c71b4406bd477a790156f3794",
     "packages": [
         {
             "name": "fruitcake/php-cors",
@@ -471,16 +471,16 @@
         },
         {
             "name": "myparcelnl/pdk",
-            "version": "4.6.0",
+            "version": "4.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myparcelnl/pdk.git",
-                "reference": "27aaefc453445c2bbfa42db2546bc9fcb9cbb02f"
+                "reference": "ed9c0d5e919a87c0daf37fadd20b87c51c141fc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/27aaefc453445c2bbfa42db2546bc9fcb9cbb02f",
-                "reference": "27aaefc453445c2bbfa42db2546bc9fcb9cbb02f",
+                "url": "https://api.github.com/repos/myparcelnl/pdk/zipball/ed9c0d5e919a87c0daf37fadd20b87c51c141fc6",
+                "reference": "ed9c0d5e919a87c0daf37fadd20b87c51c141fc6",
                 "shasum": ""
             },
             "require": {
@@ -527,9 +527,9 @@
             "homepage": "https://myparcel.nl",
             "support": {
                 "issues": "https://github.com/myparcelnl/pdk/issues",
-                "source": "https://github.com/myparcelnl/pdk/tree/v4.6.0"
+                "source": "https://github.com/myparcelnl/pdk/tree/v4.7.0"
             },
-            "time": "2026-08-06T09:12:04+00:00"
+            "time": "2026-08-06T11:23:43+00:00"
         },
         {
             "name": "myparcelnl/sdk",

--- a/config/pdk.php
+++ b/config/pdk.php
@@ -196,6 +196,14 @@ return [
         return plugin_basename(Pdk::getAppInfo()->path);
     }),
 
+    /**
+     * Directory the installer scans for timestamped migration files. The PDK default resolves
+     * against its own package directory, so without this the plugin's migrations are never found.
+     */
+    'migrationDirectory' => factory(function (): string {
+        return rtrim(Pdk::getAppInfo()->path, '/') . '/src/Migration';
+    }),
+
     'urlDocumentation' => value('https://developer.myparcel.nl/nl/documentatie/10.woocommerce.html'),
     'urlReleaseNotes'  => value('https://github.com/myparcelnl/woocommerce/releases'),
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@myparcel-dev/eslint-config-prettier": "^1.4.0",
     "@myparcel-dev/eslint-config-prettier-typescript": "^1.4.0",
     "@myparcel-dev/eslint-config-prettier-typescript-vue": "^1.4.0",
-    "@myparcel-dev/pdk-app-builder": "^4.1.0",
+    "@myparcel-dev/pdk-app-builder": "^4.1.3",
     "@myparcel-dev/semantic-release-config": "^6.0.10",
     "@myparcel-dev/semantic-release-wordpress-readme-generator": "^1.3.0",
     "@semantic-release/git": "^10.0.1",

--- a/src/Migration/2026_07_29_092726_refresh_carrier_capabilities.php
+++ b/src/Migration/2026_07_29_092726_refresh_carrier_capabilities.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\App\Installer\Migration\AbstractTimestampedMigration;
+use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Pdk;
+
+/**
+ * Re-fetches the stored carrier data so insurance limits are in the flat format.
+ *
+ * Carrier data stored before this release holds insurance limits in the nested wrapper the
+ * MyParcel API is removing. The PDK now reads the flat limits, which are absent from that older
+ * data, so insurance would be unavailable until something refreshed it. Fetching the contract
+ * definitions again rewrites the stored carriers in the shape the PDK expects.
+ */
+return new class extends AbstractTimestampedMigration {
+    public function up(): void
+    {
+        /** @var PdkAccountRepositoryInterface $accountRepository */
+        $accountRepository = Pdk::get(PdkAccountRepositoryInterface::class);
+        $account           = $accountRepository->getAccount(true);
+        // PHPStan types Account::$shops as a non-null ShopCollection, but the guard is kept
+        // intentionally to stay safe against partial/corrupted account data during upgrade.
+        // @phpstan-ignore booleanAnd.rightAlwaysTrue
+        $shop = $account && $account->shops ? $account->shops->first() : null;
+
+        if (! $shop) {
+            Logger::debug('No account or shop available; skipping carrier capabilities refresh.');
+
+            return;
+        }
+
+        /** @var CarrierCapabilitiesRepository $capabilitiesRepository */
+        $capabilitiesRepository = Pdk::get(CarrierCapabilitiesRepository::class);
+
+        try {
+            $shop->carriers = $capabilitiesRepository->getContractDefinitions();
+        } catch (Throwable $exception) {
+            // Re-throw so the migration is not marked as applied, letting it retry on the next
+            // load instead of leaving the carriers on the old shape.
+            Logger::warning('Failed to refresh carrier capabilities; migration will retry.', [
+                'exception' => $exception->getMessage(),
+            ]);
+
+            throw $exception;
+        }
+
+        $accountRepository->store($account);
+    }
+};

--- a/src/Migration/2026_07_29_092726_refresh_carrier_capabilities.php
+++ b/src/Migration/2026_07_29_092726_refresh_carrier_capabilities.php
@@ -39,13 +39,16 @@ return new class extends AbstractTimestampedMigration {
         try {
             $shop->carriers = $capabilitiesRepository->getContractDefinitions();
         } catch (Throwable $exception) {
-            // Re-throw so the migration is not marked as applied, letting it retry on the next
-            // load instead of leaving the carriers on the old shape.
-            Logger::warning('Failed to refresh carrier capabilities; migration will retry.', [
-                'exception' => $exception->getMessage(),
+            // Reporting failure leaves the migration unrecorded, so it is attempted again on the
+            // next load. Throwing would do that too, but it would take the page down with it.
+            $this->markFailed('Failed to refresh carrier capabilities.', [
+                'message' => $exception->getMessage(),
+                'file'    => $exception->getFile() . ':' . $exception->getLine(),
+                'class'   => get_class($exception),
+                'trace'   => $exception->getTraceAsString(),
             ]);
 
-            throw $exception;
+            return;
         }
 
         $accountRepository->store($account);

--- a/tests/Unit/Migration/MigrationDiscoveryTest.php
+++ b/tests/Unit/Migration/MigrationDiscoveryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Migration;
+
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockWcPdkInstance());
+
+/**
+ * The installer only runs timestamped migrations it finds on disk, and it looks in
+ * migrationDirectory. The PDK default resolves against the PDK package instead of the plugin, so
+ * without the plugin's own value none of its migrations are ever picked up.
+ */
+it('derives the migration directory from the plugin path', function () {
+    // The test bootstrap mocks appInfo, so this asserts the relationship rather than a fixed
+    // path: the directory has to follow the plugin, wherever it is installed.
+    $expected = rtrim(Pdk::getAppInfo()->path, '/') . '/src/Migration';
+
+    expect(Pdk::get('migrationDirectory'))->toBe($expected);
+});
+
+it('keeps the timestamped migrations where the installer looks for them', function () {
+    // Same filename pattern the installer filters on, checked against the real directory: a file
+    // that fails this is a file the installer silently skips.
+    $found = array_map('basename', array_filter(
+        glob(__DIR__ . '/../../../src/Migration/*.php') ?: [],
+        function (string $path): bool {
+            return (bool) preg_match('/^\d{4}_\d{2}_\d{2}_\d{6}_/', pathinfo($path, PATHINFO_FILENAME));
+        }
+    ));
+
+    expect($found)->toContain('2026_07_29_092726_refresh_carrier_capabilities.php');
+});

--- a/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
+++ b/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
@@ -16,6 +16,8 @@ use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
 use MyParcelNL\Pdk\Tests\Api\Response\ExampleGetAccountsResponse;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockApi;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\SdkApi\MockSdkApiHandler;
+use MyParcelNL\Pdk\Tests\SdkApi\Response\ExampleContractDefinitionsResponse;
 use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
 use RuntimeException;
 use function MyParcelNL\Pdk\Tests\mockPdkProperties;
@@ -74,33 +76,51 @@ it('rethrows when fetching carrier definitions fails so the migration retries', 
     expect(fn() => loadRefreshCarrierCapabilitiesMigration()->up())->toThrow(RuntimeException::class);
 });
 
-it('stores the freshly fetched carriers on the shop', function () {
+dataset('insurance shapes from the api', [
+    // What the API sends today. The nested wrapper carries different amounts, so if the wrong
+    // set of limits ever survived, the assertions below would catch it.
+    'flat limits alongside the deprecated nested wrapper' => [
+        [
+            'min'           => ['amount' => 0, 'currency' => 'EUR'],
+            'max'           => ['amount' => 500_000, 'currency' => 'EUR'],
+            'default'       => ['amount' => 0, 'currency' => 'EUR'],
+            'insuredAmount' => [
+                'min'     => ['amount' => 1, 'currency' => 'EUR'],
+                'max'     => ['amount' => 2, 'currency' => 'EUR'],
+                'default' => ['amount' => 3, 'currency' => 'EUR'],
+            ],
+        ],
+    ],
+    // What the API sends once the nested wrapper is removed.
+    'flat limits only'                                   => [
+        [
+            'min'     => ['amount' => 0, 'currency' => 'EUR'],
+            'max'     => ['amount' => 500_000, 'currency' => 'EUR'],
+            'default' => ['amount' => 0, 'currency' => 'EUR'],
+        ],
+    ],
+]);
+
+it('stores only the flat insurance limits', function (array $insurance) {
     TestBootstrapper::hasAccount();
     // The migration forces an account refresh, which calls the accounts endpoint.
     MockApi::enqueue(new ExampleGetAccountsResponse());
-
-    $stubRepo = new class(
-        Pdk::get(StorageInterface::class),
-        Pdk::get(CapabilitiesService::class)
-    ) extends CarrierCapabilitiesRepository {
-        public function getContractDefinitions(?string $carrier = null): CarrierCollection
-        {
-            return new CarrierCollection([
-                [
-                    'carrier' => 'POSTNL',
-                    'options' => [
-                        'insurance' => [
-                            'min'     => ['amount' => 0, 'currency' => 'EUR'],
-                            'max'     => ['amount' => 500_000, 'currency' => 'EUR'],
-                            'default' => ['amount' => 0, 'currency' => 'EUR'],
-                        ],
-                    ],
-                ],
-            ]);
-        }
-    };
-
-    mockPdkProperties([CarrierCapabilitiesRepository::class => $stubRepo]);
+    // Goes through the real CapabilitiesService and repository, so the nested wrapper is
+    // dropped by the code that actually does it rather than by a stub.
+    MockSdkApiHandler::enqueue(new ExampleContractDefinitionsResponse([
+        [
+            'carrier'          => 'POSTNL',
+            'packageTypes'     => ['PACKAGE'],
+            'deliveryTypes'    => ['STANDARD_DELIVERY'],
+            'transactionTypes' => ['B2C'],
+            'options'          => [
+                'insurance' => array_merge(
+                    ['isSelectedByDefault' => false, 'isRequired' => false],
+                    $insurance
+                ),
+            ],
+        ],
+    ]));
 
     loadRefreshCarrierCapabilitiesMigration()->up();
 
@@ -109,11 +129,11 @@ it('stores the freshly fetched carriers on the shop', function () {
     $carrier     = $accountRepo->getAccount()
         ->shops->first()
         ->carriers->firstWhere('carrier', 'POSTNL');
-    $insurance   = $carrier->options->getInsurance();
+    $stored      = $carrier->options->getInsurance();
 
-    // The stored shape is what the admin and the calculator read back, so the flat limits
-    // have to survive being written to storage.
-    expect($insurance->getMax()->getAmount())->toBe(500_000)
-        ->and($insurance->getMin()->getAmount())->toBe(0)
-        ->and($insurance->getInsuredAmount())->toBeNull();
-});
+    // Same stored result either way: the flat limits, and no nested wrapper left behind.
+    expect($stored->getInsuredAmount())->toBeNull()
+        ->and($stored->getMin()->getAmount())->toBe(0)
+        ->and($stored->getMax()->getAmount())->toBe(500_000)
+        ->and($stored->getDefault()->getAmount())->toBe(0);
+})->with('insurance shapes from the api');

--- a/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
+++ b/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
@@ -56,8 +56,11 @@ it('skips without failing when no account or shop is available', function () {
     expect($accountRepo->getAccount())->toBeNull();
 });
 
-it('rethrows when fetching carrier definitions fails so the migration retries', function () {
+it('reports failure instead of throwing when fetching carrier definitions fails', function () {
     TestBootstrapper::hasAccount();
+    // The migration forces an account refresh before it gets as far as the carriers. Without a
+    // response queued that call throws, and the test would pass on the wrong exception.
+    MockApi::enqueue(new ExampleGetAccountsResponse());
 
     $throwingRepo = new class(
         Pdk::get(StorageInterface::class),
@@ -71,9 +74,13 @@ it('rethrows when fetching carrier definitions fails so the migration retries', 
 
     mockPdkProperties([CarrierCapabilitiesRepository::class => $throwingRepo]);
 
-    // Throwing is the only way to retry: the installer marks a migration as applied straight
-    // after up() returns, so swallowing the error would strand the old carrier data.
-    expect(fn() => loadRefreshCarrierCapabilitiesMigration()->up())->toThrow(RuntimeException::class);
+    $migration = loadRefreshCarrierCapabilitiesMigration();
+    $migration->up();
+
+    // Reporting failure keeps the migration out of applied_migrations, so it is attempted again
+    // on the next load. Reaching this line at all is the other half of the point: a carrier API
+    // that is briefly unavailable no longer takes the page down with it.
+    expect($migration->hasFailed())->toBeTrue();
 });
 
 dataset('insurance shapes from the api', [

--- a/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
+++ b/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Migration;
+
+use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\App\Installer\Contract\TimestampedMigrationInterface;
+use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
+use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService;
+use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
+use MyParcelNL\Pdk\Tests\Api\Response\ExampleGetAccountsResponse;
+use MyParcelNL\Pdk\Tests\Bootstrap\MockApi;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use RuntimeException;
+use function MyParcelNL\Pdk\Tests\mockPdkProperties;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockWcPdkInstance());
+
+/**
+ * Loads the migration the same way the installer does: require the file and take the
+ * returned anonymous-class instance.
+ */
+function loadRefreshCarrierCapabilitiesMigration(): TimestampedMigrationInterface
+{
+    return require __DIR__ . '/../../../src/Migration/2026_07_29_092726_refresh_carrier_capabilities.php';
+}
+
+it('is a timestamped migration the installer can discover', function () {
+    $migration = loadRefreshCarrierCapabilitiesMigration();
+
+    // The installer injects identity from the filename, so the migration must accept it
+    // and report it back rather than deriving one itself.
+    $migration->setIdentity('2026_07_29_092726_refresh_carrier_capabilities');
+
+    expect($migration)->toBeInstanceOf(TimestampedMigrationInterface::class)
+        ->and($migration->getId())->toBe('2026_07_29_092726_refresh_carrier_capabilities');
+});
+
+it('skips without failing when no account or shop is available', function () {
+    /** @var PdkAccountRepositoryInterface $accountRepo */
+    $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
+
+    // No account configured, so a forced refresh returns null. Skipping beats fataling:
+    // a fresh install has nothing to refresh.
+    loadRefreshCarrierCapabilitiesMigration()->up();
+
+    expect($accountRepo->getAccount())->toBeNull();
+});
+
+it('rethrows when fetching carrier definitions fails so the migration retries', function () {
+    TestBootstrapper::hasAccount();
+
+    $throwingRepo = new class(
+        Pdk::get(StorageInterface::class),
+        Pdk::get(CapabilitiesService::class)
+    ) extends CarrierCapabilitiesRepository {
+        public function getContractDefinitions(?string $carrier = null): CarrierCollection
+        {
+            throw new RuntimeException('API unavailable');
+        }
+    };
+
+    mockPdkProperties([CarrierCapabilitiesRepository::class => $throwingRepo]);
+
+    // Throwing is the only way to retry: the installer marks a migration as applied straight
+    // after up() returns, so swallowing the error would strand the old carrier data.
+    expect(fn() => loadRefreshCarrierCapabilitiesMigration()->up())->toThrow(RuntimeException::class);
+});
+
+it('stores the freshly fetched carriers on the shop', function () {
+    TestBootstrapper::hasAccount();
+    // The migration forces an account refresh, which calls the accounts endpoint.
+    MockApi::enqueue(new ExampleGetAccountsResponse());
+
+    $stubRepo = new class(
+        Pdk::get(StorageInterface::class),
+        Pdk::get(CapabilitiesService::class)
+    ) extends CarrierCapabilitiesRepository {
+        public function getContractDefinitions(?string $carrier = null): CarrierCollection
+        {
+            return new CarrierCollection([
+                [
+                    'carrier' => 'POSTNL',
+                    'options' => [
+                        'insurance' => [
+                            'min'     => ['amount' => 0, 'currency' => 'EUR'],
+                            'max'     => ['amount' => 500_000, 'currency' => 'EUR'],
+                            'default' => ['amount' => 0, 'currency' => 'EUR'],
+                        ],
+                    ],
+                ],
+            ]);
+        }
+    };
+
+    mockPdkProperties([CarrierCapabilitiesRepository::class => $stubRepo]);
+
+    loadRefreshCarrierCapabilitiesMigration()->up();
+
+    /** @var PdkAccountRepositoryInterface $accountRepo */
+    $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
+    $carrier     = $accountRepo->getAccount()
+        ->shops->first()
+        ->carriers->firstWhere('carrier', 'POSTNL');
+    $insurance   = $carrier->options->getInsurance();
+
+    // The stored shape is what the admin and the calculator read back, so the flat limits
+    // have to survive being written to storage.
+    expect($insurance->getMax()->getAmount())->toBe(500_000)
+        ->and($insurance->getMin()->getAmount())->toBe(0)
+        ->and($insurance->getInsuredAmount())->toBeNull();
+});

--- a/views/backend/admin/package.json
+++ b/views/backend/admin/package.json
@@ -13,10 +13,10 @@
     "test:run": "run ws:test:run \"$(pwd)\" || true"
   },
   "dependencies": {
-    "@myparcel-dev/pdk-admin": "^2.2.0",
-    "@myparcel-dev/pdk-admin-component-tests": "^2.2.0",
-    "@myparcel-dev/pdk-admin-preset-dashicons": "^2.2.0",
-    "@myparcel-dev/pdk-admin-preset-default": "^2.2.0",
+    "@myparcel-dev/pdk-admin": "^2.2.2",
+    "@myparcel-dev/pdk-admin-component-tests": "^2.2.2",
+    "@myparcel-dev/pdk-admin-preset-dashicons": "^2.2.2",
+    "@myparcel-dev/pdk-admin-preset-default": "^2.2.2",
     "@myparcel-dev/ts-utils": "^1.15.0",
     "@tanstack/vue-query": "^4.43.0"
   },

--- a/views/blocks/delivery-options/package.json
+++ b/views/blocks/delivery-options/package.json
@@ -14,7 +14,7 @@
     "clean": "run ws:clean \"$(pwd)\""
   },
   "dependencies": {
-    "@myparcel-dev/pdk-checkout": "^2.1.2"
+    "@myparcel-dev/pdk-checkout": "^2.1.3"
   },
   "devDependencies": {
     "@myparcel-woocommerce/webpack-config": "workspace:*",

--- a/views/frontend/checkout-address-widget/package.json
+++ b/views/frontend/checkout-address-widget/package.json
@@ -21,8 +21,8 @@
     "vite": "^5.0.0"
   },
   "dependencies": {
-    "@myparcel-dev/pdk-checkout": "^2.1.2",
-    "@myparcel-dev/pdk-checkout-common": "^2.1.2",
+    "@myparcel-dev/pdk-checkout": "^2.1.3",
+    "@myparcel-dev/pdk-checkout-common": "^2.1.3",
     "@myparcel-woocommerce/frontend-common": "workspace:^",
     "mypa-address-widget": "^1.9.0"
   }

--- a/views/frontend/checkout-core/package.json
+++ b/views/frontend/checkout-core/package.json
@@ -14,7 +14,7 @@
     "test:run": "run ws:test:run \"$(pwd)\""
   },
   "dependencies": {
-    "@myparcel-dev/pdk-checkout": "^2.1.2",
+    "@myparcel-dev/pdk-checkout": "^2.1.3",
     "@myparcel-woocommerce/frontend-common": "workspace:^"
   },
   "devDependencies": {

--- a/views/frontend/checkout-delivery-options/package.json
+++ b/views/frontend/checkout-delivery-options/package.json
@@ -13,7 +13,7 @@
     "test:run": "run ws:test:run \"$(pwd)\""
   },
   "dependencies": {
-    "@myparcel-dev/pdk-checkout": "^2.1.2",
+    "@myparcel-dev/pdk-checkout": "^2.1.3",
     "@myparcel-dev/ts-utils": "^1.15.0"
   },
   "devDependencies": {

--- a/views/frontend/checkout-separate-address-fields/package.json
+++ b/views/frontend/checkout-separate-address-fields/package.json
@@ -13,7 +13,7 @@
     "test:run": "run ws:test:run \"$(pwd)\""
   },
   "dependencies": {
-    "@myparcel-dev/pdk-checkout": "^2.1.2",
+    "@myparcel-dev/pdk-checkout": "^2.1.3",
     "@myparcel-dev/ts-utils": "^1.15.0"
   },
   "devDependencies": {

--- a/views/frontend/checkout-tax-fields/package.json
+++ b/views/frontend/checkout-tax-fields/package.json
@@ -13,7 +13,7 @@
     "test:run": "run ws:test:run \"$(pwd)\""
   },
   "dependencies": {
-    "@myparcel-dev/pdk-checkout": "^2.1.2",
+    "@myparcel-dev/pdk-checkout": "^2.1.3",
     "@myparcel-dev/ts-utils": "^1.15.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,7 +48,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ampproject/remapping@npm:^2.2.0, @ampproject/remapping@npm:^2.2.1, @ampproject/remapping@npm:^2.3.0":
+"@ampproject/remapping@npm:^2.2.0, @ampproject/remapping@npm:^2.2.1":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
   dependencies:
@@ -1017,6 +1017,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.24.7, @babel/parser@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/parser@npm:7.29.8"
+  dependencies:
+    "@babel/types": "npm:^7.29.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/acc890c5e6a6dd40863a47b50bac111d7185ee6fbbe163ebe11d5214854ca2adb901462ad4d718a65090ef84bd2230e9e8ab45a2e0caccc685f1f57ab0bb1e28
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/parser@npm:7.27.2"
@@ -1047,17 +1058,6 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/f06920c819550c0db689e4c5b626bf55ba3cebf80ebe9ccfa434e134036cf3de50951fe759f74abb2dae381989239860bde46d4600328578ad1f7114c3711a6d
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.29.7, @babel/parser@npm:^7.29.8":
-  version: 7.29.8
-  resolution: "@babel/parser@npm:7.29.8"
-  dependencies:
-    "@babel/types": "npm:^7.29.8"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/acc890c5e6a6dd40863a47b50bac111d7185ee6fbbe163ebe11d5214854ca2adb901462ad4d718a65090ef84bd2230e9e8ab45a2e0caccc685f1f57ab0bb1e28
   languageName: node
   linkType: hard
 
@@ -3455,13 +3455,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/figures@npm:^1.0.3":
-  version: 1.0.7
-  resolution: "@inquirer/figures@npm:1.0.7"
-  checksum: 10c0/d7b4cfcd38dd43d1ac79da52c4478aa89145207004a471aa2083856f1d9b99adef45563f09d66c09d6457b09200fcf784527804b70ad3bd517cbc5e11142c2df
-  languageName: node
-  linkType: hard
-
 "@isaacs/balanced-match@npm:^4.0.1":
   version: 4.0.1
   resolution: "@isaacs/balanced-match@npm:4.0.1"
@@ -4073,22 +4066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@myparcel-dev/delivery-options@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "@myparcel-dev/delivery-options@npm:6.25.0"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.9.0"
-    "@myparcel-dev/do-shared": "npm:^6.25.0"
-    "@myparcel-dev/sdk": "npm:^5.0.0"
-    "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@vueuse/core": "npm:^10.0.0"
-    leaflet: "npm:^1.9.4"
-    radash: "npm:^12.0.0"
-    vue: "npm:^3.5.26"
-  checksum: 10c0/0a1324d312fb8a5a77298d7a32b6acaefa20269fc73c7f0ac74b2b29097fa48970ad9eeea06ee7eaecf7949502089f0e959b4e0acedb4ab31438c01004357a70
-  languageName: node
-  linkType: hard
-
 "@myparcel-dev/delivery-options@npm:^7.5.0":
   version: 7.5.0
   resolution: "@myparcel-dev/delivery-options@npm:7.5.0"
@@ -4102,24 +4079,6 @@ __metadata:
     radash: "npm:^12.0.0"
     vue: "npm:^3.5.26"
   checksum: 10c0/e9111baf69d10216d6c2f1a9f73382a92f0f62ea0bd42166197a155ce03f8fbec580bacca77106fee656b31b9704f4d453d4b9662df27cd87496235c42c87869
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/do-shared@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "@myparcel-dev/do-shared@npm:6.25.0"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.9.0"
-    "@myparcel-dev/do-shared": "npm:^6.25.0"
-    "@myparcel-dev/sdk": "npm:^5.0.0"
-    "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@vueuse/core": "npm:^10.6.0"
-    date-fns: "npm:^3.0.0"
-    pinia: "npm:^2.1.7"
-    radash: "npm:^12.0.0"
-    vue: "npm:^3.5.26"
-    vue-tsc: "npm:^3.2.2"
-  checksum: 10c0/c87b42eabf563930727cf0ecec251ed15331f30d58105eada807f70094cfe12a13546162db6ea0f6875bec847c263747f1b622117f292b564fb164b5af1b3a03
   languageName: node
   linkType: hard
 
@@ -4302,54 +4261,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin-component-tests@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin-component-tests@npm:2.2.0"
+"@myparcel-dev/pdk-admin-component-tests@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin-component-tests@npm:2.2.2"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
     "@pinia/testing": "npm:>= 0.1.0 < 1"
-    "@vitest/coverage-v8": "npm:^2.1.3"
     "@vue/test-utils": "npm:^2.0.0"
-    happy-dom: "npm:^14.0.0"
     pinia: "npm:^2.0.0"
     vitest: "npm:^3.2.6"
   peerDependencies:
-    vue: 3.5.40
-  checksum: 10c0/96802eccf8f358114d8855a5932c0b5443230c95f7112c6917ace71816cededbaaca92471301740c280a212086b9d3bc47219eeff50befefdea1880293b9ccda
+    vue: 3.4.31
+  checksum: 10c0/494c90aff41f506fb2bbca8dee18d6607e328a300d1dd319fe9a8f47f2e487d813fc3a9b4066eaf6e5bc8c8c91778fce0f367e802484a34889c3f53c63879905
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin-preset-dashicons@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin-preset-dashicons@npm:2.2.0"
+"@myparcel-dev/pdk-admin-preset-dashicons@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin-preset-dashicons@npm:2.2.2"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
-    vite: "npm:^5.4.10"
-    vue: "npm:3.5.40"
-    vue-tsc: "npm:^3.3.9"
-  checksum: 10c0/67d18b46ca07efc7cc1dd39011d2e66c9a4673330582d96e9f288a3ed4e9ad3431e0937abf2131dca1fe0f80a09765b02f7d4eef59e0be8d294e600f7063e029
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
+    vue: "npm:3.4.31"
+  checksum: 10c0/94d70112aefa9137a6bd61771cacc066c6283cd1ec37dde469ec51b6aac0ae6c352631bc5e599af5bb85f95027d1b7a2da1c8897edaab4b94601a981bc7bbfee
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin-preset-default@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin-preset-default@npm:2.2.0"
+"@myparcel-dev/pdk-admin-preset-default@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin-preset-default@npm:2.2.2"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
     "@vuepic/vue-datepicker": "npm:^11.0.2"
     "@vueuse/core": "npm:^10.0.0"
-    vue: "npm:3.5.40"
-  checksum: 10c0/951a2a03b7d68b8c1f082094ed888b1f0dfba8c298667007c90dc37d0637f0b15b46f9dc8180470daf8e5e963350f5cc89fc768b89811d660036dd00dba8358e
+    vue: "npm:3.4.31"
+  checksum: 10c0/edd7c4acd0f1991cb2094b73c8b749d85fbede2331483af81c675a90a7a88c5495441817cda7ad32ca9ba04cf85664e5e6a1327b96dcfeaf9136e5d9e01739df
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-admin@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@myparcel-dev/pdk-admin@npm:2.2.0"
+"@myparcel-dev/pdk-admin@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@myparcel-dev/pdk-admin@npm:2.2.2"
   dependencies:
     "@myparcel-dev/constants": "npm:^2.9.0"
-    "@myparcel-dev/pdk-common": "npm:^2.1.0"
+    "@myparcel-dev/pdk-common": "npm:^2.1.2"
     "@myparcel-dev/sdk": "npm:^5.1.0"
     "@myparcel-dev/vue-form-builder": "npm:1.0.0-beta.42.6"
     "@tanstack/vue-query": "npm:~4.43.0"
@@ -4358,106 +4313,90 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     lodash-unified: "npm:^1.0.3"
     pinia: "npm:^2.0.0"
-    vite: "npm:^5.4.10"
-    vue: "npm:3.5.40"
-    vue-tsc: "npm:^3.3.9"
-  checksum: 10c0/490b24f11cafd5eceeace17569730f709ce45af03eff897a94a16a66998dbc5102e2e251bb4ba4bb7487236696c34ee717ed352e5a3f1b97c0912c6e0e5ee900
+    vue: "npm:3.4.31"
+  checksum: 10c0/1ce74ea9217e6d1b9ca2c01f89f450d2e635095c5e0d3b6700840390d704c460f7f9010b54700f72ada3af5d229268c9920d575c3d6741077ee3985f69d4bd33
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-app-builder@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@myparcel-dev/pdk-app-builder@npm:4.1.0"
+"@myparcel-dev/pdk-app-builder@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@myparcel-dev/pdk-app-builder@npm:4.1.3"
   dependencies:
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
-    "@yarnpkg/parsers": "npm:^3.0.0"
-    chalk: "npm:^5.2.0"
+    chalk: "npm:^6.0.0"
     commander: "npm:^12.0.0"
     debug: "npm:^4.3.4"
-    inquirer: "npm:^9.1.4"
     interpret: "npm:^3.1.1"
     liftoff: "npm:^5.0.0"
     mypa-google-docs-importer: "npm:^1.0.1"
     radash: "npm:^12.1.0"
-    semver: "npm:^7.5.4"
-    supports-color: "npm:^9.3.1"
   bin:
     pdk-builder: ./bin/index.js
-  checksum: 10c0/cdba62074a2832d2344ee3b6e754aa981ca91fedef7945bde74290e3d1c0ab0becc24cca29de968f1821dc9d63272b05eef5be5ad05eb37fa74528cb64f9658c
+  checksum: 10c0/2971cc27bd2de26fc33e576cb869308d71854eac2ee5097f47f9d97704c6b7cd98e0693d9f22dd6aa1062e883023ea32a11c81008e6b7beda5d2cf0b6c891c29
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-common@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@myparcel-dev/pdk-checkout-common@npm:2.1.2"
+"@myparcel-dev/pdk-checkout-common@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-common@npm:2.1.3"
   dependencies:
     "@myparcel-dev/constants": "npm:^2.7.0"
     "@myparcel-dev/delivery-options": "npm:^7.5.0"
-    "@myparcel-dev/pdk-common": "npm:^2.1.1"
+    "@myparcel-dev/pdk-common": "npm:^2.1.2"
     radash: "npm:^12.1.0"
-  checksum: 10c0/d4aaa1c56aaa1374202ced3a1e18e5f70ba99b355e8bfe64d0df407b1ac6ee259d9a3464454ae68547077bae472e51ed5924e3006fee227ec8b305c71fc2ed2b
+  checksum: 10c0/27a02da43388892ca62c9e15b298c9e44501ccc376ca85111c19db14917fcfbae4467d10552053959a27e81c3960f23e77e1c6716872e540615099f3b5b3bf38
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-delivery-options@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@myparcel-dev/pdk-checkout-delivery-options@npm:2.1.2"
+"@myparcel-dev/pdk-checkout-delivery-options@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-delivery-options@npm:2.1.3"
   dependencies:
     "@myparcel-dev/delivery-options": "npm:^7.5.0"
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.2"
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
-  checksum: 10c0/de687c37afe3cc8e700c76aec2974db13048d4bcea21783e8e93ecfefc6217edf39025511b5b9aa4041c783f34776bda70053e32538e4118af9ed0fd6f673f20
+  checksum: 10c0/c27158b0cd22d7fc218e9b463f235a9603f49da913b1ed7c3056b06372ccff4d756829aa7a34602b2ea92dcd2e5be177028183b69df96895dbc2fe0fa7704edf
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-separate-address-fields@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@myparcel-dev/pdk-checkout-separate-address-fields@npm:2.1.2"
+"@myparcel-dev/pdk-checkout-separate-address-fields@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-separate-address-fields@npm:2.1.3"
   dependencies:
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.2"
-  checksum: 10c0/808d0b0066b5505d4a47004b7f8b35d6ef5f97378b47ccb2febb33e9d885f1aa227431ad718e111a7a44ee09e9ac86345669d379e413e3041eee0a566d37b20d
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
+  checksum: 10c0/0aefc39a60e7367a341a257c46da0509571085b0671bde14e7db5ec0200b9262abc36b2be50633ab5208ddbc5c07e080deb0fd77aa6e0c921f516593b8a47909
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-checkout-tax-fields@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@myparcel-dev/pdk-checkout-tax-fields@npm:2.1.2"
-  dependencies:
-    "@myparcel-dev/constants": "npm:^2.7.0"
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.2"
-  checksum: 10c0/8560a987b8d0e075c8acc4b245a79203023c76b44e7d024155995a526a1b5bfea2b9f25cc723d72082ae5e4aab6a8b6ac31f3093adeaae385812b6c03144e1cf
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/pdk-checkout@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@myparcel-dev/pdk-checkout@npm:2.1.2"
-  dependencies:
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.2"
-    "@myparcel-dev/pdk-checkout-delivery-options": "npm:^2.1.2"
-    "@myparcel-dev/pdk-checkout-separate-address-fields": "npm:^2.1.2"
-    "@myparcel-dev/pdk-checkout-tax-fields": "npm:^2.1.2"
-  checksum: 10c0/e1b156b2a47a6d128c7b0f300b37502672254cb0ee78738c4e906a67f11c797388d539eaad8970a1fd4541914cf8b30dc1963583e20f9a7f2f684273c9055f7f
-  languageName: node
-  linkType: hard
-
-"@myparcel-dev/pdk-common@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@myparcel-dev/pdk-common@npm:2.1.0"
+"@myparcel-dev/pdk-checkout-tax-fields@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout-tax-fields@npm:2.1.3"
   dependencies:
     "@myparcel-dev/constants": "npm:^2.7.0"
-    "@myparcel-dev/delivery-options": "npm:^6.25.0"
-  checksum: 10c0/85f2fb01fc896afa8c3f0acda77b44f918e830aa09eb3baca2c420973b3de5b9ea5377924509f59dc6fac658e2ca6b4fd8218bbd2ed7c39f1c1d59f21dd7de27
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
+  checksum: 10c0/6ed73e505629206892334a7388a867bd50c9373b646b5b5079158ae5f35f2905a3dade35cdbb2e79d2890d19dcbad6bdfaa8edf7b84317b12ed37c359993135b
   languageName: node
   linkType: hard
 
-"@myparcel-dev/pdk-common@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@myparcel-dev/pdk-common@npm:2.1.1"
+"@myparcel-dev/pdk-checkout@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "@myparcel-dev/pdk-checkout@npm:2.1.3"
+  dependencies:
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
+    "@myparcel-dev/pdk-checkout-delivery-options": "npm:^2.1.3"
+    "@myparcel-dev/pdk-checkout-separate-address-fields": "npm:^2.1.3"
+    "@myparcel-dev/pdk-checkout-tax-fields": "npm:^2.1.3"
+  checksum: 10c0/a73cf17da47238aea09a38adab5ed5d9b7c0117b10a907512a55bc3432aa34bd163dc4fdc9142028f5beda5a75ae8ec65325561ce56e684fdddffacaa867fe48
+  languageName: node
+  linkType: hard
+
+"@myparcel-dev/pdk-common@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@myparcel-dev/pdk-common@npm:2.1.2"
   dependencies:
     "@myparcel-dev/constants": "npm:^2.7.0"
     "@myparcel-dev/delivery-options": "npm:^7.5.0"
-  checksum: 10c0/911422dbfd767987688134f2d313663af43d67b8468125f537426b2e705f2057ebcfc610b3d6b610e9148292f4230133cbca1e8e3e8aaed856b3a40524559704
+  checksum: 10c0/b696de2d6dcb1d1209d765acdba1b9339c1fa009ee44c66a7e9714bb74d6f4293093f9af5f45d9421b957d1282755e494d8d7557623f5ff69b908b4f8272949d
   languageName: node
   linkType: hard
 
@@ -4615,8 +4554,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-woocommerce/address-widget@workspace:views/frontend/checkout-address-widget"
   dependencies:
-    "@myparcel-dev/pdk-checkout": "npm:^2.1.2"
-    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.2"
+    "@myparcel-dev/pdk-checkout": "npm:^2.1.3"
+    "@myparcel-dev/pdk-checkout-common": "npm:^2.1.3"
     "@myparcel-woocommerce/frontend-common": "workspace:^"
     "@myparcel-woocommerce/vite-config": "workspace:*"
     "@types/jquery": "npm:^3.5.16"
@@ -4630,10 +4569,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-woocommerce/backend-admin@workspace:views/backend/admin"
   dependencies:
-    "@myparcel-dev/pdk-admin": "npm:^2.2.0"
-    "@myparcel-dev/pdk-admin-component-tests": "npm:^2.2.0"
-    "@myparcel-dev/pdk-admin-preset-dashicons": "npm:^2.2.0"
-    "@myparcel-dev/pdk-admin-preset-default": "npm:^2.2.0"
+    "@myparcel-dev/pdk-admin": "npm:^2.2.2"
+    "@myparcel-dev/pdk-admin-component-tests": "npm:^2.2.2"
+    "@myparcel-dev/pdk-admin-preset-dashicons": "npm:^2.2.2"
+    "@myparcel-dev/pdk-admin-preset-default": "npm:^2.2.2"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
     "@myparcel-woocommerce/vite-config": "workspace:*"
     "@tanstack/vue-query": "npm:^4.43.0"
@@ -4658,7 +4597,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-woocommerce/block-delivery-options@workspace:views/blocks/delivery-options"
   dependencies:
-    "@myparcel-dev/pdk-checkout": "npm:^2.1.2"
+    "@myparcel-dev/pdk-checkout": "npm:^2.1.3"
     "@myparcel-woocommerce/webpack-config": "workspace:*"
     "@woocommerce/block-library": "npm:^2.3.0"
     "@woocommerce/settings": "npm:^1.0.0"
@@ -4677,7 +4616,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-woocommerce/frontend-checkout-core@workspace:views/frontend/checkout-core"
   dependencies:
-    "@myparcel-dev/pdk-checkout": "npm:^2.1.2"
+    "@myparcel-dev/pdk-checkout": "npm:^2.1.3"
     "@myparcel-woocommerce/frontend-common": "workspace:^"
     "@myparcel-woocommerce/vite-config": "workspace:*"
     "@types/jquery": "npm:^3.5.16"
@@ -4690,7 +4629,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-woocommerce/frontend-checkout-delivery-options@workspace:views/frontend/checkout-delivery-options"
   dependencies:
-    "@myparcel-dev/pdk-checkout": "npm:^2.1.2"
+    "@myparcel-dev/pdk-checkout": "npm:^2.1.3"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
     "@myparcel-woocommerce/frontend-common": "workspace:*"
     "@myparcel-woocommerce/vite-config": "workspace:*"
@@ -4705,7 +4644,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-woocommerce/frontend-checkout-separate-address-fields@workspace:views/frontend/checkout-separate-address-fields"
   dependencies:
-    "@myparcel-dev/pdk-checkout": "npm:^2.1.2"
+    "@myparcel-dev/pdk-checkout": "npm:^2.1.3"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
     "@myparcel-woocommerce/frontend-common": "workspace:*"
     "@myparcel-woocommerce/vite-config": "workspace:*"
@@ -4720,7 +4659,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@myparcel-woocommerce/frontend-checkout-tax-fields@workspace:views/frontend/checkout-tax-fields"
   dependencies:
-    "@myparcel-dev/pdk-checkout": "npm:^2.1.2"
+    "@myparcel-dev/pdk-checkout": "npm:^2.1.3"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
     "@myparcel-woocommerce/frontend-common": "workspace:*"
     "@myparcel-woocommerce/vite-config": "workspace:*"
@@ -4749,7 +4688,7 @@ __metadata:
     "@myparcel-dev/eslint-config-prettier": "npm:^1.4.0"
     "@myparcel-dev/eslint-config-prettier-typescript": "npm:^1.4.0"
     "@myparcel-dev/eslint-config-prettier-typescript-vue": "npm:^1.4.0"
-    "@myparcel-dev/pdk-app-builder": "npm:^4.1.0"
+    "@myparcel-dev/pdk-app-builder": "npm:^4.1.3"
     "@myparcel-dev/semantic-release-config": "npm:^6.0.10"
     "@myparcel-dev/semantic-release-wordpress-readme-generator": "npm:^1.3.0"
     "@semantic-release/git": "npm:^10.0.1"
@@ -8942,32 +8881,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^2.1.3":
-  version: 2.1.4
-  resolution: "@vitest/coverage-v8@npm:2.1.4"
-  dependencies:
-    "@ampproject/remapping": "npm:^2.3.0"
-    "@bcoe/v8-coverage": "npm:^0.2.3"
-    debug: "npm:^4.3.7"
-    istanbul-lib-coverage: "npm:^3.2.2"
-    istanbul-lib-report: "npm:^3.0.1"
-    istanbul-lib-source-maps: "npm:^5.0.6"
-    istanbul-reports: "npm:^3.1.7"
-    magic-string: "npm:^0.30.12"
-    magicast: "npm:^0.3.5"
-    std-env: "npm:^3.7.0"
-    test-exclude: "npm:^7.0.1"
-    tinyrainbow: "npm:^1.2.0"
-  peerDependencies:
-    "@vitest/browser": 2.1.4
-    vitest: 2.1.4
-  peerDependenciesMeta:
-    "@vitest/browser":
-      optional: true
-  checksum: 10c0/f795fdd645ccc46de45baa431a1b3b216d74195b9751cb0498009b8ef929dcd48c2f858570d421908549f5a631ac2931f7c7f3fe4ff0bc80707805beda5c18d7
-  languageName: node
-  linkType: hard
-
 "@vitest/expect@npm:1.6.0":
   version: 1.6.0
   resolution: "@vitest/expect@npm:1.6.0"
@@ -9114,26 +9027,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@volar/language-core@npm:2.4.28":
-  version: 2.4.28
-  resolution: "@volar/language-core@npm:2.4.28"
-  dependencies:
-    "@volar/source-map": "npm:2.4.28"
-  checksum: 10c0/d41f7327fed7fa5301fbf2d8f96753d645a976b21dbbeb869794a780aa6523d1e6bf258242bc3d8ccd37f8e8b98a04fea9574e6f63badc585a8a3c2e068c4a86
-  languageName: node
-  linkType: hard
-
 "@volar/source-map@npm:2.4.27":
   version: 2.4.27
   resolution: "@volar/source-map@npm:2.4.27"
   checksum: 10c0/717db4d98cf70a9a12fcde71fb92854d19d3aa0e62b7343865c7bb624a5f691579e5f8b8d33f851cf6bebb8a69de372d12586b6f66947ed65b9ad58fdad941bf
-  languageName: node
-  linkType: hard
-
-"@volar/source-map@npm:2.4.28":
-  version: 2.4.28
-  resolution: "@volar/source-map@npm:2.4.28"
-  checksum: 10c0/24b0b02c7f66febe47f0bfda4a5ed4beaf949041eddc6325c7478b900faeb071795b696d97a4f326dde47217d06e40b67129300bc544f054772c5cb84c2f254e
   languageName: node
   linkType: hard
 
@@ -9148,14 +9045,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@volar/typescript@npm:2.4.28":
-  version: 2.4.28
-  resolution: "@volar/typescript@npm:2.4.28"
+"@vue/compiler-core@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-core@npm:3.4.31"
   dependencies:
-    "@volar/language-core": "npm:2.4.28"
-    path-browserify: "npm:^1.0.1"
-    vscode-uri: "npm:^3.0.8"
-  checksum: 10c0/075c890b9ec1cb17f17e38aaed035f8ee7d507439e87270d8e3c394356fc9387fd0bda9ec1069b36ea4c378d9375a08f5bc64c063a83427010ddd86d472124fc
+    "@babel/parser": "npm:^7.24.7"
+    "@vue/shared": "npm:3.4.31"
+    entities: "npm:^4.5.0"
+    estree-walker: "npm:^2.0.2"
+    source-map-js: "npm:^1.2.0"
+  checksum: 10c0/17833fa55af0168da4ec79b1233aba2bf6df9a88cd95be513a122f3433901e70284ce467a504a36547debdf49f887cf807734360a7660fd8f7622bf15c74b01d
   languageName: node
   linkType: hard
 
@@ -9172,19 +9071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-core@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-core@npm:3.5.40"
-  dependencies:
-    "@babel/parser": "npm:^7.29.7"
-    "@vue/shared": "npm:3.5.40"
-    entities: "npm:^7.0.1"
-    estree-walker: "npm:^2.0.2"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/695744e23cebf18bef6fc07d51d76c173dcbb79829a10cd0424b3e7ea540ef400974ecc8d0dfd684955c1d16b47adbd33fcc01d04eef2c9d549c415d4b3b7a9d
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-core@npm:3.5.41":
   version: 3.5.41
   resolution: "@vue/compiler-core@npm:3.5.41"
@@ -9198,13 +9084,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-dom@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-dom@npm:3.5.40"
+"@vue/compiler-dom@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-dom@npm:3.4.31"
   dependencies:
-    "@vue/compiler-core": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/2b8a6d89fac89f1b880c18004a392b190555d9a5c882b804755a560c8ca84eefa771015c757d478dcd3323c0ea5a34025a7a641a06434a80ee4b978d8fd011ed
+    "@vue/compiler-core": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/136b2208685d7d67e282a7da5f377f40878c467832789be21aadbe322832541aa20a4e2d0c5faa57b4f5608067eeb680d123fdb08c2ef9b28f0d6a94a3d79dbc
   languageName: node
   linkType: hard
 
@@ -9228,20 +9114,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-sfc@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-sfc@npm:3.5.40"
+"@vue/compiler-sfc@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-sfc@npm:3.4.31"
   dependencies:
-    "@babel/parser": "npm:^7.29.7"
-    "@vue/compiler-core": "npm:3.5.40"
-    "@vue/compiler-dom": "npm:3.5.40"
-    "@vue/compiler-ssr": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
+    "@babel/parser": "npm:^7.24.7"
+    "@vue/compiler-core": "npm:3.4.31"
+    "@vue/compiler-dom": "npm:3.4.31"
+    "@vue/compiler-ssr": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
     estree-walker: "npm:^2.0.2"
-    magic-string: "npm:^0.30.21"
-    postcss: "npm:^8.5.19"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7cbdacee87c2fd20087747ef95a4a52d7406cb24b76757a7734f7d3efe88292623e81a706a5ca9e626ed3e160dedb4a01a302ecf7707db7ebd7b16a2fb01f11c
+    magic-string: "npm:^0.30.10"
+    postcss: "npm:^8.4.38"
+    source-map-js: "npm:^1.2.0"
+  checksum: 10c0/b8983a52dd3d5d7f9640dbda5946f01fcb92213a6c3a9a76d1df8f67fd43c59402ab6ff4211a205bf91155c4cd2a45fb39c36a83199bc1256eaeb9f690895b73
   languageName: node
   linkType: hard
 
@@ -9262,13 +9148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-ssr@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/compiler-ssr@npm:3.5.40"
+"@vue/compiler-ssr@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/compiler-ssr@npm:3.4.31"
   dependencies:
-    "@vue/compiler-dom": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/934fcfc2e0b18ce1239bb47db9155f6533eda39e90f56f6a0a4bcb79755dc3fdebe771555496bf043ec54f62f52664085a935725d8e479873481c08dabff4ee9
+    "@vue/compiler-dom": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/8083959c21b344f8ee5029c0ea91d50118a32b7c7c430971a721785b0349ce92d82d9cf17d7991a283f79b4ec1c68db4d1d182e035c17aa9116aa07ee115bac0
   languageName: node
   linkType: hard
 
@@ -9322,27 +9208,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/language-core@npm:3.3.9":
-  version: 3.3.9
-  resolution: "@vue/language-core@npm:3.3.9"
+"@vue/reactivity@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/reactivity@npm:3.4.31"
   dependencies:
-    "@volar/language-core": "npm:2.4.28"
-    "@vue/compiler-dom": "npm:^3.5.0"
-    "@vue/shared": "npm:^3.5.0"
-    alien-signals: "npm:^3.2.1"
-    muggle-string: "npm:^0.4.1"
-    path-browserify: "npm:^1.0.1"
-    picomatch: "npm:^4.0.4"
-  checksum: 10c0/bff339e8ce218d32b8db7a372c1f958db52950e74bbedff527e928b68e52fad30c14e0652dc2626673a579cab15b47d8106eac0deefc7898f370da7889122bba
-  languageName: node
-  linkType: hard
-
-"@vue/reactivity@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/reactivity@npm:3.5.40"
-  dependencies:
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/cbefefe6aee3fce6cdf04fcb8c36eab0b47581af499b51a3b19fe9358ab98366b1edd38fefe6059b38284879053656c4e4c0656396426880f255c90eada8b443
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/974ce9c9f26367845d71ab37aa5644b06f5e8e938ebe343004a8cb700505350da70fd315f39aecc46ffa62c474e3fb947529bd3981b66efab8ab45c34189a334
   languageName: node
   linkType: hard
 
@@ -9355,13 +9226,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/runtime-core@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/runtime-core@npm:3.5.40"
+"@vue/runtime-core@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/runtime-core@npm:3.4.31"
   dependencies:
-    "@vue/reactivity": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/e1dada4b25a4467073dd71516dcf8be4224c571df36a5b7dd193c6a12171c0c0ae7645fbb3d508ddd417af472b10e1c10c1efe70cdce99b7da03558e6bcd6119
+    "@vue/reactivity": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  checksum: 10c0/446711364e34520d5f38133950ecb27ede0d235fabb74237b51dc6ef22cce1b5db94033acbf6fc485c2dd3034862492eb247d267487bd36c88cb4ad151ffaf3c
   languageName: node
   linkType: hard
 
@@ -9375,15 +9246,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/runtime-dom@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/runtime-dom@npm:3.5.40"
+"@vue/runtime-dom@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/runtime-dom@npm:3.4.31"
   dependencies:
-    "@vue/reactivity": "npm:3.5.40"
-    "@vue/runtime-core": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-    csstype: "npm:^3.2.3"
-  checksum: 10c0/a397ee1e7964fe7791a3e6456c7bd0a3c85c6c156971a172cfabba5009457885b14060c7aad12c7db7f6f0f35c0d94921b45314994b010e2b454a44b89e9a281
+    "@vue/reactivity": "npm:3.4.31"
+    "@vue/runtime-core": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+    csstype: "npm:^3.1.3"
+  checksum: 10c0/4c0b20f16ad3a676d1a61b07f24d1668166e5b0cc133344eafcecde308952d577005fc4a1fa77fd055dffce5dbacbd4577688f2dc151ac0f2f6e1d31529fdfc6
   languageName: node
   linkType: hard
 
@@ -9399,14 +9270,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/server-renderer@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/server-renderer@npm:3.5.40"
+"@vue/server-renderer@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/server-renderer@npm:3.4.31"
   dependencies:
-    "@vue/compiler-ssr": "npm:3.5.40"
-    "@vue/runtime-dom": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
-  checksum: 10c0/b991a7b0a03c9e4d1968e62d64495d988c0ed027826ac2be02b1461db42fdebaa80dd950132d0fedb96c4511eab6940d83799faa769d6f10945ad0c1f839ad75
+    "@vue/compiler-ssr": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
+  peerDependencies:
+    vue: 3.4.31
+  checksum: 10c0/1e01142c2f7b6ee9b1e94a25142452fc60ef7fbdd47b4c145db001fbfd20e5c9fab97a74d7c0978b4a0beacc043f330524623b22f1bd7faa353c41feb824c549
   languageName: node
   linkType: hard
 
@@ -9421,17 +9293,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/shared@npm:3.4.31":
+  version: 3.4.31
+  resolution: "@vue/shared@npm:3.4.31"
+  checksum: 10c0/45643c0c7aa6b208891aac5798629ee5b982a5e52343c0a23ecc15b7aeb580b606ce78e70daee0fd691ccddb5f10196c4d56c7da4b8716157be1772a43f1c45e
+  languageName: node
+  linkType: hard
+
 "@vue/shared@npm:3.5.27, @vue/shared@npm:^3.5.0":
   version: 3.5.27
   resolution: "@vue/shared@npm:3.5.27"
   checksum: 10c0/c80a84464530d51cf3d5fa1aab6c3e9717e5901fbc1b8a8eb9962edfc02985c1e03e6dc6d0d205d10cdff067c1c5f689d7156446d2a4c7686a8409a40e3a5f20
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.5.40":
-  version: 3.5.40
-  resolution: "@vue/shared@npm:3.5.40"
-  checksum: 10c0/b18346d3936d2c7b16d01a7c77b0b95fac19f4427bb17e5c968ea4e1c752df5d3f4f2db70b26a28fe033f81522f3cb83ccd13713f4e4f861fedba915b0b3f825
   languageName: node
   linkType: hard
 
@@ -13042,16 +12914,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/parsers@npm:^3.0.0":
-  version: 3.0.2
-  resolution: "@yarnpkg/parsers@npm:3.0.2"
-  dependencies:
-    js-yaml: "npm:^3.10.0"
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/a0c340e13129643162423d7e666061c0b39b143bfad3fc5a74c7d92a30fd740f6665d41cd4e61832c20375889d793eea1d1d103cacb39ed68f7acd168add8c53
-  languageName: node
-  linkType: hard
-
 "@zkochan/js-yaml@npm:0.0.6":
   version: 0.0.6
   resolution: "@zkochan/js-yaml@npm:0.0.6"
@@ -13332,13 +13194,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"alien-signals@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "alien-signals@npm:3.2.1"
-  checksum: 10c0/4c4064faa208126177224d1ed6a2310687d452dec0771994e276d9af4c72e853fcb969ae4a7fcd034b1d1b9accb9500f4941178326eeea1cb8f64ec612853ef8
-  languageName: node
-  linkType: hard
-
 "ansi-colors@npm:^4.1.1":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
@@ -13346,7 +13201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.2":
+"ansi-escapes@npm:^4.2.1":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -14281,7 +14136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.3, bl@npm:^4.1.0":
+"bl@npm:^4.0.3":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -14835,6 +14690,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "chalk@npm:6.0.0"
+  checksum: 10c0/47fd9028aa66fa532295525fe3ac5aec5e467e0d86847d4b5f6e01f9c9bb70b6fd1edca79cddc78a0f31a357baa65cc752d30c6557d025904207d113c82d8962
+  languageName: node
+  linkType: hard
+
 "change-case@npm:4.1.2, change-case@npm:^4.1.2":
   version: 4.1.2
   resolution: "change-case@npm:4.1.2"
@@ -14880,13 +14742,6 @@ __metadata:
   version: 1.1.4
   resolution: "character-reference-invalid@npm:1.1.4"
   checksum: 10c0/29f05081c5817bd1e975b0bf61e77b60a40f62ad371d0f0ce0fdb48ab922278bc744d1fbe33771dced751887a8403f265ff634542675c8d7375f6ff4811efd0e
-  languageName: node
-  linkType: hard
-
-"chardet@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "chardet@npm:0.7.0"
-  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
   languageName: node
   linkType: hard
 
@@ -15208,13 +15063,6 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^7.0.0"
   checksum: 10c0/d7f0b73e3d9b88cb496e6c086df7410b541b56a43d18ade6a573c9c18bd001b1c3fba1ad578f741a4218fdc794d042385f8ac02c25e1c295a2d8b9f3cb86eb4c
-  languageName: node
-  linkType: hard
-
-"cli-width@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "cli-width@npm:4.1.0"
-  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
   languageName: node
   linkType: hard
 
@@ -16389,7 +16237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.2.2, csstype@npm:^3.2.3":
+"csstype@npm:^3.1.3, csstype@npm:^3.2.2, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
@@ -18924,17 +18772,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"external-editor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "external-editor@npm:3.1.0"
-  dependencies:
-    chardet: "npm:^0.7.0"
-    iconv-lite: "npm:^0.4.24"
-    tmp: "npm:^0.0.33"
-  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
-  languageName: node
-  linkType: hard
-
 "extract-zip@npm:2.0.1, extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
@@ -19940,7 +19777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.3, glob@npm:^10.3.7, glob@npm:^10.4.1":
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.3, glob@npm:^10.3.7":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -20851,7 +20688,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
+"iconv-lite@npm:0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
@@ -21121,26 +20958,6 @@ __metadata:
     validate-npm-package-license: "npm:^3.0.4"
     validate-npm-package-name: "npm:^7.0.0"
   checksum: 10c0/8b0079f714f3a075365644f2e83cd07536e99b5e00de60aa1a28f260f0683be70d83fb556425aa6ebd2ea528a607d6bf2b4983b3c11569342314d92840fb411e
-  languageName: node
-  linkType: hard
-
-"inquirer@npm:^9.1.4":
-  version: 9.3.7
-  resolution: "inquirer@npm:9.3.7"
-  dependencies:
-    "@inquirer/figures": "npm:^1.0.3"
-    ansi-escapes: "npm:^4.3.2"
-    cli-width: "npm:^4.1.0"
-    external-editor: "npm:^3.1.0"
-    mute-stream: "npm:1.0.0"
-    ora: "npm:^5.4.1"
-    run-async: "npm:^3.0.0"
-    rxjs: "npm:^7.8.1"
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-    wrap-ansi: "npm:^6.2.0"
-    yoctocolors-cjs: "npm:^2.1.2"
-  checksum: 10c0/7a5b70312a734b579846648365cbf354e8b23ec73f379d46ada30bc2cf3961dc33b7ca59a3c2beed8a8e03744e3d6c12d4998a34b2d3904774aed238d77328b4
   languageName: node
   linkType: hard
 
@@ -22154,7 +21971,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-source-maps@npm:^5.0.4, istanbul-lib-source-maps@npm:^5.0.6":
+"istanbul-lib-source-maps@npm:^5.0.4":
   version: 5.0.6
   resolution: "istanbul-lib-source-maps@npm:5.0.6"
   dependencies:
@@ -22165,7 +21982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-reports@npm:^3.1.3, istanbul-reports@npm:^3.1.6, istanbul-reports@npm:^3.1.7":
+"istanbul-reports@npm:^3.1.3, istanbul-reports@npm:^3.1.6":
   version: 3.1.7
   resolution: "istanbul-reports@npm:3.1.7"
   dependencies:
@@ -24751,16 +24568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.12, magic-string@npm:^0.30.5":
-  version: 0.30.12
-  resolution: "magic-string@npm:0.30.12"
-  dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
-  checksum: 10c0/469f457d18af37dfcca8617086ea8a65bcd8b60ba8a1182cb024ce43e470ace3c9d1cb6bee58d3b311768fb16bc27bd50bdeebcaa63dadd0fd46cac4d2e11d5f
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21":
+"magic-string@npm:^0.30.10, magic-string@npm:^0.30.17, magic-string@npm:^0.30.21":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -24769,7 +24577,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magicast@npm:^0.3.3, magicast@npm:^0.3.5":
+"magic-string@npm:^0.30.5":
+  version: 0.30.12
+  resolution: "magic-string@npm:0.30.12"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+  checksum: 10c0/469f457d18af37dfcca8617086ea8a65bcd8b60ba8a1182cb024ce43e470ace3c9d1cb6bee58d3b311768fb16bc27bd50bdeebcaa63dadd0fd46cac4d2e11d5f
+  languageName: node
+  linkType: hard
+
+"magicast@npm:^0.3.3":
   version: 0.3.5
   resolution: "magicast@npm:0.3.5"
   dependencies:
@@ -25916,7 +25733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:1.0.0, mute-stream@npm:^1.0.0, mute-stream@npm:~1.0.0":
+"mute-stream@npm:^1.0.0, mute-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "mute-stream@npm:1.0.0"
   checksum: 10c0/dce2a9ccda171ec979a3b4f869a102b1343dee35e920146776780de182f16eae459644d187e38d59a3d37adf85685e1c17c38cf7bfda7e39a9880f7a1d10a74c
@@ -25980,6 +25797,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -27214,34 +27040,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ora@npm:^5.4.1":
-  version: 5.4.1
-  resolution: "ora@npm:5.4.1"
-  dependencies:
-    bl: "npm:^4.1.0"
-    chalk: "npm:^4.1.0"
-    cli-cursor: "npm:^3.1.0"
-    cli-spinners: "npm:^2.5.0"
-    is-interactive: "npm:^1.0.0"
-    is-unicode-supported: "npm:^0.1.0"
-    log-symbols: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-    wcwidth: "npm:^1.0.1"
-  checksum: 10c0/10ff14aace236d0e2f044193362b22edce4784add08b779eccc8f8ef97195cae1248db8ec1ec5f5ff076f91acbe573f5f42a98c19b78dba8c54eefff983cae85
-  languageName: node
-  linkType: hard
-
 "os-homedir@npm:^1.0.1":
   version: 1.0.2
   resolution: "os-homedir@npm:1.0.2"
   checksum: 10c0/6be4aa67317ee247b8d46142e243fb4ef1d2d65d3067f54bfc5079257a2f4d4d76b2da78cba7af3cb3f56dbb2e4202e0c47f26171d11ca1ed4008d842c90363f
-  languageName: node
-  linkType: hard
-
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
@@ -28944,6 +28746,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/0a12c1e74b456c57122e81f684e02fd98ff4d57526f794d10c996df1147158808f5ae373ac82b988c8de6cbbaa82dbd7b13803b14f5dd3cf7cc6a42ccad5c9f2
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.38":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
+  dependencies:
+    nanoid: "npm:^3.3.17"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
   languageName: node
   linkType: hard
 
@@ -30879,13 +30692,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"run-async@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "run-async@npm:3.0.0"
-  checksum: 10c0/b18b562ae37c3020083dcaae29642e4cc360c824fbfb6b7d50d809a9d5227bb986152d09310255842c8dce40526e82ca768f02f00806c91ba92a8dfa6159cb85
-  languageName: node
-  linkType: hard
-
 "run-con@npm:~1.2.10":
   version: 1.2.12
   resolution: "run-con@npm:1.2.12"
@@ -32131,7 +31937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.5.0, std-env@npm:^3.7.0":
+"std-env@npm:^3.5.0":
   version: 3.7.0
   resolution: "std-env@npm:3.7.0"
   checksum: 10c0/60edf2d130a4feb7002974af3d5a5f3343558d1ccf8d9b9934d225c638606884db4a20d2fe6440a09605bca282af6b042ae8070a10490c0800d69e82e478f41e
@@ -32780,7 +32586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^9.3.1, supports-color@npm:^9.4.0":
+"supports-color@npm:^9.4.0":
   version: 9.4.0
   resolution: "supports-color@npm:9.4.0"
   checksum: 10c0/6c24e6b2b64c6a60e5248490cfa50de5924da32cf09ae357ad8ebbf305cc5d2717ba705a9d4cb397d80bbf39417e8fdc8d7a0ce18bd0041bf7b5b456229164e4
@@ -33133,17 +32939,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"test-exclude@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "test-exclude@npm:7.0.1"
-  dependencies:
-    "@istanbuljs/schema": "npm:^0.1.2"
-    glob: "npm:^10.4.1"
-    minimatch: "npm:^9.0.4"
-  checksum: 10c0/6d67b9af4336a2e12b26a68c83308c7863534c65f27ed4ff7068a56f5a58f7ac703e8fc80f698a19bb154fd8f705cdf7ec347d9512b2c522c737269507e7b263
-  languageName: node
-  linkType: hard
-
 "text-decoder@npm:^1.1.0":
   version: 1.2.0
   resolution: "text-decoder@npm:1.2.0"
@@ -33348,13 +33143,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyrainbow@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "tinyrainbow@npm:1.2.0"
-  checksum: 10c0/7f78a4b997e5ba0f5ecb75e7ed786f30bab9063716e7dff24dd84013fb338802e43d176cb21ed12480561f5649a82184cf31efb296601a29d38145b1cdb4c192
-  languageName: node
-  linkType: hard
-
 "tinyrainbow@npm:^2.0.0":
   version: 2.0.0
   resolution: "tinyrainbow@npm:2.0.0"
@@ -33373,15 +33161,6 @@ __metadata:
   version: 4.0.4
   resolution: "tinyspy@npm:4.0.4"
   checksum: 10c0/a8020fc17799251e06a8398dcc352601d2770aa91c556b9531ecd7a12581161fd1c14e81cbdaff0c1306c93bfdde8ff6d1c1a3f9bbe6d91604f0fd4e01e2f1eb
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
   languageName: node
   linkType: hard
 
@@ -34502,6 +34281,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^5.0.0":
+  version: 5.4.21
+  resolution: "vite@npm:5.4.21"
+  dependencies:
+    esbuild: "npm:^0.21.3"
+    fsevents: "npm:~2.3.3"
+    postcss: "npm:^8.4.43"
+    rollup: "npm:^4.20.0"
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
+  languageName: node
+  linkType: hard
+
 "vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
   version: 7.3.6
   resolution: "vite@npm:7.3.6"
@@ -34554,49 +34376,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/c6d359f84ad362f5c97ff7988b77c90add04162c60cdf6059375a7d9e3217848c53a8cb6b6c48517bef84b6bba4c9bc85319a889b5236acb7d5a2bc8cb7b9a8d
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.0.0, vite@npm:^5.4.10":
-  version: 5.4.21
-  resolution: "vite@npm:5.4.21"
-  dependencies:
-    esbuild: "npm:^0.21.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.43"
-    rollup: "npm:^4.20.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
   languageName: node
   linkType: hard
 
@@ -34783,35 +34562,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-tsc@npm:^3.3.9":
-  version: 3.3.9
-  resolution: "vue-tsc@npm:3.3.9"
+"vue@npm:3.4.31":
+  version: 3.4.31
+  resolution: "vue@npm:3.4.31"
   dependencies:
-    "@volar/typescript": "npm:2.4.28"
-    "@vue/language-core": "npm:3.3.9"
-  peerDependencies:
-    typescript: ">=5.0.0"
-  bin:
-    vue-tsc: bin/vue-tsc.js
-  checksum: 10c0/582ab81a0c5bb53a589e7f0ff2710cfaf32df1c180acaac5f65cbdfec8bd52a647aea0926a9fbef664799260d2df08a9f15cc9405759a6365169c73be16066c4
-  languageName: node
-  linkType: hard
-
-"vue@npm:3.5.40":
-  version: 3.5.40
-  resolution: "vue@npm:3.5.40"
-  dependencies:
-    "@vue/compiler-dom": "npm:3.5.40"
-    "@vue/compiler-sfc": "npm:3.5.40"
-    "@vue/runtime-dom": "npm:3.5.40"
-    "@vue/server-renderer": "npm:3.5.40"
-    "@vue/shared": "npm:3.5.40"
+    "@vue/compiler-dom": "npm:3.4.31"
+    "@vue/compiler-sfc": "npm:3.4.31"
+    "@vue/runtime-dom": "npm:3.4.31"
+    "@vue/server-renderer": "npm:3.4.31"
+    "@vue/shared": "npm:3.4.31"
   peerDependencies:
     typescript: "*"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/89a455e8fef36096c05e9e504457ec2210d9cd0f2966a229ec84d1d52bc98028a749c8675571fe0caaf1022c59628ef2fe627f1b4fe48f7b491a995ebd5b4ebb
+  checksum: 10c0/d9d7ac45f2f9b69b3c2f1cabf2d70cad4e829f7daebc2d2896b5e2e58074fee002d870691cfeb12af891ce1bedac2318269dffc4c581319823ed5e5e9173cd03
   languageName: node
   linkType: hard
 
@@ -35600,17 +35365,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "wrap-ansi@npm:6.2.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
-  languageName: node
-  linkType: hard
-
 "wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
@@ -35975,13 +35729,6 @@ __metadata:
   version: 1.1.1
   resolution: "yocto-queue@npm:1.1.1"
   checksum: 10c0/cb287fe5e6acfa82690acb43c283de34e945c571a78a939774f6eaba7c285bacdf6c90fbc16ce530060863984c906d2b4c6ceb069c94d1e0a06d5f2b458e2a92
-  languageName: node
-  linkType: hard
-
-"yoctocolors-cjs@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "yoctocolors-cjs@npm:2.1.2"
-  checksum: 10c0/a0e36eb88fea2c7981eab22d1ba45e15d8d268626e6c4143305e2c1628fa17ebfaa40cd306161a8ce04c0a60ee0262058eab12567493d5eb1409780853454c6f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
refreshes the stored carrier data on update so insurance keeps working when the API changes format.

Carrier data stored before this release holds insurance limits in the nested wrapper the MyParcel API is removing (Core API story SB-2770). The PDK now reads the flat limits, which that older data does not have, so insurance would be unavailable in the shop until something refreshed it.

Adds a timestamped migration that fetches the contract definitions again and rewrites the stored carriers in the shape the PDK expects. It runs once per install, tracked by identity rather than plugin version. When the API cannot be reached the migration reports failure through the PDK's `markFailed()`, so it stays unrecorded and is retried on the next load without taking the storefront down.

Tested against both formats the API can send: the flat limits on their own, and the flat limits alongside the deprecated nested wrapper as it sends today. Both store the same thing, with no nested wrapper left behind. The test drives the real capabilities service rather than a stub, so it is the actual strip being exercised.

Now on PDK 4.7.0, which carries `markFailed()` (myparcelnl/pdk#519).

Still to do before this can be released: myparcelnl/pdk#511 for the flat insurance format has to merge and ship. Until it does, the `flat limits alongside the deprecated nested wrapper` test stays red, because the PDK does not drop the nested wrapper yet. With #511 merged locally the whole suite passes: 211 passing.

Resolves INT-1698
Part of INT-1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)
