### PR TITLE
fix(v4): save delivery options when account is created during checkout

### DIFF
--- a/includes/frontend/class-wcmp-checkout.php
+++ b/includes/frontend/class-wcmp-checkout.php
@@ -81,17 +81,10 @@ class WCMP_Checkout
      */
     public static function save_delivery_options(int $orderId): void
     {
-        $nonce = sanitize_text_field(
-            wp_unslash(
-                $_POST['woocommerce-process-checkout-nonce']
-                ?? $_POST['_wpnonce']
-                ?? ''
-            )
-        );
-
-        if (! wp_verify_nonce($nonce, 'woocommerce-process_checkout')) {
-            return;
-        }
+        /**
+         * Nonce is already checked when hook ‘woocommerce_checkout_update_order_meta’ is executed.
+         * DO NOT CHECK NONCE, as the posted value is invalid when an account is created during checkout.
+         */
 
         $order                = WCX::get_order($orderId);
         $shippingMethod       = sanitize_text_field(


### PR DESCRIPTION
Removes superfluous nonce check that actually blocks the (save) action when an account is created during checkout, as the nonce changes during the request the posted value is invalid.

INT-1779