### PR TITLE
fix: display order grid normally when carrier is unavailable on order

### DIFF
--- a/src/Pdk/Hooks/PdkOrderListHooks.php
+++ b/src/Pdk/Hooks/PdkOrderListHooks.php
@@ -7,6 +7,7 @@ namespace MyParcelNL\WooCommerce\Pdk\Hooks;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
 use MyParcelNL\Pdk\Facade\Frontend;
 use MyParcelNL\Pdk\Facade\Language;
+use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\WooCommerce\Facade\WooCommerce;
 use MyParcelNL\WooCommerce\Hooks\Contract\WordPressHooksInterface;
@@ -114,7 +115,15 @@ class PdkOrderListHooks implements WordPressHooksInterface
         }
 
         if ($wcOrder !== null && $this->pdkOrderRepository instanceof PdkOrderRepository) {
-            $pdkOrder = $this->pdkOrderRepository->getForOrderList($wcOrder);
+            try {
+                $pdkOrder = $this->pdkOrderRepository->getForOrderList($wcOrder);
+            } catch (\Throwable $e) {
+                Logger::info('Could not retrieve PDK order for order list', [
+                    'order_id' => $wcOrder->get_id(),
+                    'error'    => $e->getMessage(),
+                ]);
+                return;
+            }
         } else {
             try {
                 $pdkOrder = $this->pdkOrderRepository->get($orderOrId);

--- a/src/Pdk/Hooks/PdkOrderListHooks.php
+++ b/src/Pdk/Hooks/PdkOrderListHooks.php
@@ -118,10 +118,16 @@ class PdkOrderListHooks implements WordPressHooksInterface
             try {
                 $pdkOrder = $this->pdkOrderRepository->getForOrderList($wcOrder);
             } catch (\Throwable $e) {
-                Logger::info('Could not retrieve PDK order for order list', [
-                    'order_id' => $wcOrder->get_id(),
-                    'error'    => $e->getMessage(),
-                ]);
+                static $hasLogged = false;
+
+                if (! $hasLogged) {
+                    $hasLogged = true;
+                    Logger::debug('Could not retrieve PDK order for order list', [
+                        'order_id'  => $wcOrder->get_id(),
+                        'exception' => $e,
+                    ]);
+                }
+
                 return;
             }
         } else {

--- a/src/Pdk/Hooks/PdkOrderListHooks.php
+++ b/src/Pdk/Hooks/PdkOrderListHooks.php
@@ -118,15 +118,10 @@ class PdkOrderListHooks implements WordPressHooksInterface
             try {
                 $pdkOrder = $this->pdkOrderRepository->getForOrderList($wcOrder);
             } catch (\Throwable $e) {
-                static $hasLogged = false;
-
-                if (! $hasLogged) {
-                    $hasLogged = true;
-                    Logger::debug('Could not retrieve PDK order for order list', [
-                        'order_id'  => $wcOrder->get_id(),
-                        'exception' => $e,
-                    ]);
-                }
+                Logger::debug('Could not retrieve PDK order for order list', [
+                    'order_id'  => $wcOrder->get_id(),
+                    'exception' => $e,
+                ]);
 
                 return;
             }

--- a/tests/Unit/Pdk/Hooks/PdkOrderListHooksTest.php
+++ b/tests/Unit/Pdk/Hooks/PdkOrderListHooksTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Pdk\Hooks;
+
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\WooCommerce\Pdk\Plugin\Repository\PdkOrderRepository;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use MyParcelNL\WooCommerce\WooCommerce\Contract\WcOrderRepositoryInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use WC_Order;
+use function MyParcelNL\Pdk\Tests\usesShared;
+use function MyParcelNL\WooCommerce\Tests\wpFactory;
+
+usesShared(new UsesMockWcPdkInstance());
+
+beforeEach(function () {
+    TestBootstrapper::hasAccount();
+});
+
+it('renders nothing when the pdk order cannot be retrieved and logs', function () {
+    // A repository whose getForOrderList blows up (e.g. carrier unavailable on the order).
+    $throwingRepository = new class extends PdkOrderRepository {
+        /** @noinspection PhpMissingParentConstructorInspection */
+        public function __construct() {}
+
+        public function getForOrderList(WC_Order $order): PdkOrder
+        {
+            throw new RuntimeException('Carrier unavailable');
+        }
+    };
+
+    $hooks = new PdkOrderListHooks($throwingRepository, Pdk::get(WcOrderRepositoryInterface::class));
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(LoggerInterface::class);
+
+    ob_start();
+    $hooks->renderPdkOrderListItem(Pdk::get('orderListColumnName'), wpFactory(WC_Order::class)->make());
+    $output = ob_get_clean();
+
+    // The column renders nothing (early return) and the failure is logged once at debug level.
+    expect($output)->toBe('')
+        ->and($logger->getLogs('debug'))->toHaveCount(1)
+        ->and($logger->getLogs('debug')[0]['message'])->toContain('Could not retrieve PDK order for order list');
+});
+
+it('renders the order list column for a healthy order', function () {
+    /** @var PdkOrderListHooks $hooks */
+    $hooks = Pdk::get(PdkOrderListHooks::class);
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(LoggerInterface::class);
+
+    ob_start();
+    $hooks->renderPdkOrderListItem(Pdk::get('orderListColumnName'), wpFactory(WC_Order::class)->make());
+    $output = ob_get_clean();
+
+    // The try succeeds, so nothing is logged and the column markup is rendered.
+    expect($output)->not->toBe('')
+        ->and($logger->getLogs('debug'))->toBe([]);
+});


### PR DESCRIPTION
INT-1780

Fixed in plugin because the other PDK plugin renders the list items quite differently, not having this bug (it seems).