### PR TITLE
fix(address-widget): pin yarn to 4.17.1 so the build runs

### DIFF
--- a/views/frontend/checkout-address-widget/package.json
+++ b/views/frontend/checkout-address-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myparcel-woocommerce/address-widget",
-  "packageManager": "yarn@4.3.1",
+  "packageManager": "yarn@4.17.1",
   "version": "1.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
pins the address-widget workspace to yarn 4.17.1 so the plugin build runs again.

The address-widget workspace pinned yarn 4.3.1 while the rest of the plugin is on 4.17.1. Its build script shells out to a nested `yarn run`, which then picked up 4.3.1 and refused to start, because the `approvedGitRepositories` setting in `.yarnrc.yml` only exists in newer yarn. That broke `yarn build` for the whole plugin, not just this workspace.

Pinning the workspace to the same 4.17.1 the plugin already uses fixes it. No lockfile change needed, and `yarn install --immutable` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
