### PR TITLE
Allow filtering of addresses

### DIFF
--- a/src/Adapter/WcAddressAdapter.php
+++ b/src/Adapter/WcAddressAdapter.php
@@ -8,6 +8,7 @@ use Exception;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Base\Model\MyParcelAddress;
 use MyParcelNL\Sdk\Helper\SplitStreet;
+use MyParcelNL\WooCommerce\Facade\Filter;
 use WC_Cart;
 use WC_Customer;
 use WC_Order;
@@ -100,7 +101,7 @@ class WcAddressAdapter
         // Legacy fallback if the address widget wasn't used
         $state = $this->getState($class, $addressType);
 
-        return array_merge($pdkAddressAttributes, [
+        $data = array_merge($pdkAddressAttributes, [
             'address1'   => $this->getAddressField($class, Pdk::get('fieldAddress1'), $addressType),
             'address2'   => $this->getAddressField($class, Pdk::get('fieldAddress2'), $addressType),
             'cc'         => $this->getAddressField($class, Pdk::get('fieldCountry'), $addressType),
@@ -110,6 +111,8 @@ class WcAddressAdapter
             'region'     => $state,
             'state'      => $state,
         ]);
+
+        return Filter::apply('wcAddressFields', $data, $class, $addressType);
     }
 
     /**

--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -186,6 +186,7 @@ class WcPdkBootstrapper extends PdkBootstrapper
                  */
                 'separateAddressFieldsPriority'    => 'mpwc_checkout_separate_address_fields_priority',
                 'taxFieldsPriority'                => 'mpwc_checkout_tax_fields_priority',
+                'wcAddressFields'                  => 'mpwc_checkout_wc_address_fields',
 
                 /**
                  * Field classes

--- a/tests/Mock/MockWpActions.php
+++ b/tests/Mock/MockWpActions.php
@@ -39,6 +39,26 @@ final class MockWpActions implements StaticMockInterface
     }
 
     /**
+     * @param  string            $tag
+     * @param  callable|string $functionToRemove
+     * @param  int             $priority
+     *
+     * @return void
+     */
+    public static function remove(string $tag, $functionToRemove, int $priority): void
+    {
+        $actions = self::get($tag);
+
+        foreach ($actions as $index => $action) {
+            if ($action['function'] === $functionToRemove && $action['priority'] === $priority) {
+                unset($actions[$index]);
+            }
+        }
+
+        self::$actions->put($tag, array_values($actions));
+    }
+
+    /**
      * @return \MyParcelNL\Pdk\Base\Support\Collection
      */
     public static function all(): Collection

--- a/tests/Unit/Adapter/WcAddressAdapterTest.php
+++ b/tests/Unit/Adapter/WcAddressAdapterTest.php
@@ -372,16 +372,20 @@ it('allows filtering address fields through the wcAddressFields filter', functio
         ->with(array_merge($address, ['id' => 1234, 'meta' => []]))
         ->make();
 
-    add_filter('mpwc_checkout_wc_address_fields', function (array $fields, $object, string $addressType) {
+    $filter = function (array $fields, $object, string $addressType) {
         expect($object)->toBeInstanceOf(WC_Order::class)
             ->and($addressType)->toBe('shipping');
 
         $fields['company'] = 'Filtered Company';
 
         return $fields;
-    }, 10, 3);
+    };
+
+    add_filter('mpwc_checkout_wc_address_fields', $filter, 10, 3);
 
     $result = $adapter->fromWcOrder($order, 'shipping');
 
     expect($result['company'])->toBe('Filtered Company');
+
+    remove_filter('mpwc_checkout_wc_address_fields', $filter, 10);
 });

--- a/tests/Unit/Adapter/WcAddressAdapterTest.php
+++ b/tests/Unit/Adapter/WcAddressAdapterTest.php
@@ -348,3 +348,40 @@ it('passes the cart company through to the pdk cart as isBusiness, without stori
     'business (company entered)' => ['Acme B.V.', true],
     'consumer (no company)'      => [null, false],
 ]);
+
+it('allows filtering address fields through the wcAddressFields filter', function () {
+    /** @var WcAddressAdapter $adapter */
+    $adapter = Pdk::get(WcAddressAdapter::class);
+
+    $address = [
+        'billing_email'       => 'test@test.com',
+        'billing_phone'       => '0612345678',
+        'shipping_address_1'  => 'Antareslaan 31',
+        'shipping_address_2'  => '',
+        'shipping_city'       => 'Hoofddorp',
+        'shipping_company'    => 'MyParcel',
+        'shipping_country'    => 'NL',
+        'shipping_first_name' => 'Felicia',
+        'shipping_last_name'  => 'Parcel',
+        'shipping_postcode'   => '2132JE',
+        'shipping_state'      => 'NL-NH',
+    ];
+
+    $order = wpFactory(WC_Order::class)
+        ->fromScratch()
+        ->with(array_merge($address, ['id' => 1234, 'meta' => []]))
+        ->make();
+
+    add_filter('mpwc_checkout_wc_address_fields', function (array $fields, $object, string $addressType) {
+        expect($object)->toBeInstanceOf(WC_Order::class)
+            ->and($addressType)->toBe('shipping');
+
+        $fields['company'] = 'Filtered Company';
+
+        return $fields;
+    }, 10, 3);
+
+    $result = $adapter->fromWcOrder($order, 'shipping');
+
+    expect($result['company'])->toBe('Filtered Company');
+});

--- a/tests/mock_wp_functions.php
+++ b/tests/mock_wp_functions.php
@@ -106,6 +106,12 @@ function add_filter($tag, $functionToAdd, $priority = 10, $acceptedArgs = 1)
     MockWpActions::add($tag, $functionToAdd, $priority, $acceptedArgs);
 }
 
+/**@see \remove_filter() */
+function remove_filter($tag, $functionToRemove, $priority = 10)
+{
+    MockWpActions::remove($tag, $functionToRemove, $priority);
+}
+
 /**@see \add_action() */
 function add_action($tag, $functionToAdd, $priority = 10, $acceptedArgs = 1)
 {


### PR DESCRIPTION
With complex WooCommerce sites the address fields don't always follow the same rules for addresses (E.G. some may add custom fields with addresses which need to be filtered into 1 address field to work nicely with MyParcel)

This is just a thing we need for one of our customers as they have split up their address fields and I couldn't find a clear way in the documentation to allow our custom fields from WC_Order to be send correctly following the myparcel specs for creating shipments.


Small example for adding the filter: 
```php
    add_filter('mpwc_checkout_wc_address_fields', function (array $fields, $object, string $addressType) {
    	//Your code here for doing stuff
        return $fields;
    }, 10, 3);
```

This also closes a year old issue
Closes #1367 
