### PR TITLE
fix(migration): fix an issue causing future database migrations not being detected

### DIFF
--- a/src/Pdk/WcPdkBootstrapper.php
+++ b/src/Pdk/WcPdkBootstrapper.php
@@ -42,6 +42,13 @@ class WcPdkBootstrapper extends PdkBootstrapper
     ): array {
         return array_replace(self::$config, [
             ###
+            # Migrations
+            ###
+
+            // The pdk defaults this to its own package root, where no plugin migration lives.
+            'migrationDirectory' => value(sprintf('%s/src/Migration', rtrim($path, '/'))),
+
+            ###
             # Meta Keys
             ###
 

--- a/tests/Unit/Migration/MigrationDiscoveryTest.php
+++ b/tests/Unit/Migration/MigrationDiscoveryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Migration;
+
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockWcPdkInstance());
+
+it('scans the plugin for timestamped migrations', function () {
+    // The pdk defaults migrationDirectory to its own package root, which holds no plugin
+    // migration. Without an override the installer finds no timestamped migration file at all.
+    expect(realpath((string) Pdk::get('migrationDirectory')))
+        ->toBe(realpath(__DIR__ . '/../../../src/Migration'));
+});


### PR DESCRIPTION
The plugin now points the PDK's migration discovery at its own `src/Migration` folder, so a timestamped migration it ships is actually found.

The PDK defaults `migrationDirectory` to the PDK package root, which contains no plugin migration, so discovery returned an empty list. Only class-based migrations worked, because `WcMigrationService` registers those by class name instead. The same defect was fixed in the PrestaShop plugin under INT-1699.

Resolves INT-1816

🤖 Generated with [Claude Code](https://claude.com/claude-code)