### PR TITLE
fix(checkout): preserve unique hidden form fields

### DIFF
--- a/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.spec.ts
+++ b/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.spec.ts
@@ -134,6 +134,33 @@ describe('getClassicCheckoutConfig - getFormData', () => {
     expect(getFormData()['billing_postcode']).toBe('1234AB');
   });
 
+  it('keeps a unique field hidden by the address widget', () => {
+    document.body.innerHTML = `
+      <form name="checkout" class="checkout woocommerce-checkout">
+        <p id="billing_postcode_field" style="display:none">
+          <input type="text" name="billing_postcode" value="1502VP" />
+        </p>
+      </form>
+    `;
+
+    expect(getFormData()['billing_postcode']).toBe('1502VP');
+  });
+
+  it('ignores a checked hidden checkbox when a visible unchecked duplicate exists', () => {
+    document.body.innerHTML = `
+      <form name="checkout">
+        <input type="checkbox" name="ship_to_different_address" value="1" />
+      </form>
+      <form name="checkout">
+        <div style="display:none">
+          <input type="checkbox" name="ship_to_different_address" value="1" checked />
+        </div>
+      </form>
+    `;
+
+    expect(getFormData()['ship_to_different_address']).toBeUndefined();
+  });
+
   it('keeps a shipping method WooCommerce renders as a single hidden input', () => {
     // A single shipping method renders as <input type=hidden name=shipping_method[0]> — display:none
     // via the UA stylesheet (set explicitly here; happy-dom doesn't apply that rule). It carries a real

--- a/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
+++ b/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
@@ -29,6 +29,26 @@ const isHidden = (element: Element): boolean => hasDisplayNoneAncestor(element);
  */
 const isInHiddenContainer = (element: Element): boolean => hasDisplayNoneAncestor(element.parentElement);
 
+/**
+ * Names that have at least one control outside a hidden container. Hidden controls are valid form
+ * values, so visibility is only used to resolve duplicate names rendered by layouts such as Divi.
+ */
+const getNamesInVisibleContainers = (forms: HTMLFormElement[]): Set<string> => {
+  const names = new Set<string>();
+
+  forms.forEach((form) => {
+    Array.from(form.elements).forEach((control) => {
+      const name = control.getAttribute('name');
+
+      if (name && !isInHiddenContainer(control)) {
+        names.add(name);
+      }
+    });
+  });
+
+  return names;
+};
+
 // eslint-disable-next-line max-lines-per-function
 export const getClassicCheckoutConfig = (): CheckoutConfig => {
   return {
@@ -80,10 +100,13 @@ export const getClassicCheckoutConfig = (): CheckoutConfig => {
       },
 
       getFormData() {
-        return getCheckoutForms().reduce<Record<string, FormDataEntryValue>>((merged, form) => {
+        const forms = getCheckoutForms();
+        const namesInVisibleContainers = getNamesInVisibleContainers(forms);
+
+        return forms.reduce<Record<string, FormDataEntryValue>>((merged, form) => {
           // Divi's hidden duplicate billing fieldset isn't disabled, so FormData includes it and, being
-          // later in DOM order, would clobber live values. Skip names inside a display:none container,
-          // but keep self-hidden real inputs like `shipping_method[0]`. form.elements avoids escaping.
+          // later in DOM order, would clobber live values. Only skip a hidden value when another control
+          // with that name has a visible container. Unique hidden fields remain valid form values.
           const hiddenNames = new Set<string>();
 
           for (const control of Array.from(form.elements)) {
@@ -95,7 +118,7 @@ export const getClassicCheckoutConfig = (): CheckoutConfig => {
           }
 
           for (const [key, value] of new FormData(form).entries()) {
-            if (hiddenNames.has(key)) {
+            if (hiddenNames.has(key) && namesInVisibleContainers.has(key)) {
               continue;
             }
 

--- a/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
+++ b/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
@@ -29,26 +29,6 @@ const isHidden = (element: Element): boolean => hasDisplayNoneAncestor(element);
  */
 const isInHiddenContainer = (element: Element): boolean => hasDisplayNoneAncestor(element.parentElement);
 
-/**
- * Names that have at least one control outside a hidden container. Hidden controls are valid form
- * values, so visibility is only used to resolve duplicate names rendered by layouts such as Divi.
- */
-const getNamesInVisibleContainers = (forms: HTMLFormElement[]): Set<string> => {
-  const names = new Set<string>();
-
-  forms.forEach((form) => {
-    Array.from(form.elements).forEach((control) => {
-      const name = control.getAttribute('name');
-
-      if (name && !isInHiddenContainer(control)) {
-        names.add(name);
-      }
-    });
-  });
-
-  return names;
-};
-
 // eslint-disable-next-line max-lines-per-function
 export const getClassicCheckoutConfig = (): CheckoutConfig => {
   return {
@@ -100,33 +80,44 @@ export const getClassicCheckoutConfig = (): CheckoutConfig => {
       },
 
       getFormData() {
-        const forms = getCheckoutForms();
-        const namesInVisibleContainers = getNamesInVisibleContainers(forms);
-
-        return forms.reduce<Record<string, FormDataEntryValue>>((merged, form) => {
-          // Divi's hidden duplicate billing fieldset isn't disabled, so FormData includes it and, being
-          // later in DOM order, would clobber live values. Only skip a hidden value when another control
-          // with that name has a visible container. Unique hidden fields remain valid form values.
+        const visibleNames = new Set<string>();
+        const formStates = getCheckoutForms().map((form) => {
           const hiddenNames = new Set<string>();
 
-          for (const control of Array.from(form.elements)) {
+          for (const control of form.elements) {
             const name = control.getAttribute('name');
 
-            if (name && isInHiddenContainer(control)) {
-              hiddenNames.add(name);
-            }
-          }
-
-          for (const [key, value] of new FormData(form).entries()) {
-            if (hiddenNames.has(key) && namesInVisibleContainers.has(key)) {
+            if (!name) {
               continue;
             }
 
-            merged[key] = value;
+            if (isInHiddenContainer(control)) {
+              hiddenNames.add(name);
+            } else {
+              visibleNames.add(name);
+            }
           }
 
-          return merged;
-        }, {});
+          return {form, hiddenNames};
+        });
+
+        // Visible names are global because Divi puts duplicate fields in separate forms. Hidden names
+        // stay scoped to their form, so only the hidden duplicate is skipped. Unique hidden fields are
+        // valid form values and remain in the merged data.
+        return formStates.reduce<Record<string, FormDataEntryValue>>(
+          (merged, {form, hiddenNames}) => {
+            for (const [key, value] of new FormData(form).entries()) {
+              if (hiddenNames.has(key) && visibleNames.has(key)) {
+                continue;
+              }
+
+              merged[key] = value;
+            }
+
+            return merged;
+          },
+          {},
+        );
       },
 
       // The value js-pdk passes lags one form-read behind and omits an unchecked box; read the live DOM.


### PR DESCRIPTION
Since 6.9.0, `getFormData()` in the classic checkout drops every form value whose container is `display:none` (introduced in #1661 for Divi 5 support).

Fix: Visibility is now only used to resolve duplicate names: a hidden value is skipped only when another control with the same name exists in a visible container (across all checkout forms). Unique hidden fields are kept.

fixes INT-1827