### PR TITLE
fix(checkout): enforce required validation of separate address fields

### DIFF
--- a/src/Hooks/SeparateAddressFieldsHooks.php
+++ b/src/Hooks/SeparateAddressFieldsHooks.php
@@ -447,8 +447,7 @@ class SeparateAddressFieldsHooks extends AbstractFieldsHooks implements WooComme
      */
     private function extendWithSeparateAddressFields(array $fields, string $form): array
     {
-        return array_merge(
-            $fields,
+        $separateAddressFields = array_merge(
             $this->createField($form, 'fieldStreet', 'street'),
             $this->createField($form, 'fieldNumber', 'number', ['type' => 'number']),
             $this->createField(
@@ -458,5 +457,18 @@ class SeparateAddressFieldsHooks extends AbstractFieldsHooks implements WooComme
                 ['maxlength' => Pdk::get('numberSuffixMaxLength')]
             )
         );
+
+        /**
+         * WooCommerce applies the country locale (which carries `required`/`hidden`, see
+         * extendLocaleWithSeparateAddressFields) BEFORE this filter runs. Merge with the existing
+         * definitions so those values survive; replacing them wholesale disabled the server-side
+         * required validation of street and house number (#1805). Our attributes stay leading on
+         * conflicts, so the field customization filters keep working as before.
+         */
+        foreach ($separateAddressFields as $key => $attributes) {
+            $fields[$key] = array_merge($fields[$key] ?? [], $attributes);
+        }
+
+        return $fields;
     }
 }

--- a/tests/Unit/Hooks/SeparateAddressFieldsHooksTest.php
+++ b/tests/Unit/Hooks/SeparateAddressFieldsHooksTest.php
@@ -1,0 +1,78 @@
+<?php
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Hooks;
+
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockWcPdkInstance());
+
+it('adds the separate address fields to the billing fields', function () {
+    /** @var SeparateAddressFieldsHooks $hook */
+    $hook = Pdk::get(SeparateAddressFieldsHooks::class);
+
+    $fields = $hook->extendBillingFields([]);
+
+    expect($fields)
+        ->toHaveKeys(['billing_street_name', 'billing_house_number', 'billing_house_number_suffix'])
+        ->and($fields['billing_street_name'])
+        ->toHaveKeys(['class', 'label', 'priority'])
+        ->and($fields['billing_house_number']['type'])
+        ->toBe('number');
+});
+
+it('preserves the locale-applied required and hidden values on the separate address fields', function () {
+    /** @var SeparateAddressFieldsHooks $hook */
+    $hook = Pdk::get(SeparateAddressFieldsHooks::class);
+
+    // WooCommerce applies the country locale before the woocommerce_billing_fields filter runs, so the
+    // fields arrive here carrying `required`/`hidden`. Regression test for #1805: these values were
+    // replaced by the filter, which disabled the server-side required validation.
+    $fields = $hook->extendBillingFields([
+        'billing_street_name'         => ['required' => true, 'hidden' => false],
+        'billing_house_number'        => ['required' => true, 'hidden' => false],
+        'billing_house_number_suffix' => ['required' => false, 'hidden' => false],
+    ]);
+
+    expect($fields['billing_street_name']['required'])
+        ->toBeTrue()
+        ->and($fields['billing_house_number']['required'])
+        ->toBeTrue()
+        ->and($fields['billing_house_number_suffix']['required'])
+        ->toBeFalse()
+        ->and($fields['billing_street_name']['hidden'])
+        ->toBeFalse()
+        // Presentation attributes must still be added alongside the preserved values.
+        ->and($fields['billing_street_name'])
+        ->toHaveKeys(['class', 'label', 'priority']);
+});
+
+it('preserves the locale-applied values on the shipping fields as well', function () {
+    /** @var SeparateAddressFieldsHooks $hook */
+    $hook = Pdk::get(SeparateAddressFieldsHooks::class);
+
+    $fields = $hook->extendShippingFields([
+        'shipping_street_name'  => ['required' => true, 'hidden' => false],
+        'shipping_house_number' => ['required' => true, 'hidden' => false],
+    ]);
+
+    expect($fields['shipping_street_name']['required'])
+        ->toBeTrue()
+        ->and($fields['shipping_house_number']['required'])
+        ->toBeTrue();
+});
+
+it('leaves unrelated fields untouched', function () {
+    /** @var SeparateAddressFieldsHooks $hook */
+    $hook = Pdk::get(SeparateAddressFieldsHooks::class);
+
+    $postcode = ['label' => 'Postcode', 'required' => true];
+
+    $fields = $hook->extendBillingFields(['billing_postcode' => $postcode]);
+
+    expect($fields['billing_postcode'])->toBe($postcode);
+});


### PR DESCRIPTION
The separate address fields (street, house number) show a required asterisk but  are never validated server-side: orders come in with both fields empty.   

 `extendWithSeparateAddressFields()` now merges `createField()` attributes into the existing (locale-applied) field definition instead of replacing it, so `required` and `hidden` from the locale survive. `address_1` stays optional:                                                                                                                                  it is composed server-side after validation and making it required would block every checkout.
 
 fixes INT-1835 & #1805