### PR TITLE
fix(admin): fix display of actions on the orders page

### DIFF
--- a/views/backend/admin/src/assets/scss/_woocommerce.scss
+++ b/views/backend/admin/src/assets/scss/_woocommerce.scss
@@ -11,7 +11,7 @@
   // Increase the width of the MyParcel column in the orders list.
   // Default is 12ch and causes the shipment buttons to float outside the column.
   // 23ch comfortably fits a 15-character barcode.
-  .wp-list-table .column-myparcelnl {
+  .wp-list-table .column-myparcelcom {
     @apply mypa-w-[23ch];
 
     .postbox .inside {

--- a/views/backend/admin/src/assets/scss/_woocommerce.scss
+++ b/views/backend/admin/src/assets/scss/_woocommerce.scss
@@ -21,7 +21,7 @@
 }
 
 // Disable dragging of the MyParcel box on the order page.
-#myparcelnl_woocommerce_order_data {
+#myparcelcom_woocommerce_order_data {
   &.postbox {
     @apply mypa-p-0 mypa-border-0 mypa-bg-transparent mypa-shadow-none mypa-m-0;
   }

--- a/views/backend/admin/src/components/pdk/WcShipmentLabelWrapper.vue
+++ b/views/backend/admin/src/components/pdk/WcShipmentLabelWrapper.vue
@@ -2,7 +2,7 @@
   <PdkBox
     v-test="AdminComponent.ShipmentLabelWrapper"
     :size="Size.Small"
-    class="mypa-mb-1 mypa-min-w-0">
+    class="mypa-mb-1 mypa-min-w-0 mypa-overflow-visible">
     <WcLoadingOverlay v-show="loading" />
 
     <slot />


### PR DESCRIPTION
fix several overflow issues causing the actions for exported orders being cut off on the woocommerce orders page

fixes INT-1720, #1673