### PR TITLE
fix(checkout): preserve required and hidden flags on separate address fields

### DIFF
--- a/src/Hooks/SeparateAddressFieldsHooks.php
+++ b/src/Hooks/SeparateAddressFieldsHooks.php
@@ -447,8 +447,7 @@ class SeparateAddressFieldsHooks extends AbstractFieldsHooks implements WooComme
      */
     private function extendWithSeparateAddressFields(array $fields, string $form): array
     {
-        return array_merge(
-            $fields,
+        $separateAddressFields = array_merge(
             $this->createField($form, 'fieldStreet', 'street'),
             $this->createField($form, 'fieldNumber', 'number', ['type' => 'number']),
             $this->createField(
@@ -458,5 +457,19 @@ class SeparateAddressFieldsHooks extends AbstractFieldsHooks implements WooComme
                 ['maxlength' => Pdk::get('numberSuffixMaxLength')]
             )
         );
+
+        /**
+         * The separate address fields already exist in $fields at this point: they are added
+         * through woocommerce_default_address_fields and modified per country through
+         * woocommerce_get_country_locale, which sets 'required' and 'hidden'. Replacing the
+         * whole field definition here would drop those properties, causing street and number
+         * to render as "(optional)" and skip checkout validation for NL/BE. So merge our
+         * definition underneath the existing one instead of on top of it.
+         */
+        foreach ($separateAddressFields as $key => $field) {
+            $fields[$key] = array_merge($field, $fields[$key] ?? []);
+        }
+
+        return $fields;
     }
 }


### PR DESCRIPTION
Fixes #1811.

### Problem

With classic checkout and separate address fields enabled, `extendWithSeparateAddressFields()` `array_merge`s the output of `createField()` over `$fields`. By that time the street/number/suffix fields already exist in `$fields`: they are added through `woocommerce_default_address_fields` and given their per-country `required`/`hidden` flags through `woocommerce_get_country_locale` (`extendLocaleWithSeparateAddressFields()`). Since `array_merge` replaces the whole definition per key, and `createField()` only returns `class`/`label`/`priority`, the locale-derived `required => true` / `hidden => false` for NL/BE is wiped.

Result: Street and House number render as "(optional)" and WooCommerce does not validate them, so orders can be placed without a street or house number (with `address_1` ending up empty).

### Fix

Merge the created field definitions underneath the existing ones, so anything WooCommerce derived from the locale survives while the plugin still contributes `class`, `label`, `priority`, `type` and `maxlength`:

```php
foreach ($separateAddressFields as $key => $field) {
    $fields[$key] = array_merge($field, $fields[$key] ?? []);
}
```

Behavior for countries **without** separate address fields is unchanged: the locale sets `hidden => true, required => false` there, and those flags are now preserved as well instead of being dropped.

### Tested

On a production shop (6.9.2, WooCommerce 10.x, classic checkout, country NL), with a probe on `woocommerce_billing_fields`:

| | before this fix | after this fix |
|---|---|---|
| `billing_street_name` | `required` missing → "(optional)", not validated | `required => true`, asterisk shown, validated |
| `billing_house_number` | `required` missing → "(optional)", not validated | `required => true`, asterisk shown, validated |
| `billing_house_number_suffix` | optional | optional (unchanged, as intended) |
| non-NL/BE country | fields hidden via JS selectors only | server-side `hidden => true` preserved too |
