### PR TITLE
fix(migrations): restore lost account data

### DIFF
--- a/src/Migration/2026_07_29_092726_refresh_carrier_capabilities.php
+++ b/src/Migration/2026_07_29_092726_refresh_carrier_capabilities.php
@@ -7,6 +7,7 @@ use MyParcelNL\Pdk\App\Installer\Migration\AbstractTimestampedMigration;
 use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 
 /**
  * Re-fetches the stored carrier data so insurance limits are in the flat format.
@@ -19,9 +20,20 @@ use MyParcelNL\Pdk\Facade\Pdk;
 return new class extends AbstractTimestampedMigration {
     public function up(): void
     {
+        /** @var PdkSettingsRepositoryInterface $settingsRepository */
+        $settingsRepository = Pdk::get(PdkSettingsRepositoryInterface::class);
+        $accountSettings    = $settingsRepository->all()->account;
+
+        if (! $accountSettings->apiKey || ! $accountSettings->apiKeyValid) {
+            Logger::debug('No valid API key available; skipping carrier capabilities refresh.');
+
+            return;
+        }
+
         /** @var PdkAccountRepositoryInterface $accountRepository */
         $accountRepository = Pdk::get(PdkAccountRepositoryInterface::class);
-        $account           = $accountRepository->getAccount(true);
+        // Keep plugin-managed account fields that are absent from the accounts API response.
+        $account           = $accountRepository->getAccount();
         // PHPStan types Account::$shops as a non-null ShopCollection, but the guard is kept
         // intentionally to stay safe against partial/corrupted account data during upgrade.
         // @phpstan-ignore booleanAnd.rightAlwaysTrue

--- a/src/Migration/2026_09_03_130123_restore_account_data.php
+++ b/src/Migration/2026_09_03_130123_restore_account_data.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\App\Installer\Migration\AbstractTimestampedMigration;
+use MyParcelNL\Pdk\Base\Support\Collection;
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule\ImplicationsService;
+use MyParcelNL\Pdk\SdkApi\Service\Iam\WhoamiService;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
+
+/**
+ * Restores plugin-managed account data that was lost during a forced account refresh.
+ */
+return new class extends AbstractTimestampedMigration {
+    public function up(): void
+    {
+        /** @var PdkSettingsRepositoryInterface $settingsRepository */
+        $settingsRepository = Pdk::get(PdkSettingsRepositoryInterface::class);
+        $accountSettings    = $settingsRepository->all()->account;
+
+        if (! $accountSettings->apiKey || ! $accountSettings->apiKeyValid) {
+            return;
+        }
+
+        /** @var PdkAccountRepositoryInterface $accountRepository */
+        $accountRepository = Pdk::get(PdkAccountRepositoryInterface::class);
+        $account           = $accountRepository->getAccount();
+
+        if (! $account) {
+            return;
+        }
+
+        $hasChanges = false;
+        $shop       = $account->shops->first();
+
+        $hasAvailableDefaultCarrier = $shop
+            && $shop->defaultCarrier
+            && $shop->carriers->contains('carrier', $shop->defaultCarrier);
+
+        if ($shop && ! $hasAvailableDefaultCarrier) {
+            if (! $shop->id) {
+                Logger::warning('Cannot restore default carrier: no shop id is available.');
+            } else {
+                /** @var ImplicationsService $implicationsService */
+                $implicationsService = Pdk::get(ImplicationsService::class);
+                $defaultCarrier      = $implicationsService->getDefaultCarrierName($shop->id);
+
+                if (null !== $defaultCarrier && $shop->carriers->contains('carrier', $defaultCarrier)) {
+                    $shop->defaultCarrier = $defaultCarrier;
+                    $hasChanges           = true;
+                } else {
+                    Logger::warning('Cannot safely restore the shop default carrier.', [
+                        'shopId'  => $shop->id,
+                        'carrier' => $defaultCarrier,
+                    ]);
+                }
+            }
+        }
+
+        if ($account->subscriptionFeatures->isEmpty()) {
+            try {
+                /** @var WhoamiService $whoamiService */
+                $whoamiService                 = Pdk::get(WhoamiService::class);
+                $whoami                        = $whoamiService->getWhoami();
+                $account->subscriptionFeatures = new Collection($whoami->getFeatures() ?? []);
+                $hasChanges                    = true;
+            } catch (\Throwable $exception) {
+                // Keep the migration pending so a temporary IAM failure can be retried.
+                $this->markFailed('Cannot restore subscription features.', [
+                    'message' => $exception->getMessage(),
+                    'class'   => get_class($exception),
+                ]);
+            }
+        }
+
+        if ($hasChanges) {
+            $accountRepository->store($account);
+        }
+    }
+};

--- a/src/Migration/Migration6_5_1.php
+++ b/src/Migration/Migration6_5_1.php
@@ -52,7 +52,16 @@ final class Migration6_5_1 extends AbstractMigration
      */
     public function migrateAccountData(): void
     {
-        $account = $this->accountRepository->getAccount(true);
+        $accountSettings = $this->settingsRepository->all()->account;
+
+        if (! $accountSettings->apiKey || ! $accountSettings->apiKeyValid) {
+            $this->debug('No valid API key available; skipping carrier capabilities migration.');
+
+            return;
+        }
+
+        // Keep plugin-managed account fields that are absent from the accounts API response.
+        $account = $this->accountRepository->getAccount();
         // PHPStan types Account::$shops as a non-null ShopCollection, but the guard is kept
         // intentionally to stay safe against partial/corrupted account data during upgrade.
         // @phpstan-ignore booleanAnd.rightAlwaysTrue

--- a/tests/Unit/Migration/MigrationDiscoveryTest.php
+++ b/tests/Unit/Migration/MigrationDiscoveryTest.php
@@ -35,5 +35,8 @@ it('keeps the timestamped migrations where the installer looks for them', functi
         }
     ));
 
-    expect($found)->toContain('2026_07_29_092726_refresh_carrier_capabilities.php');
+    expect($found)->toContain(
+        '2026_07_29_092726_refresh_carrier_capabilities.php',
+        '2026_09_03_130123_restore_account_data.php'
+    );
 });

--- a/tests/Unit/Migration/Pdk/Migration6_5_1Test.php
+++ b/tests/Unit/Migration/Pdk/Migration6_5_1Test.php
@@ -7,13 +7,19 @@ declare(strict_types=1);
 namespace MyParcelNL\WooCommerce\Migration\Pdk;
 
 use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\Base\Support\Collection;
 use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
 use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
+use MyParcelNL\Pdk\Tests\Api\Response\ExampleGetAccountsResponse;
+use MyParcelNL\Pdk\Tests\Bootstrap\MockApi;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\SdkApi\MockSdkApiHandler;
+use MyParcelNL\Pdk\Tests\SdkApi\Response\ExampleContractDefinitionsResponse;
+use MyParcelNL\Pdk\Tests\Uses\UsesSdkApiMock;
 use MyParcelNL\WooCommerce\Migration\Migration6_5_1;
 use MyParcelNL\WooCommerce\Tests\Mock\MockWpMeta;
 use MyParcelNL\WooCommerce\Tests\Mock\WordPressScheduledTasks;
@@ -23,7 +29,7 @@ use function MyParcelNL\Pdk\Tests\mockPdkProperties;
 use function MyParcelNL\Pdk\Tests\usesShared;
 use function MyParcelNL\WooCommerce\Tests\createWcOrder;
 
-usesShared(new UsesMockWcPdkInstance());
+usesShared(new UsesMockWcPdkInstance(), new UsesSdkApiMock());
 
 // --- migrateAccountData (defensive) ---
 
@@ -39,6 +45,55 @@ it('does not fail account data migration when no account or shop is available', 
     $migration->migrateAccountData();
 
     expect($accountRepo->getAccount())->toBeNull();
+});
+
+it('skips account data migration when the api key is invalid', function () {
+    TestBootstrapper::hasAccount();
+
+    /** @var PdkSettingsRepositoryInterface $settingsRepository */
+    $settingsRepository            = Pdk::get(PdkSettingsRepositoryInterface::class);
+    $accountSettings               = $settingsRepository->all()->account;
+    $accountSettings->apiKeyValid = false;
+    $settingsRepository->storeSettings($accountSettings);
+
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
+    $migration->migrateAccountData();
+
+    /** @var PdkAccountRepositoryInterface $accountRepository */
+    $accountRepository = Pdk::get(PdkAccountRepositoryInterface::class);
+
+    expect($accountRepository->getAccount())->not->toBeNull();
+});
+
+it('preserves local account data while refreshing carrier capabilities', function () {
+    TestBootstrapper::hasAccount();
+
+    /** @var PdkAccountRepositoryInterface $accountRepo */
+    $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
+    $account     = $accountRepo->getAccount();
+    $shop        = $account->shops->first();
+
+    $shop->defaultCarrier          = 'DHL_FOR_YOU';
+    $account->subscriptionFeatures = new Collection(['some_feature']);
+    $accountRepo->store($account);
+
+    // A forced account refresh would consume this response and lose both local fields.
+    MockApi::enqueue(new ExampleGetAccountsResponse());
+    MockSdkApiHandler::enqueue(new ExampleContractDefinitionsResponse());
+
+    /** @var Migration6_5_1 $migration */
+    $migration = Pdk::get(Migration6_5_1::class);
+    $migration->migrateAccountData();
+
+    $storedAccount = $accountRepo->getAccount();
+    $storedShop    = $storedAccount->shops->first();
+
+    expect($storedShop->defaultCarrier)->toBe('DHL_FOR_YOU')
+        ->and($storedAccount->subscriptionFeatures->toArray())->toBe(['some_feature'])
+        ->and($storedShop->carriers->first()->carrier)->toBe('POSTNL')
+        ->and($storedShop->carriers->contains('carrier', 'DHL_FOR_YOU'))->toBeTrue()
+        ->and(MockApi::getLastRequest())->toBeNull();
 });
 
 it('rethrows when fetching carrier definitions fails so the migration retries', function () {

--- a/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
+++ b/tests/Unit/Migration/RefreshCarrierCapabilitiesMigrationTest.php
@@ -8,22 +8,25 @@ namespace MyParcelNL\WooCommerce\Migration;
 
 use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
 use MyParcelNL\Pdk\App\Installer\Contract\TimestampedMigrationInterface;
+use MyParcelNL\Pdk\Base\Support\Collection;
 use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
 use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
 use MyParcelNL\Pdk\Tests\Api\Response\ExampleGetAccountsResponse;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockApi;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
 use MyParcelNL\Pdk\Tests\SdkApi\MockSdkApiHandler;
 use MyParcelNL\Pdk\Tests\SdkApi\Response\ExampleContractDefinitionsResponse;
+use MyParcelNL\Pdk\Tests\Uses\UsesSdkApiMock;
 use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
 use RuntimeException;
 use function MyParcelNL\Pdk\Tests\mockPdkProperties;
 use function MyParcelNL\Pdk\Tests\usesShared;
 
-usesShared(new UsesMockWcPdkInstance());
+usesShared(new UsesMockWcPdkInstance(), new UsesSdkApiMock());
 
 /**
  * Loads the migration the same way the installer does: require the file and take the
@@ -49,18 +52,57 @@ it('skips without failing when no account or shop is available', function () {
     /** @var PdkAccountRepositoryInterface $accountRepo */
     $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
 
-    // No account configured, so a forced refresh returns null. Skipping beats fataling:
-    // a fresh install has nothing to refresh.
+    // A fresh install has no stored account to refresh.
     loadRefreshCarrierCapabilitiesMigration()->up();
 
     expect($accountRepo->getAccount())->toBeNull();
 });
 
+it('skips without failing when the api key is invalid', function () {
+    TestBootstrapper::hasAccount();
+
+    /** @var PdkSettingsRepositoryInterface $settingsRepository */
+    $settingsRepository            = Pdk::get(PdkSettingsRepositoryInterface::class);
+    $accountSettings               = $settingsRepository->all()->account;
+    $accountSettings->apiKeyValid = false;
+    $settingsRepository->storeSettings($accountSettings);
+
+    $migration = loadRefreshCarrierCapabilitiesMigration();
+    $migration->up();
+
+    expect($migration->hasFailed())->toBeFalse();
+});
+
+it('preserves local account data while refreshing carrier capabilities', function () {
+    TestBootstrapper::hasAccount();
+
+    /** @var PdkAccountRepositoryInterface $accountRepo */
+    $accountRepo = Pdk::get(PdkAccountRepositoryInterface::class);
+    $account     = $accountRepo->getAccount();
+    $shop        = $account->shops->first();
+
+    $shop->defaultCarrier          = 'DHL_FOR_YOU';
+    $account->subscriptionFeatures = new Collection(['some_feature']);
+    $accountRepo->store($account);
+
+    // A forced account refresh would consume this response and lose both local fields.
+    MockApi::enqueue(new ExampleGetAccountsResponse());
+    MockSdkApiHandler::enqueue(new ExampleContractDefinitionsResponse());
+
+    loadRefreshCarrierCapabilitiesMigration()->up();
+
+    $storedAccount = $accountRepo->getAccount();
+    $storedShop    = $storedAccount->shops->first();
+
+    expect($storedShop->defaultCarrier)->toBe('DHL_FOR_YOU')
+        ->and($storedAccount->subscriptionFeatures->toArray())->toBe(['some_feature'])
+        ->and($storedShop->carriers->first()->carrier)->toBe('POSTNL')
+        ->and($storedShop->carriers->contains('carrier', 'DHL_FOR_YOU'))->toBeTrue()
+        ->and(MockApi::getLastRequest())->toBeNull();
+});
+
 it('reports failure instead of throwing when fetching carrier definitions fails', function () {
     TestBootstrapper::hasAccount();
-    // The migration forces an account refresh before it gets as far as the carriers. Without a
-    // response queued that call throws, and the test would pass on the wrong exception.
-    MockApi::enqueue(new ExampleGetAccountsResponse());
 
     $throwingRepo = new class(
         Pdk::get(StorageInterface::class),
@@ -110,8 +152,6 @@ dataset('insurance shapes from the api', [
 
 it('stores only the flat insurance limits', function (array $insurance) {
     TestBootstrapper::hasAccount();
-    // The migration forces an account refresh, which calls the accounts endpoint.
-    MockApi::enqueue(new ExampleGetAccountsResponse());
     // Goes through the real CapabilitiesService and repository, so the nested wrapper is
     // dropped by the code that actually does it rather than by a stub.
     MockSdkApiHandler::enqueue(new ExampleContractDefinitionsResponse([

--- a/tests/Unit/Migration/RestoreAccountDataMigrationTest.php
+++ b/tests/Unit/Migration/RestoreAccountDataMigrationTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\WooCommerce\Migration;
+
+use MyParcelNL\Pdk\Account\Contract\AccountFeaturesServiceInterface;
+use MyParcelNL\Pdk\Account\Service\PdkAccountFeaturesService;
+use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\App\Installer\Contract\TimestampedMigrationInterface;
+use MyParcelNL\Pdk\Base\Support\Collection;
+use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Facade\AccountSettings;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\SdkApi\Service\Iam\WhoamiService;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
+use MyParcelNL\Pdk\Tests\Bootstrap\MockImplicationsService;
+use MyParcelNL\Pdk\Tests\Bootstrap\MockWhoamiService;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesSdkApiMock;
+use MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal;
+use MyParcelNL\WooCommerce\Tests\Uses\UsesMockWcPdkInstance;
+use RuntimeException;
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\mockPdkProperties;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockWcPdkInstance(), new UsesSdkApiMock());
+
+beforeEach(function () {
+    MockWhoamiService::reset();
+});
+
+afterEach(function () {
+    MockWhoamiService::reset();
+});
+
+function loadRestoreAccountDataMigration(): TimestampedMigrationInterface
+{
+    return require __DIR__ . '/../../../src/Migration/2026_09_03_130123_restore_account_data.php';
+}
+
+function seedAccountForAccountDataMigration(
+    ?string $defaultCarrier,
+    array $subscriptionFeatures = []
+): PdkAccountRepositoryInterface
+{
+    TestBootstrapper::hasAccount();
+
+    /** @var PdkAccountRepositoryInterface $accountRepository */
+    $accountRepository = Pdk::get(PdkAccountRepositoryInterface::class);
+    $account           = $accountRepository->getAccount();
+    $shop              = $account->shops->first();
+
+    $account->subscriptionFeatures = new Collection($subscriptionFeatures);
+    $shop->id                      = 2100;
+    $shop->defaultCarrier          = $defaultCarrier;
+    $shop->carriers                = factory(CarrierCollection::class)
+        ->push(
+            factory(Carrier::class)->fromPostNL(),
+            factory(Carrier::class)->fromDhlForYou()
+        )
+        ->make();
+
+    $accountRepository->store($account);
+
+    return $accountRepository;
+}
+
+it('is a timestamped migration the installer can discover', function () {
+    $migration = loadRestoreAccountDataMigration();
+    $migration->setIdentity('2026_09_03_130123_restore_account_data');
+
+    expect($migration)->toBeInstanceOf(TimestampedMigrationInterface::class)
+        ->and($migration->getId())->toBe('2026_09_03_130123_restore_account_data');
+});
+
+it('restores the implied carrier once and preserves existing subscription features', function () {
+    $accountRepository = seedAccountForAccountDataMigration(null, ['existing_feature']);
+
+    MockImplicationsService::setDefaultCarrierName('DHL_FOR_YOU');
+
+    $migration = loadRestoreAccountDataMigration();
+    $migration->up();
+    $migration->up();
+
+    $account = $accountRepository->getAccount();
+    $shop    = $account->shops->first();
+
+    expect($shop->carriers->first()->carrier)->toBe('POSTNL')
+        ->and($shop->defaultCarrier)->toBe('DHL_FOR_YOU')
+        ->and($account->subscriptionFeatures->toArray())->toBe(['existing_feature'])
+        ->and(MockImplicationsService::getCallCount())->toBe(1);
+});
+
+it('preserves an available default carrier and restores subscription features', function () {
+    $accountRepository = seedAccountForAccountDataMigration('POSTNL');
+
+    MockImplicationsService::setDefaultCarrierName('DHL_FOR_YOU');
+    MockWhoamiService::withFeatures([
+        PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT,
+    ]);
+
+    loadRestoreAccountDataMigration()->up();
+
+    $account = $accountRepository->getAccount();
+
+    expect($account->shops->first()->defaultCarrier)->toBe('POSTNL')
+        ->and($account->subscriptionFeatures->toArray())->toBe([
+            PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT,
+        ])
+        ->and(AccountSettings::getEffectiveOrderMode())->toBe(AccountFeaturesServiceInterface::ORDER_MODE_V1)
+        ->and(MockImplicationsService::getCallCount())->toBe(0);
+});
+
+it('retries subscription features after a temporary whoami failure', function () {
+    $accountRepository = seedAccountForAccountDataMigration(null);
+
+    MockImplicationsService::setDefaultCarrierName('DHL_FOR_YOU');
+
+    $throwingWhoamiService = new class extends WhoamiService {
+        public function __construct()
+        {
+        }
+
+        public function getWhoami(): FixedPrincipal
+        {
+            throw new RuntimeException('IAM unavailable');
+        }
+    };
+
+    $restoreWhoamiService = mockPdkProperties([WhoamiService::class => $throwingWhoamiService]);
+
+    $failedMigration = loadRestoreAccountDataMigration();
+    $failedMigration->up();
+
+    $accountAfterFailure = $accountRepository->getAccount();
+
+    expect($failedMigration->hasFailed())->toBeTrue()
+        ->and($accountAfterFailure->shops->first()->defaultCarrier)->toBe('DHL_FOR_YOU')
+        ->and($accountAfterFailure->subscriptionFeatures->isEmpty())->toBeTrue();
+
+    $restoreWhoamiService();
+    MockWhoamiService::withFeatures([
+        PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT,
+    ]);
+
+    $retryMigration = loadRestoreAccountDataMigration();
+    $retryMigration->up();
+
+    expect($retryMigration->hasFailed())->toBeFalse()
+        ->and($accountRepository->getAccount()->subscriptionFeatures->toArray())->toBe([
+            PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT,
+        ]);
+});
+
+it('replaces an unavailable default carrier with the valid implication', function () {
+    $accountRepository = seedAccountForAccountDataMigration('UPS_STANDARD', ['existing_feature']);
+
+    MockImplicationsService::setDefaultCarrierName('DHL_FOR_YOU');
+
+    loadRestoreAccountDataMigration()->up();
+
+    expect($accountRepository->getAccount()->shops->first()->defaultCarrier)->toBe('DHL_FOR_YOU')
+        ->and(MockImplicationsService::getCallCount())->toBe(1);
+});
+
+it('does not guess a default carrier when no safe match is available', function (?string $resolvedCarrier) {
+    $accountRepository = seedAccountForAccountDataMigration(null, ['existing_feature']);
+
+    MockImplicationsService::setDefaultCarrierName($resolvedCarrier);
+
+    $migration = loadRestoreAccountDataMigration();
+    $migration->up();
+
+    expect($accountRepository->getAccount()->shops->first()->defaultCarrier)->toBeNull()
+        ->and(MockImplicationsService::getCallCount())->toBe(1)
+        ->and($migration->hasFailed())->toBeFalse();
+})->with([
+    'no shipping rule implication' => null,
+    'carrier is not available'     => 'UPS_STANDARD',
+]);
+
+it('skips when no account is stored', function () {
+    loadRestoreAccountDataMigration()->up();
+
+    expect(MockImplicationsService::getCallCount())->toBe(0);
+});
+
+it('skips when the api key is invalid', function () {
+    seedAccountForAccountDataMigration(null);
+
+    /** @var PdkSettingsRepositoryInterface $settingsRepository */
+    $settingsRepository            = Pdk::get(PdkSettingsRepositoryInterface::class);
+    $accountSettings               = $settingsRepository->all()->account;
+    $accountSettings->apiKeyValid = false;
+    $settingsRepository->storeSettings($accountSettings);
+
+    loadRestoreAccountDataMigration()->up();
+
+    expect(MockImplicationsService::getCallCount())->toBe(0);
+});


### PR DESCRIPTION
This PR prevents carrier migrations from removing locally managed account data. It also adds a migration that restores missing account data for affected installations.

The carrier migrations fetched a new account from the Accounts API and stored the complete response. The response does not contain `defaultCarrier` or `subscriptionFeatures`. The stored account therefore lost these values.

An order without its own carrier could then fail with: `No default carrier available; shop has no default carrier set`

Changes:
- Preserve `defaultCarrier` and `subscriptionFeatures` during carrier migrations.
- Restore a missing or unavailable `defaultCarrier` from the shipping rule implications.
- Restore missing `subscriptionFeatures` with the Whoami API.
- Preserve existing valid account data.
- Do not select the first available carrier as a fallback.
- Retry the migration after a temporary Whoami API failure.

Fixes INT-1854
Fixes #1648
