### PR TITLE
chore(eslint): extend the installed @myparcel-dev config packages

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
   overrides: [
     {
       files: ['./**/*.vue'],
-      extends: ['@myparcel-eslint/eslint-config-prettier-typescript-vue', '@myparcel-eslint/eslint-config-import'],
+      extends: ['@myparcel-dev/eslint-config-prettier-typescript-vue', '@myparcel-dev/eslint-config-import'],
       rules: {
         '@typescript-eslint/no-misused-promises': 'off',
         'import/first': 'off',
@@ -23,7 +23,7 @@ module.exports = {
     },
     {
       files: ['./**/*.ts', './**/*.tsx'],
-      extends: ['@myparcel-eslint/eslint-config-prettier-typescript', '@myparcel-eslint/eslint-config-import'],
+      extends: ['@myparcel-dev/eslint-config-prettier-typescript', '@myparcel-dev/eslint-config-import'],
       rules: {
         'class-methods-use-this': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
@@ -40,11 +40,11 @@ module.exports = {
     {
       files: ['./**/*.js', './**/*.cjs', './**/*.mjs'],
       extends: [
-        '@myparcel-eslint/eslint-config-esnext',
-        '@myparcel-eslint/eslint-config-node',
+        '@myparcel-dev/eslint-config-esnext',
+        '@myparcel-dev/eslint-config-node',
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
-        '@myparcel-eslint/eslint-config-import',
+        '@myparcel-dev/eslint-config-import',
       ],
     },
     {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,6 @@ updates:
       exclude:
         - '@myparcel/*'
         - '@myparcel-dev/*'
-        - '@myparcel-eslint/*'
     groups:
       minor-js-updates:
         applies-to: version-updates

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@myparcel-dev/eslint-config-prettier-typescript": "^1.4.0",
     "@myparcel-dev/eslint-config-prettier-typescript-vue": "^1.4.0",
     "@myparcel-dev/pdk-app-builder": "^4.1.3",
+    "@myparcel-dev/prettier-config": "^2.0.1",
     "@myparcel-dev/semantic-release-config": "^6.0.10",
     "@myparcel-dev/semantic-release-wordpress-readme-generator": "^1.3.0",
     "@semantic-release/git": "^10.0.1",

--- a/views/backend/admin/src/components/pdk/WcModal.vue
+++ b/views/backend/admin/src/components/pdk/WcModal.vue
@@ -17,7 +17,15 @@
 
     <div
       v-show="isOpen"
-      :class="['mypa-fixed', 'mypa-scrollable-modal', 'mypa-left-2', 'mypa-m-auto', 'mypa-max-w-2xl', 'mypa-right-2', 'mypa-top-12']"
+      :class="[
+        'mypa-fixed',
+        'mypa-scrollable-modal',
+        'mypa-left-2',
+        'mypa-m-auto',
+        'mypa-max-w-2xl',
+        'mypa-right-2',
+        'mypa-top-12',
+      ]"
       role="document"
       @click.stop>
       <PdkBox :actions="actions">

--- a/views/backend/admin/src/components/pdk/WcNotification.vue
+++ b/views/backend/admin/src/components/pdk/WcNotification.vue
@@ -19,8 +19,8 @@
 
 <script lang="ts" setup>
 import {type PropType, computed} from 'vue';
-import {AdminComponent, type Notification} from '@myparcel-dev/pdk-admin';
 import {toArray} from '@myparcel-dev/ts-utils';
+import {AdminComponent, type Notification} from '@myparcel-dev/pdk-admin';
 
 const props = defineProps({
   notification: {

--- a/views/backend/admin/src/components/pdk/WcSelectInput.vue
+++ b/views/backend/admin/src/components/pdk/WcSelectInput.vue
@@ -9,8 +9,8 @@
 <script lang="ts" setup>
 import {onBeforeUnmount, onMounted, ref, watchEffect, watch} from 'vue';
 import {get} from '@vueuse/core';
-import {type ElementInstance, type OptionsProp, useSelectInputContext, AdminComponent} from '@myparcel-dev/pdk-admin';
 import {type OneOrMore} from '@myparcel-dev/ts-utils';
+import {type ElementInstance, type OptionsProp, useSelectInputContext, AdminComponent} from '@myparcel-dev/pdk-admin';
 
 // eslint-disable-next-line vue/no-unused-properties
 const props = defineProps<{element: ElementInstance<OptionsProp>; modelValue: string | number}>();
@@ -34,18 +34,22 @@ watchEffect(() => {
 });
 
 // Watch for options changes and update SelectWoo
-watch(() => get(options), () => {
-  if ($select.value) {
-    $select.value.selectWoo('destroy');
-    $select.value.selectWoo({
-      data: get(options).map((option) => ({
-        id: option.value as string | number,
-        text: option.label,
-        disabled: option.disabled,
-      })),
-    });
-  }
-}, { deep: true });
+watch(
+  () => get(options),
+  () => {
+    if ($select.value) {
+      $select.value.selectWoo('destroy');
+      $select.value.selectWoo({
+        data: get(options).map((option) => ({
+          id: option.value as string | number,
+          text: option.label,
+          disabled: option.disabled,
+        })),
+      });
+    }
+  },
+  {deep: true},
+);
 
 onMounted(() => {
   if (!selectElement.value) {

--- a/views/frontend/checkout-delivery-options/src/utils/init.spec.ts
+++ b/views/frontend/checkout-delivery-options/src/utils/init.spec.ts
@@ -50,9 +50,7 @@ describe('initializeCheckoutDeliveryOptions', () => {
   });
 
   it('composes the proxyCapabilities URL from baseUrl + endpoint.parameters', async () => {
-    useSettings.mockReturnValue(
-      settingsWith({proxyCapabilities: {parameters: {action: 'proxyCapabilities'}}}),
-    );
+    useSettings.mockReturnValue(settingsWith({proxyCapabilities: {parameters: {action: 'proxyCapabilities'}}}));
 
     const {initializeCheckoutDeliveryOptions} = await import('./init');
     initializeCheckoutDeliveryOptions();
@@ -82,9 +80,7 @@ describe('initializeCheckoutDeliveryOptions', () => {
   });
 
   it('always exposes a proxyCapabilities key on the resulting config (sentinel)', async () => {
-    useSettings.mockReturnValue(
-      settingsWith({proxyCapabilities: {parameters: {action: 'proxyCapabilities'}}}),
-    );
+    useSettings.mockReturnValue(settingsWith({proxyCapabilities: {parameters: {action: 'proxyCapabilities'}}}));
 
     const {initializeCheckoutDeliveryOptions} = await import('./init');
     initializeCheckoutDeliveryOptions();
@@ -134,9 +130,7 @@ describe('initializeCheckoutDeliveryOptions', () => {
   });
 
   it('hands the PDK both a getPackageType and an updateDeliveryOptions callback', async () => {
-    useSettings.mockReturnValue(
-      settingsWith({proxyCapabilities: {parameters: {action: 'proxyCapabilities'}}}),
-    );
+    useSettings.mockReturnValue(settingsWith({proxyCapabilities: {parameters: {action: 'proxyCapabilities'}}}));
 
     const {initializeCheckoutDeliveryOptions} = await import('./init');
     initializeCheckoutDeliveryOptions();

--- a/views/frontend/checkout-delivery-options/src/utils/init.ts
+++ b/views/frontend/checkout-delivery-options/src/utils/init.ts
@@ -1,3 +1,4 @@
+import {FrontendEndpoint} from '@myparcel-dev/pdk-common';
 import {
   PdkDeliveryOptionsEvent,
   initializeCheckoutDeliveryOptions as initialize,
@@ -7,7 +8,6 @@ import {
   defaultGetPackageType,
   defaultUpdateDeliveryOptions,
 } from '@myparcel-dev/pdk-checkout';
-import {FrontendEndpoint} from '@myparcel-dev/pdk-common';
 import {getHighestShippingClass} from './getHighestShippingClass';
 
 /**

--- a/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.spec.ts
+++ b/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.spec.ts
@@ -106,7 +106,7 @@ describe('getClassicCheckoutConfig - getFormData', () => {
 
     const data = getFormData();
 
-    expect(data['billing_first_name']).toBe('Jane');
+    expect(data.billing_first_name).toBe('Jane');
     expect(data['shipping_method[0]']).toBe('flat_rate:1');
   });
 
@@ -117,21 +117,21 @@ describe('getClassicCheckoutConfig - getFormData', () => {
 
     // shipping_method lives in the order-details form, billing in the billing form
     expect(data['shipping_method[0]']).toBe('flat_rate:1');
-    expect(data['billing_first_name']).toBe('Jane');
+    expect(data.billing_first_name).toBe('Jane');
   });
 
   it('ignores an empty hidden duplicate so the visible billing value survives (fresh checkout)', () => {
     document.body.innerHTML = DIVI_DUPLICATE_BILLING('');
 
     // The hidden duplicate is empty and comes later in DOM order; it must not clobber to ''.
-    expect(getFormData()['billing_postcode']).toBe('1234AB');
+    expect(getFormData().billing_postcode).toBe('1234AB');
   });
 
   it('ignores a stale hidden duplicate so the edited visible value survives (returning customer)', () => {
     document.body.innerHTML = DIVI_DUPLICATE_BILLING('9999ZZ');
 
     // The hidden duplicate carries a stale non-empty value; the visible edited value must win.
-    expect(getFormData()['billing_postcode']).toBe('1234AB');
+    expect(getFormData().billing_postcode).toBe('1234AB');
   });
 
   it('keeps a unique field hidden by the address widget', () => {
@@ -143,7 +143,7 @@ describe('getClassicCheckoutConfig - getFormData', () => {
       </form>
     `;
 
-    expect(getFormData()['billing_postcode']).toBe('1502VP');
+    expect(getFormData().billing_postcode).toBe('1502VP');
   });
 
   it('ignores a checked hidden checkbox when a visible unchecked duplicate exists', () => {
@@ -158,7 +158,7 @@ describe('getClassicCheckoutConfig - getFormData', () => {
       </form>
     `;
 
-    expect(getFormData()['ship_to_different_address']).toBeUndefined();
+    expect(getFormData().ship_to_different_address).toBeUndefined();
   });
 
   it('keeps a shipping method WooCommerce renders as a single hidden input', () => {
@@ -332,7 +332,7 @@ describe('getClassicCheckoutConfig - formChange', () => {
     expect(calls).toBe(2);
   });
 
-  it('fires the callback on WooCommerce\'s updated_checkout event', () => {
+  it("fires the callback on WooCommerce's updated_checkout event", () => {
     // WooCommerce's AJAX re-render auto-selects the shipping method without a bubbling `change`;
     // only `updated_checkout` signals it, so formChange must listen to that too.
     document.body.innerHTML = SINGLE_FORM;

--- a/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
+++ b/views/frontend/common/src/utils/checkout/getClassicCheckoutConfig.ts
@@ -73,9 +73,8 @@ export const getClassicCheckoutConfig = (): CheckoutConfig => {
         // Our hidden delivery-options input must live on the form that gets submitted: the one with the
         // place-order button. forms[0]! is safe — isClassicCheckout() guarantees at least one form.
         return (
-          forms.find((form) =>
-            form.querySelector('#place_order, [name="woocommerce_checkout_place_order"]'),
-          ) ?? forms[0]!
+          forms.find((form) => form.querySelector('#place_order, [name="woocommerce_checkout_place_order"]')) ??
+          forms[0]!
         );
       },
 
@@ -104,20 +103,17 @@ export const getClassicCheckoutConfig = (): CheckoutConfig => {
         // Visible names are global because Divi puts duplicate fields in separate forms. Hidden names
         // stay scoped to their form, so only the hidden duplicate is skipped. Unique hidden fields are
         // valid form values and remain in the merged data.
-        return formStates.reduce<Record<string, FormDataEntryValue>>(
-          (merged, {form, hiddenNames}) => {
-            for (const [key, value] of new FormData(form).entries()) {
-              if (hiddenNames.has(key) && visibleNames.has(key)) {
-                continue;
-              }
-
-              merged[key] = value;
+        return formStates.reduce<Record<string, FormDataEntryValue>>((merged, {form, hiddenNames}) => {
+          for (const [key, value] of new FormData(form).entries()) {
+            if (hiddenNames.has(key) && visibleNames.has(key)) {
+              continue;
             }
 
-            return merged;
-          },
-          {},
-        );
+            merged[key] = value;
+          }
+
+          return merged;
+        }, {});
       },
 
       // The value js-pdk passes lags one form-read behind and omits an unchecked box; read the live DOM.

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,11 +1,11 @@
-import { defineWorkspace } from 'vitest/config'
+import {defineWorkspace} from 'vitest/config';
 
 export default defineWorkspace([
-  "./views/backend/admin/vite.config.ts",
-  "./views/frontend/checkout-core/vite.config.ts",
-  "./views/frontend/common/vite.config.ts",
-  "./views/frontend/checkout-tax-fields/vite.config.ts",
-  "./views/frontend/checkout-separate-address-fields/vite.config.ts",
-  "./views/frontend/checkout-delivery-options/vite.config.ts",
-  "./views/frontend/checkout-address-widget/vite.config.ts"
-])
+  './views/backend/admin/vite.config.ts',
+  './views/frontend/checkout-core/vite.config.ts',
+  './views/frontend/common/vite.config.ts',
+  './views/frontend/checkout-tax-fields/vite.config.ts',
+  './views/frontend/checkout-separate-address-fields/vite.config.ts',
+  './views/frontend/checkout-delivery-options/vite.config.ts',
+  './views/frontend/checkout-address-widget/vite.config.ts',
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,6 +4400,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@myparcel-dev/prettier-config@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@myparcel-dev/prettier-config@npm:2.0.1"
+  checksum: 10c0/04952affe76ff080c883c92e511004365bdb47956882616f275e48318dcd36029bd80de75bd812ec7bb4615dcfc0f41a48e64a19868b1570f4556354af9f0190
+  languageName: node
+  linkType: hard
+
 "@myparcel-dev/sdk@npm:^4.1.1":
   version: 4.1.1
   resolution: "@myparcel-dev/sdk@npm:4.1.1"
@@ -4689,6 +4696,7 @@ __metadata:
     "@myparcel-dev/eslint-config-prettier-typescript": "npm:^1.4.0"
     "@myparcel-dev/eslint-config-prettier-typescript-vue": "npm:^1.4.0"
     "@myparcel-dev/pdk-app-builder": "npm:^4.1.3"
+    "@myparcel-dev/prettier-config": "npm:^2.0.1"
     "@myparcel-dev/semantic-release-config": "npm:^6.0.10"
     "@myparcel-dev/semantic-release-wordpress-readme-generator": "npm:^1.3.0"
     "@semantic-release/git": "npm:^10.0.1"


### PR DESCRIPTION
Extends the @myparcel-dev config packages that package.json already installs.

.eslintrc.cjs still extended @myparcel-eslint/eslint-config-*, a scope this repo does not install, so eslint could not resolve its config at all. package.json has been on @myparcel-dev since an earlier migration; only the config file was left behind.

Declared @myparcel-dev/prettier-config, which the prettier field already named but nothing installed. Without it eslint aborts on the prettier/prettier rule.

Dropped the dead @myparcel-eslint/* glob from the dependabot cooldown list; @myparcel-dev/* was already there.

The second commit is a one-time eslint --fix pass, so later PRs do not carry unrelated formatting changes on the files they happen to touch. 39 findings are not autofixable and are left alone: 34 jsdoc/no-undefined-types and 5 vue/no-setup-props-destructure.

Refs INT-1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)
